### PR TITLE
Shell escape dollar signs

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,21 @@ servers:
       my-label: "50"
 ```
 
+### Using shell expansion
+
+You can use shell expansion to interpolate values from the host machine into labels and env variables with the `${}` syntax.
+Anything within the curly braces will be executed on the host machine and the result will be interpolated into the label or env variable.
+
+```yaml
+labels:
+  host-machine: "${cat /etc/hostname}"
+
+env:
+  HOST_DEPLOYMENT_DIR: "${PWD}"
+```
+
+Note: Any other occurrence of `$` will be escaped to prevent unwanted shell expansion!
+
 ### Using container options
 
 You can specialize the options used to start containers using the `options` definitions:

--- a/lib/mrsk/utils.rb
+++ b/lib/mrsk/utils.rb
@@ -1,6 +1,8 @@
 module Mrsk::Utils
   extend self
 
+  DOLLAR_SIGN_WITHOUT_SHELL_EXPANSION_REGEX = /\$(?!{[^\}]*\})/
+
   # Return a list of escaped shell arguments using the same named argument against the passed attributes (hash or array).
   def argumentize(argument, attributes, sensitive: false)
     Array(attributes).flat_map do |key, value|
@@ -75,7 +77,9 @@ module Mrsk::Utils
 
   # Escape a value to make it safe for shell use.
   def escape_shell_value(value)
-    value.to_s.dump.gsub(/`/, '\\\\`')
+    value.to_s.dump
+      .gsub(/`/, '\\\\`')
+      .gsub(DOLLAR_SIGN_WITHOUT_SHELL_EXPANSION_REGEX, '\$')
   end
 
   # Abbreviate a git revhash for concise display

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -49,5 +49,16 @@ class UtilsTest < ActiveSupport::TestCase
   test "escape_shell_value" do
     assert_equal "\"foo\"", Mrsk::Utils.escape_shell_value("foo")
     assert_equal "\"\\`foo\\`\"", Mrsk::Utils.escape_shell_value("`foo`")
+
+    assert_equal "\"${PWD}\"", Mrsk::Utils.escape_shell_value("${PWD}")
+    assert_equal "\"${cat /etc/hostname}\"", Mrsk::Utils.escape_shell_value("${cat /etc/hostname}")
+    assert_equal "\"\\${PWD]\"", Mrsk::Utils.escape_shell_value("${PWD]")
+    assert_equal "\"\\$(PWD)\"", Mrsk::Utils.escape_shell_value("$(PWD)")
+    assert_equal "\"\\$PWD\"", Mrsk::Utils.escape_shell_value("$PWD")
+
+    assert_equal "\"^(https?://)www.example.com/(.*)\\$\"",
+      Mrsk::Utils.escape_shell_value("^(https?://)www.example.com/(.*)$")
+    assert_equal "\"https://example.com/\\$2\"",
+      Mrsk::Utils.escape_shell_value("https://example.com/$2")
   end
 end


### PR DESCRIPTION
I had trouble deploying an application that used redirection with MRSK.
Because dollar signs weren't escaped there was no way to define a redirect using a regex that uses a substitution without the substitution getting shell-expanded.

## Motivation

Say you want to redirect from `blog.example.com` to `www.example.com/blog/` but you also want to preserve the path after the redirect. 
To do that in traefik you have to use a redirect regex with a substitution by assigning these labels to the container:
```
traefik.http.routers.my_site.rule: "Host(`www.example.com`) || Host(`blog.example.com`)"
traefik.http.routers.my_site.middlewares: blog_redirect
traefik.http.middlewares.blog_redirect.redirectregex.regex: "^(https?://)blog.example.com/(.*)$"
traefik.http.middlewares.blog_redirect.redirectregex.replacement: "https://www.example.com/blog/$2"
traefik.http.middlewares.blog_redirect.redirectregex.permanent: true
```

Without the changes in this PR MRSK would execute something like this on the server
```bash
docker run --detach --publish 3000:3000 ... --label "traefik.http.middlewares.blog_redirect.redirectregex.replacement=\"https://www.example.com/blog/$2\"" ...
```
since variables in bash start with`$` the `$2` would get expanded to a value or nothing (because `$2` holds the second argument passed to a bash script).

I tried a few workarounds but none of them worked:
1. Escaping the dollar sign with `\` like `\$`, but Psych complains that that's invalid syntax
2. Escaping the dollar sign with `\\` like `\\$`, but that turns into `\\$` instead of `\$`
3. Escaping the dollar sign with `\\\\` like `\\\\$`, but that turns into `\\\\$` instead of `\$`
4. Replacing the quotation marks to single quotes, but that turned `\$` into `\\$`
5. Escaping the dollar sign with another dollar sign like in docker-compose.yml files and Makefiles, but that got shell expanded into the PID of the current process
6. I tried to use `${2}` instead of `$2` as the substitution, but that also got shell expanded and resulted in just `2`

## Solution

In the end I extended `escape_shell_value` to replace any occurrence of `$` into `\$` which then correctly escaped dollar signs and allowed me to define the redirect regex.

## Concerns

I'm concerned that this change could have unintended side effects if someone depends on this kind of shell expansion to inject values into the container (e.g. setting `$PWD` or `$HOSTNAME` as an env variable or lable). But on the other hand it sucks that this kind of redirecton isn't possible to do with MRSK.