### PR TITLE
feat: Add template argument to envify

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 coverage/*
 .DS_Store
 gemfiles/*.lock
+.idea/

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -165,7 +165,7 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
   end
 
   desc "envify", "Create .env by evaluating .env.erb (or .env.staging.erb -> .env.staging when using -d staging)"
-  option :template, aliases: "-t", type: :string, default: ".env.erb", desc: "Template to use"
+  option :template, aliases: "-t", type: :string, desc: "Template to use"
   def envify
     if destination = options[:destination]
       env_template_path = options[:template] || ".env.#{destination}.erb"

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -165,15 +165,17 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
   end
 
   desc "envify", "Create .env by evaluating .env.erb (or .env.staging.erb -> .env.staging when using -d staging)"
+  option :template, aliases: "-t", type: :string, default: ".env.erb", desc: "Template to use"
   def envify
     if destination = options[:destination]
-      env_template_path = ".env.#{destination}.erb"
+      env_template_path = options[:template] || ".env.#{destination}.erb"
       env_path          = ".env.#{destination}"
     else
-      env_template_path = ".env.erb"
+      env_template_path = options[:template] || ".env.erb"
       env_path          = ".env"
     end
 
+    ENV["MRSK_DESTINATION"] = destination.to_s if destination
     File.write(env_path, ERB.new(File.read(env_template_path)).result, perm: 0600)
   end
 

--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -14,18 +14,19 @@ class Mrsk::Configuration
 
   class << self
     def create_from(config_file:, destination: nil, version: nil)
-      raw_config = load_config_files(config_file, *destination_config_file(config_file, destination))
+      raw_config = load_config_files(config_file, *destination_config_file(config_file, destination), destination: destination)
 
       new raw_config, destination: destination, version: version
     end
 
     private
-      def load_config_files(*files)
-        files.inject({}) { |config, file| config.deep_merge! load_config_file(file) }
+      def load_config_files(*files, destination: nil)
+        files.inject({}) { |config, file| config.deep_merge! load_config_file(file, destination) }
       end
 
-      def load_config_file(file)
+      def load_config_file(file, destination)
         if file.exist?
+          ENV["MRSK_DESTINATION"] = destination.to_s if destination
           YAML.load(ERB.new(IO.read(file)).result).symbolize_keys
         else
           raise "Configuration file not found in #{file}"

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -341,9 +341,9 @@ class CliMainTest < CliTestCase
 
   test "envify with custom template file" do
     File.expects(:read).with(".env.template.erb").returns("HELLO=<%= 'world' %>")
-    File.expects(:write).with(".env.staging", "HELLO=world", perm: 0600)
+    File.expects(:write).with(".env", "HELLO=world", perm: 0600)
 
-    run_command("envify", "-t", ".env.template.erb", "-d", "staging")
+    run_command("envify", "-t", ".env.template.erb")
   end
 
   test "envify with custom template file and destination" do

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -339,6 +339,20 @@ class CliMainTest < CliTestCase
     run_command("envify", "-d", "staging")
   end
 
+  test "envify with custom template file" do
+    File.expects(:read).with(".env.template.erb").returns("HELLO=<%= 'world' %>")
+    File.expects(:write).with(".env.staging", "HELLO=world", perm: 0600)
+
+    run_command("envify", "-t", ".env.template.erb", "-d", "staging")
+  end
+
+  test "envify with custom template file and destination" do
+    File.expects(:read).with(".env.template.erb").returns("HELLO=<%= ENV['MRSK_DESTINATION'] %>")
+    File.expects(:write).with(".env.staging", "HELLO=staging", perm: 0600)
+
+    run_command("envify", "-t", ".env.template.erb", "-d", "staging")
+  end
+
   test "remove with confirmation" do
     run_command("remove", "-y", config_file: "deploy_with_accessories").tap do |output|
       assert_match /docker container stop traefik/, output


### PR DESCRIPTION
Closes #351

- Adds `-t` argument to `envify`
- injects `MRSK_DESTINATION` so a single template can be used to generate env files for multiple destinations
- injects `MRSK_DESTINATION` when loading `deploy.yml` files

### TODO
- [ ] Docs