### PR TITLE
feat: Add --env-path specify env path

### DIFF
--- a/lib/mrsk/cli/base.rb
+++ b/lib/mrsk/cli/base.rb
@@ -31,7 +31,7 @@ module Mrsk::Cli
 
     private
       def load_envs
-        if destination = options[:destination]
+        if (destination = options[:destination])
           Dotenv.load("#{options[:env_path]}.#{destination}", options[:env_path])
         else
           Dotenv.load(options[:env_path])

--- a/lib/mrsk/cli/base.rb
+++ b/lib/mrsk/cli/base.rb
@@ -19,6 +19,7 @@ module Mrsk::Cli
 
     class_option :config_file, aliases: "-c", default: "config/deploy.yml", desc: "Path to config file"
     class_option :destination, aliases: "-d", desc: "Specify destination to be used for config file (staging -> deploy.staging.yml)"
+    class_option :env_path, aliases: "-e", default: ".env", desc: "Path to env file"
 
     class_option :skip_hooks, aliases: "-H", type: :boolean, default: false, desc: "Don't run hooks"
 
@@ -31,9 +32,9 @@ module Mrsk::Cli
     private
       def load_envs
         if destination = options[:destination]
-          Dotenv.load(".env.#{destination}", ".env")
+          Dotenv.load("#{options[:env_path]}.#{destination}", options[:env_path])
         else
-          Dotenv.load(".env")
+          Dotenv.load(options[:env_path])
         end
       end
 

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -1,5 +1,3 @@
-require 'fileutils'
-
 class Mrsk::Cli::Main < Mrsk::Cli::Base
   desc "setup", "Setup all accessories and deploy app to servers"
   def setup

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 class Mrsk::Cli::Main < Mrsk::Cli::Base
   desc "setup", "Setup all accessories and deploy app to servers"
   def setup
@@ -172,6 +174,10 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
     else
       env_template_path = ".env.erb"
       env_path          = options[:env_path]
+    end
+
+    unless File.exist?(env_path) && env_path.include?('/')
+      FileUtils.mkdir_p(File.dirname(env_path))
     end
 
     File.write(env_path, ERB.new(File.read(env_template_path)).result, perm: 0600)

--- a/lib/mrsk/cli/main.rb
+++ b/lib/mrsk/cli/main.rb
@@ -137,9 +137,9 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
       puts "Created configuration file in config/deploy.yml"
     end
 
-    unless (deploy_file = Pathname.new(File.expand_path(".env"))).exist?
+    unless (deploy_file = Pathname.new(File.expand_path(options[:env_path]))).exist?
       FileUtils.cp_r Pathname.new(File.expand_path("templates/template.env", __dir__)), deploy_file
-      puts "Created .env file"
+      puts "Created #{options[:env_path]} file"
     end
 
     unless (hooks_dir = Pathname.new(File.expand_path(".mrsk/hooks"))).exist?
@@ -168,10 +168,10 @@ class Mrsk::Cli::Main < Mrsk::Cli::Base
   def envify
     if destination = options[:destination]
       env_template_path = ".env.#{destination}.erb"
-      env_path          = ".env.#{destination}"
+      env_path          = "#{options[:env_path]}.#{destination}"
     else
       env_template_path = ".env.erb"
-      env_path          = ".env"
+      env_path          = options[:env_path]
     end
 
     File.write(env_path, ERB.new(File.read(env_template_path)).result, perm: 0600)


### PR DESCRIPTION
Continuation of #352 with by making it so you can also load/output .env files for a different path (i.e. in out case we'd end up with 35+ top level .env files)

### TODO
- [ ] Docs