### PR TITLE
feat: Support optional env secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 coverage/*
 .DS_Store
 gemfiles/*.lock
+.vscode/
+.idea/

--- a/lib/mrsk/configuration/role.rb
+++ b/lib/mrsk/configuration/role.rb
@@ -139,14 +139,25 @@ class Mrsk::Configuration::Role
     # Secrets are stored in an array, which won't merge by default, so have to do it by hand.
     def merged_env_with_secrets
       merged_env.tap do |new_env|
-        new_env["secret"] = Array(config.env["secret"]) + Array(specialized_env["secret"])
-
         # If there's no secret/clear split, everything is clear
         clear_app_env  = config.env["secret"] ? Array(config.env["clear"]) : Array(config.env["clear"] || config.env)
         clear_role_env = specialized_env["secret"] ? Array(specialized_env["clear"]) : Array(specialized_env["clear"] || specialized_env)
-
         new_env["clear"] = (clear_app_env + clear_role_env).uniq
+
+        secrets_app_env = Array(config.env["secret"])
+        secrets_role_env = Array(specialized_env["secret"])
+        new_env["secret"] = (secrets_app_env + secrets_role_env).uniq.filter { |secret| filter_secret_env(secret, new_env) }
       end
+    end
+
+    def filter_secret_env(secret, new_env)
+      # allow clear to override secret
+      return false if new_env['clear'].include?(secret)
+
+      # if we find FOO but FOO? exists, we keep the FOO?
+      return false if !secret.end_with?('?') && new_env['secret'].include?("#{secret}?")
+
+      true
     end
 
     def http_health_check(port:, path:)

--- a/lib/mrsk/utils.rb
+++ b/lib/mrsk/utils.rb
@@ -20,10 +20,20 @@ module Mrsk::Utils
   # but redacts and expands secrets.
   def argumentize_env_with_secrets(env)
     if (secrets = env["secret"]).present?
-      argumentize("-e", secrets.to_h { |key| [ key, ENV.fetch(key) ] }, sensitive: true) + argumentize("-e", env["clear"])
+      argumentize("-e", handle_optional_secrets(secrets), sensitive: true) + argumentize("-e", env["clear"])
     else
-      argumentize "-e", env.fetch("clear", env)
+      argumentize("-e", env.fetch("clear", env))
     end
+  end
+
+  def handle_optional_secrets(secrets)
+    secrets.to_h do |key|
+      if key.end_with? '?'
+        [ key.chop, ENV[key.chop] ]
+      else
+        [ key, ENV.fetch(key) ]
+      end
+    end.compact
   end
 
   # Returns a list of shell-dashed option arguments. If the value is true, it's treated like a value-less option.

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -20,6 +20,22 @@ class UtilsTest < ActiveSupport::TestCase
     assert_equal [ "-e", "FOO=\"secret\"", "-e", "BAZ=\"qux\"" ], Mrsk::Utils.unredacted(args)
   end
 
+  test "argumentize_env_with_secrets with optional" do
+    ENV.expects(:[]).with("FOO").returns('secret')
+
+    args = Mrsk::Utils.argumentize_env_with_secrets({ "secret" => [ "FOO?" ], "clear" => { BAZ: "qux" } })
+
+    assert_equal [ "-e", "FOO=[REDACTED]", "-e", "BAZ=\"qux\"" ], Mrsk::Utils.redacted(args)
+    assert_equal [ "-e", "FOO=\"secret\"", "-e", "BAZ=\"qux\"" ], Mrsk::Utils.unredacted(args)
+  end
+
+  test "argumentize_env_with_secrets with missing optional" do
+    args = Mrsk::Utils.argumentize_env_with_secrets({ "secret" => [ "FOO?" ], "clear" => { BAZ: "qux" } })
+
+    assert_equal [ "-e", "BAZ=\"qux\"" ], Mrsk::Utils.redacted(args)
+    assert_equal [ "-e", "BAZ=\"qux\"" ], Mrsk::Utils.unredacted(args)
+  end
+
   test "optionize" do
     assert_equal [ "--foo", "\"bar\"", "--baz", "\"qux\"", "--quux" ], \
       Mrsk::Utils.optionize({ foo: "bar", baz: "qux", quux: true })


### PR DESCRIPTION
Closes #359

This PR allows specifying optional env secrets with `- FOO?` syntax

### Example
In the following example the app won't build without `RAILS_MASTER_KEY` env variable being provided but will work both with and without FOO?

```yml
env:
  secrets:
    - RAILS_MASTER_KEY
    - FOO?
```

### Todos
- [ ] Think about overriding (i.e. if we have `FOO` in `deploy.yml` and `FOO?` in `deploy.stage.yml`, what's the output) [comment here](https://github.com/mrsked/mrsk/issues/359#issuecomment-1609386638)
- [ ] Finish specs