### PR TITLE
Allow Traefik to run without publishing port

### DIFF
--- a/lib/kamal/commands/traefik.rb
+++ b/lib/kamal/commands/traefik.rb
@@ -11,7 +11,7 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
     docker :run, "--name traefik",
       "--detach",
       "--restart", "unless-stopped",
-      "--publish", port,
+      *publish_args,
       "--volume", "/var/run/docker.sock:/var/run/docker.sock",
       *env_args,
       *config.logging_args,
@@ -64,6 +64,10 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
   end
 
   private
+    def publish_args
+      argumentize "--publish", port unless config.traefik["publish"] == false
+    end
+
     def label_args
       argumentize "--label", labels
     end

--- a/test/commands/traefik_test.rb
+++ b/test/commands/traefik_test.rb
@@ -25,6 +25,11 @@ class CommandsTraefikTest < ActiveSupport::TestCase
     assert_equal \
       "docker run --name traefik --detach --restart unless-stopped --publish 8080:80 --volume /var/run/docker.sock:/var/run/docker.sock --log-opt max-size=\"10m\" #{@image} --providers.docker --log.level=\"DEBUG\" --accesslog.format=\"json\" --api.insecure --metrics.prometheus.buckets=\"0.1,0.3,1.2,5.0\"",
       new_command.run.join(" ")
+
+    @config[:traefik]["publish"] = false
+    assert_equal \
+      "docker run --name traefik --detach --restart unless-stopped --volume /var/run/docker.sock:/var/run/docker.sock --log-opt max-size=\"10m\" #{@image} --providers.docker --log.level=\"DEBUG\" --accesslog.format=\"json\" --api.insecure --metrics.prometheus.buckets=\"0.1,0.3,1.2,5.0\"",
+      new_command.run.join(" ")
   end
 
   test "run with ports configured" do


### PR DESCRIPTION
Adds the `publish` option which, if set to false, does not pass `--publish` to `docker run` when starting Traefik. This is useful when running Traefik behind a reverse proxy, for example.

Example deploy.yml:
```
traefik:
  publish: false
```

If not specified or set to true, the default or specified port will be used as per current behaviour.