### PR TITLE
Kamal::Git.version now uses git describe

### DIFF
--- a/lib/kamal/git.rb
+++ b/lib/kamal/git.rb
@@ -10,7 +10,7 @@ module Kamal::Git
   end
 
   def revision
-    `git rev-parse HEAD`.strip
+    `git describe --always`.strip
   end
 
   def uncommitted_changes


### PR DESCRIPTION
## Why change Kamal::Git.version?
Currently container names can get very long with - service, role, destination, sha and even possible uncommited changes. This can make them hard to read or compare.

## Looking for feedback before finalising this PR
The tests are not passing but I am wondering if there is interest in this change or maybe an alternative one that would simply shorten the sha - e.g. `git rev-parse --short HEAD`

## Description
Previously Kamal::Git.version used rev-parse to retrieve the current commits full sha. While this works it currently creates a very long version name. This PR changes it to use `git describe`, which will use a tag if it exists, suffix with an abberviated commit sha if there are new commits, and lastly suffix it the same as before if their are uncommited changes. Some e.g.

- No tags, no uncommited changes: '12er34d5'
- No tags, uncommited-changes: '12er34d5_uncommited_23494aa9'
- Tags, no new commits, no uncommited changes: '1.2.3'
- Tags, new commits, no uncommited changes: '1.2.3-12er34d5'
- Tags, new commits, uncommited changes: '1.2.3-12er34d5_uncommited_23494aa9'

Further reading: https://git-scm.com/docs/git-describe