### PR TITLE
Shorten git version to generate correct container DNS hostname

### DIFF
--- a/lib/mrsk/configuration.rb
+++ b/lib/mrsk/configuration.rb
@@ -250,12 +250,14 @@ class Mrsk::Configuration
       raw_config.servers.is_a?(Array) ? [ "web" ] : raw_config.servers.keys.sort
     end
 
+    # git version will be part of container hostname, DNS has a limit of 63 characters
+    # so, make this a bit shorter, see: https://en.wikipedia.org/wiki/Subdomain#Overview
     def git_version
       @git_version ||=
         if system("git rev-parse")
-          uncommitted_suffix = Mrsk::Utils.uncommitted_changes.present? ? "_uncommitted_#{SecureRandom.hex(8)}" : ""
+          uncommitted_suffix = Mrsk::Utils.uncommitted_changes.present? ? "_#{SecureRandom.hex(2)}" : ""
 
-          "#{`git rev-parse HEAD`.strip}#{uncommitted_suffix}"
+          "#{`git rev-parse --short HEAD`.strip}#{uncommitted_suffix}"
         else
           raise "Can't use commit hash as version, no git repository found in #{Dir.pwd}"
         end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -83,7 +83,7 @@ class ConfigurationTest < ActiveSupport::TestCase
   test "version from git committed" do
     ENV.delete("VERSION")
 
-    @config.expects(:`).with("git rev-parse HEAD").returns("git-version")
+    @config.expects(:`).with("git rev-parse --short HEAD").returns("git-version")
     Mrsk::Utils.expects(:uncommitted_changes).returns("")
     assert_equal "git-version", @config.version
   end
@@ -91,9 +91,9 @@ class ConfigurationTest < ActiveSupport::TestCase
   test "version from git uncommitted" do
     ENV.delete("VERSION")
 
-    @config.expects(:`).with("git rev-parse HEAD").returns("git-version")
+    @config.expects(:`).with("git rev-parse --short HEAD").returns("git-version")
     Mrsk::Utils.expects(:uncommitted_changes).returns("M   file\n")
-    assert_match /^git-version_uncommitted_[0-9a-f]{16}$/, @config.version
+    assert_match /^git-version_[0-9a-f]{4}$/, @config.version
   end
 
   test "version from env" do


### PR DESCRIPTION
Here I got a problem on resolving app IP address by container name, like this **'myapp-web-staging-599126a8f6c31f286636a8675226d4ab6585287c_uncommitted_94602f20085489c4'** has **87** chars, according to https://en.wikipedia.org/wiki/Subdomain#Overview , **"Each label may contain from 0 to 63 [octets]"**, this is invalid subdomain, so I can't container IP with:

```bash
/srv/www # ping myapp-web-staging-599126a8f6c31f286636a8675226d4ab6585287c_uncommitted_94602f20085489c4
ping: bad address 'myapp-web-staging-599126a8f6c31f286636a8675226d4ab6585287c_uncommitted_94602f20085489c4'
```

We can get short git version instead of long one, and make a version as short as possible.