### PR TITLE
require ActiveSupport module to provide String#remove

### DIFF
--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -1,3 +1,5 @@
+require "active_support/core_ext/string/filters"
+
 class Kamal::Commands::Builder < Kamal::Commands::Base
   delegate :create, :remove, :push, :clean, :pull, :info, to: :target
 


### PR DESCRIPTION
`Mrsk::Commands::Builder#name` uses `String#remove` which is provided by the ActiveSupport module `active_support/core_ext/string/filters` but that module is not being required anywhere in the code base.

For some reason, the tests pass without this fix. I can't figure out where the `active_support/core_ext/string/filters` module is being pulled into the test env.

fixes #421