### PR TITLE
Fix picking the first available role on primary_host

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -97,7 +97,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
       say "Get most recent version available as an image...", :magenta unless options[:version]
       using_version(version_or_latest) do |version|
         say "Launching interactive command with version #{version} via SSH from new container on #{KAMAL.primary_host}...", :magenta
-        run_locally { exec KAMAL.app(role: KAMAL.primary_host.roles.first).execute_in_new_container_over_ssh(cmd, host: KAMAL.primary_host) }
+        run_locally { exec KAMAL.app(role: KAMAL.roles_on(KAMAL.primary_host).first).execute_in_new_container_over_ssh(cmd, host: KAMAL.primary_host) }
       end
 
     when options[:reuse]


### PR DESCRIPTION
https://github.com/basecamp/kamal/commit/4dd8208290edbbab277b0175c8517dda5180f137 introduced a bug:

```ruby
MRSK.primary_host.roles.first
```

`MRSK.primary_host` is an IP Address as a string, so calling `roles` on it raises an error.