### PR TITLE
Fix traefik argument volumes

### DIFF
--- a/lib/kamal/commands/traefik.rb
+++ b/lib/kamal/commands/traefik.rb
@@ -16,6 +16,7 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
       *env_args,
       *config.logging_args,
       *label_args,
+      *volume_args,
       *docker_options_args,
       image,
       "--providers.docker",
@@ -72,6 +73,10 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
       argumentize "--label", labels
     end
 
+    def volume_args
+      argumentize "--volume", volumes
+    end
+
     def env_args
       env_config = config.traefik["env"] || {}
 
@@ -84,6 +89,10 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
 
     def labels
       config.traefik["labels"] || []
+    end
+
+    def volumes
+      config.traefik["volumes"] || []
     end
 
     def image

--- a/test/commands/traefik_test.rb
+++ b/test/commands/traefik_test.rb
@@ -48,7 +48,7 @@ class CommandsTraefikTest < ActiveSupport::TestCase
       "docker run --name traefik --detach --restart unless-stopped --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock --log-opt max-size=\"10m\" #{@image} --providers.docker --log.level=\"DEBUG\" --accesslog.format=\"json\" --api.insecure --metrics.prometheus.buckets=\"0.1,0.3,1.2,5.0\"",
       new_command.run.join(" ")
 
-    @config[:traefik]["options"] = {"volume" => %w[./letsencrypt/acme.json:/letsencrypt/acme.json] }
+    @config[:traefik]["options"] = {"volumes" => %w[./letsencrypt/acme.json:/letsencrypt/acme.json] }
     assert_equal \
       "docker run --name traefik --detach --restart unless-stopped --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock --log-opt max-size=\"10m\" --volume \"./letsencrypt/acme.json:/letsencrypt/acme.json\" #{@image} --providers.docker --log.level=\"DEBUG\" --accesslog.format=\"json\" --api.insecure --metrics.prometheus.buckets=\"0.1,0.3,1.2,5.0\"",
       new_command.run.join(" ")
@@ -59,7 +59,7 @@ class CommandsTraefikTest < ActiveSupport::TestCase
       "docker run --name traefik --detach --restart unless-stopped --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock --log-opt max-size=\"10m\" #{@image} --providers.docker --log.level=\"DEBUG\" --accesslog.format=\"json\" --api.insecure --metrics.prometheus.buckets=\"0.1,0.3,1.2,5.0\"",
       new_command.run.join(" ")
 
-    @config[:traefik]["options"] = {"volume" => %w[./letsencrypt/acme.json:/letsencrypt/acme.json], "publish" => %w[8080:8080], "memory" => "512m"}
+    @config[:traefik]["options"] = {"volumes" => %w[./letsencrypt/acme.json:/letsencrypt/acme.json], "publish" => %w[8080:8080], "memory" => "512m"}
     assert_equal \
       "docker run --name traefik --detach --restart unless-stopped --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock --log-opt max-size=\"10m\" --volume \"./letsencrypt/acme.json:/letsencrypt/acme.json\" --publish \"8080:8080\" --memory \"512m\" #{@image} --providers.docker --log.level=\"DEBUG\" --accesslog.format=\"json\" --api.insecure --metrics.prometheus.buckets=\"0.1,0.3,1.2,5.0\"",
       new_command.run.join(" ")


### PR DESCRIPTION
According to the docs you can mount volumes for the traefik with:
```yaml
traefik:
  options:
    volumes:
      - /tmp/example.json:/tmp/example.json 
```

But it gaves the following error:

```
 ERROR (SSHKit::Command::Failed): Exception while executing on host 1.1.1.1: docker exit status: 125
docker stdout: Nothing written
docker stderr: unknown flag: --volumes
See 'docker run --help'.
```

Fixed in this PR.