### PR TITLE
Supports Passing SSH Agent Socket to Build Options

### DIFF
--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -3,7 +3,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   class BuilderError < StandardError; end
 
   delegate :argumentize, to: Kamal::Utils
-  delegate :args, :secrets, :dockerfile, :local_arch, :local_host, :remote_arch, :remote_host, :cache_from, :cache_to, to: :builder_config
+  delegate :args, :secrets, :dockerfile, :local_arch, :local_host, :remote_arch, :remote_host, :cache_from, :cache_to, :ssh, to: :builder_config
 
   def clean
     docker :image, :rm, "--force", config.absolute_image
@@ -14,7 +14,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   end
 
   def build_options
-    [ *build_tags, *build_cache, *build_labels, *build_args, *build_secrets, *build_dockerfile ]
+    [ *build_tags, *build_cache, *build_labels, *build_args, *build_secrets, *build_dockerfile, *build_ssh ]
   end
 
   def build_context
@@ -58,6 +58,10 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
       else
         raise BuilderError, "Missing #{dockerfile}"
       end
+    end
+
+    def build_ssh
+      argumentize "--ssh", ssh if ssh.present?
     end
 
     def builder_config

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -81,6 +81,10 @@ class Kamal::Configuration::Builder
     end
   end
 
+  def ssh
+    @options["ssh"]
+  end
+
   private
     def valid?
       if @options["cache"] && @options["cache"]["type"]

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -111,6 +111,14 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "build with ssh agent socket" do
+    builder = new_builder_command(builder: { "ssh" => 'default=$SSH_AUTH_SOCK' })
+
+    assert_equal \
+      "-t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --ssh default=$SSH_AUTH_SOCK",
+      builder.target.build_options.join(" ")
+  end
+
   test "validate image" do
     assert_equal "docker inspect -f '{{ .Config.Labels.service }}' dhh/app:123 | grep -x app || (echo \"Image dhh/app:123 is missing the `service` label\" && exit 1)", new_builder_command.validate_image.join(" ")
   end

--- a/test/configuration/builder_test.rb
+++ b/test/configuration/builder_test.rb
@@ -148,4 +148,14 @@ class ConfigurationBuilderTest < ActiveSupport::TestCase
 
     assert_equal "..", @config_with_builder_option.builder.context
   end
+
+  test "ssh" do
+    assert_nil @config.builder.ssh
+  end
+
+  test "setting ssh params" do
+    @deploy_with_builder_option[:builder] = { "ssh" => 'default=$SSH_AUTH_SOCK' }
+
+    assert_equal 'default=$SSH_AUTH_SOCK', @config_with_builder_option.builder.ssh
+  end
 end


### PR DESCRIPTION
This PR adds support for passing ssh agent socket as documented in here: https://docs.docker.com/engine/reference/commandline/buildx_build/#ssh

This allows accessing private repositories without passing GITHUB_TOKEN.

If that's accepted - I'll follow up with PR to Kamal site with documentation.

P.S. Only after I opened this one I noticed #235 doing similar thing. This one though does not pass any SSH arguments if not configured - so it doesn't affect default behaviour. I'm happy to contribute to the other one if said so to get this merged.