### PR TITLE
fix: do not hardcode Net::SSH auth_methods

### DIFF
--- a/lib/kamal/configuration/ssh.rb
+++ b/lib/kamal/configuration/ssh.rb
@@ -18,7 +18,7 @@ class Kamal::Configuration::Ssh
   end
 
   def options
-    { user: user, proxy: proxy, auth_methods: [ "publickey" ], logger: logger, keepalive: true, keepalive_interval: 30 }.compact
+    { user: user, proxy: proxy, logger: logger, keepalive: true, keepalive_interval: 30 }.compact
   end
 
   def to_h

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -258,7 +258,7 @@ class ConfigurationTest < ActiveSupport::TestCase
         :absolute_image=>"dhh/app:missing",
         :service_with_version=>"app-missing",
         :env_args=>["-e", "REDIS_URL=\"redis://x/y\""],
-        :ssh_options=>{ :user=>"root", :auth_methods=>["publickey"], log_level: :fatal, keepalive: true, keepalive_interval: 30 },
+        :ssh_options=>{ :user=>"root", log_level: :fatal, keepalive: true, keepalive_interval: 30 },
         :sshkit=>{},
         :volume_args=>["--volume", "/local/path:/container/path"],
         :builder=>{},

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -51,7 +51,7 @@ class MainTest < IntegrationTest
     assert_equal "app-#{version}", config[:service_with_version]
     assert_equal [], config[:env_args]
     assert_equal [], config[:volume_args]
-    assert_equal({ user: "root", auth_methods: [ "publickey" ], keepalive: true, keepalive_interval: 30, log_level: :fatal }, config[:ssh_options])
+    assert_equal({ user: "root", keepalive: true, keepalive_interval: 30, log_level: :fatal }, config[:ssh_options])
     assert_equal({ "multiarch" => false, "args" => { "COMMIT_SHA" => version } }, config[:builder])
     assert_equal [ "--log-opt", "max-size=\"10m\"" ], config[:logging]
     assert_equal({ "path" => "/up", "port" => 3000, "max_attempts" => 7, "cmd" => "wget -qO- http://localhost > /dev/null" }, config[:healthcheck])


### PR DESCRIPTION
Hardcoding the Net::SSH `auth_methods` option to `["publickey"]` prevents alternative authentication methods such as solutions like [Tailscale](https://tailscale.com/) which obviate the need to store and share private keys. The [default `auth_methods`](https://net-ssh.github.io/ssh/v1/chapter-2.html#s3) are `“publickey”`, `“hostbased”`, `“password”`, and `“keyboard-interactive”`—and they are tried in that order. Which means this change will still attempt to use the `"publickey"` method first and will not break backwards compatibility.