### PR TITLE
feat: Add destinations command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 coverage/*
 .DS_Store
 gemfiles/*.lock
+
+.idea/

--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -10,6 +10,19 @@ class Kamal::Cli::Main < Kamal::Cli::Base
     end
   end
 
+  desc 'destinations', 'List available destinations'
+  option :json, alias: '-j', type: :boolean, default: false, desc: 'Output as JSON'
+  def destinations
+    pattern = options[:config_file].gsub(/deploy\.yml/, 'deploy.*.yml')
+    list = Dir.glob(pattern).map { |f| File.basename(f, '.yml.erb').gsub(/^deploy\./, '') }
+
+    if options[:json]
+      puts list.to_json
+    else
+      puts list
+    end
+  end
+
   desc "deploy", "Deploy app to servers"
   option :skip_push, aliases: "-P", type: :boolean, default: false, desc: "Skip image build and push"
   def deploy


### PR DESCRIPTION
This PR adds a `destinations` command to display possible destinations to more easily integrate kamal into other tools (i.e. Fig autocomplete https://github.com/withfig/autocomplete/pull/2076)