### PR TITLE
Configurable Healthcheck Expose Port

### DIFF
--- a/lib/kamal/commands/healthcheck.rb
+++ b/lib/kamal/commands/healthcheck.rb
@@ -1,5 +1,4 @@
 class Kamal::Commands::Healthcheck < Kamal::Commands::Base
-  EXPOSED_PORT = 3999
 
   def run
     web = config.role(:web)
@@ -7,7 +6,7 @@ class Kamal::Commands::Healthcheck < Kamal::Commands::Base
     docker :run,
       "--detach",
       "--name", container_name_with_version,
-      "--publish", "#{EXPOSED_PORT}:#{config.healthcheck["port"]}",
+      "--publish", "#{exposed_port}:#{config.healthcheck["port"]}",
       "--label", "service=#{container_name}",
       "-e", "KAMAL_CONTAINER_NAME=\"#{container_name}\"",
       *web.env_args,
@@ -52,6 +51,10 @@ class Kamal::Commands::Healthcheck < Kamal::Commands::Base
     end
 
     def health_url
-      "http://localhost:#{EXPOSED_PORT}#{config.healthcheck["path"]}"
+      "http://localhost:#{exposed_port}#{config.healthcheck["path"]}"
+    end
+
+    def exposed_port
+      config.healthcheck["exposed_port"]
     end
 end

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -145,7 +145,7 @@ class Kamal::Configuration
 
 
   def healthcheck
-    { "path" => "/up", "port" => 3000, "max_attempts" => 7 }.merge(raw_config.healthcheck || {})
+    { "path" => "/up", "port" => 3000, "max_attempts" => 7, "exposed_port" => 3999 }.merge(raw_config.healthcheck || {})
   end
 
   def readiness_delay

--- a/test/commands/healthcheck_test.rb
+++ b/test/commands/healthcheck_test.rb
@@ -40,8 +40,9 @@ class CommandsHealthcheckTest < ActiveSupport::TestCase
 
   test "run with custom options" do
     @config[:servers] = { "web" => { "hosts" => [ "1.1.1.1" ], "options" => { "mount" => "somewhere" } } }
+    @config[:healthcheck] = { "exposed_port" => 4999 }
     assert_equal \
-      "docker run --detach --name healthcheck-app-123 --publish 3999:3000 --label service=healthcheck-app -e KAMAL_CONTAINER_NAME=\"healthcheck-app\" --health-cmd \"curl -f http://localhost:3000/up || exit 1\" --health-interval \"1s\" --mount \"somewhere\" dhh/app:123",
+      "docker run --detach --name healthcheck-app-123 --publish 4999:3000 --label service=healthcheck-app -e KAMAL_CONTAINER_NAME=\"healthcheck-app\" --health-cmd \"curl -f http://localhost:3000/up || exit 1\" --health-interval \"1s\" --mount \"somewhere\" dhh/app:123",
       new_command.run.join(" ")
   end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -263,7 +263,7 @@ class ConfigurationTest < ActiveSupport::TestCase
         :volume_args=>["--volume", "/local/path:/container/path"],
         :builder=>{},
         :logging=>["--log-opt", "max-size=\"10m\""],
-        :healthcheck=>{ "path"=>"/up", "port"=>3000, "max_attempts" => 7 }}
+        :healthcheck=>{ "path"=>"/up", "port"=>3000, "max_attempts" => 7, "exposed_port" => 3999 }}
 
     assert_equal expected_config, @config.to_h
   end

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -54,6 +54,6 @@ class MainTest < IntegrationTest
     assert_equal({ user: "root", auth_methods: [ "publickey" ], keepalive: true, keepalive_interval: 30, log_level: :fatal }, config[:ssh_options])
     assert_equal({ "multiarch" => false, "args" => { "COMMIT_SHA" => version } }, config[:builder])
     assert_equal [ "--log-opt", "max-size=\"10m\"" ], config[:logging]
-    assert_equal({ "path" => "/up", "port" => 3000, "max_attempts" => 7, "cmd" => "wget -qO- http://localhost > /dev/null" }, config[:healthcheck])
+    assert_equal({ "path" => "/up", "port" => 3000, "max_attempts" => 7, "exposed_port" => 3999, "cmd" => "wget -qO- http://localhost > /dev/null" }, config[:healthcheck])
   end
 end


### PR DESCRIPTION
Healthcheck port (exposed one) is hard coded to 3999. This is a problem when doing parallel deployments and might result in this error

```
ERROR (SSHKit::Command::Failed): Exception while executing on host plus-6fc20fca3f82fa64049fec08bac4b533.svc: docker exit status: 125
--
  | docker stdout: fec19f2cf5310d4900e21ed48681ce9e896901185f656cfd1797d109af9bf251
  | docker stderr: docker: Error response from daemon: driver failed programming external connectivity on endpoint healthcheck-xxx (92d063a6607cbf7525970c123a75598dcde5dae34862ad9e436c05e9bcb82406): Bind for 0.0.0.0:3999 failed: port is already allocated.
```

This PR adds an option to `healthcheck` configuration and allow to pass `exposed_port` via configuration. Default value stays the same and is still 3999.