### PR TITLE
Add a require_destination setting

### DIFF
--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -210,6 +210,18 @@ class ConfigurationTest < ActiveSupport::TestCase
     end
   end
 
+  test "destination required" do
+    dest_config_file = Pathname.new(File.expand_path("fixtures/deploy_for_required_dest.yml", __dir__))
+
+    assert_raises(ArgumentError) do
+      config = Kamal::Configuration.create_from config_file: dest_config_file
+    end
+
+    assert_nothing_raised do
+      config = Kamal::Configuration.create_from config_file: dest_config_file, destination: "world"
+    end
+  end
+
   test "to_h" do
     expected_config = \
       { :roles=>["web"],

--- a/test/fixtures/deploy_for_required_dest.world.yml
+++ b/test/fixtures/deploy_for_required_dest.world.yml
@@ -1,0 +1,5 @@
+servers:
+  - 1.1.1.1
+  - 1.1.1.2
+env:
+  REDIS_URL: redis://x/y

--- a/test/fixtures/deploy_for_required_dest.yml
+++ b/test/fixtures/deploy_for_required_dest.yml
@@ -1,0 +1,7 @@
+service: app
+image: dhh/app
+registry:
+  server: registry.digitalocean.com
+  username: <%= "my-user" %>
+  password: <%= "my-password" %>
+require_destination: true


### PR DESCRIPTION
If you always want to use a destination, and have a base deploy.yml file that doesn't specify any hosts, then if you forget to specific the destination you will get a cryptic error.

Add a "require_destination" setting you can use to avoid this and output:

```
  Finished all in 0.0 seconds
  ERROR (ArgumentError): You must specify a destination
```