### PR TITLE
Load Deploy Config with *.erb Extension if Exists

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -41,6 +41,13 @@ module Kamal::Cli
         options.merge(@_initializer.last[:class_options] || {})
       end
 
+    def config_file_path
+      path = File.expand_path(options[:config_file])
+      return "#{path}.erb" if File.exist?("#{path}.erb")
+
+      path
+    end
+
       def initialize_commander(options)
         KAMAL.tap do |commander|
           if options[:verbose]
@@ -53,7 +60,7 @@ module Kamal::Cli
           end
 
           commander.configure \
-            config_file: Pathname.new(File.expand_path(options[:config_file])),
+            config_file: Pathname.new(File.expand_path(config_file_path)),
             destination: options[:destination],
             version: options[:version]
 

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -287,6 +287,14 @@ class CliMainTest < CliTestCase
     end
   end
 
+  test "config with config file that has .erb extension" do
+    run_command("config", config_file: "deploy").tap do |output|
+      config = YAML.load(output)
+
+      assert_equal "app-999", config[:service_with_version]
+    end
+  end
+
   test "init" do
     Pathname.any_instance.expects(:exist?).returns(false).times(3)
     Pathname.any_instance.stubs(:mkpath)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -188,7 +188,7 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "erb evaluation of yml config" do
-    config = Kamal::Configuration.create_from config_file: Pathname.new(File.expand_path("fixtures/deploy.erb.yml", __dir__))
+    config = Kamal::Configuration.create_from config_file: Pathname.new(File.expand_path("fixtures/deploy.yml.erb", __dir__))
     assert_equal "my-user", config.registry["username"]
   end
 

--- a/test/fixtures/deploy.yml.erb
+++ b/test/fixtures/deploy.yml.erb
@@ -1,4 +1,4 @@
-service: app
+service: <%= "app" %>
 image: dhh/app
 servers:
   - 1.1.1.1


### PR DESCRIPTION
At the moment configuration is by default loaded from `deploy.yml` file. It's the evaluated using ERB. But that means that IDE won't pick up ERB dialect. It'd be great if you could create `deploy.yml.erb` file and do not have to pass path to this file using `-c` flag.

So this PR is adding two things

1. If configuration file with "erb" extension exists - it'll be loaded instead
    * For example if `deploy.yml.erb` exists - it'll be loaded instead of `deploy.yml`
    * If custom config `custom_deploy.yml.erb` exists - it'll also be loaded instead of `custom_deploy.yml` (Note: this will also happens when you specify `-c custom_deploy.yml`)
2. It's also changing one of fixtures from `deploy.erb.yml` to `depoy.yml.erb` since I think this should be default naming for template file (just like in Rails you have `*.html.erb`)