### PR TITLE
Include hidden files when copying assets

### DIFF
--- a/lib/kamal/commands/app.rb
+++ b/lib/kamal/commands/app.rb
@@ -234,6 +234,6 @@ class Kamal::Commands::App < Kamal::Commands::Base
     end
 
     def copy_contents(source, destination, continue_on_error: false)
-      [ :cp, "-rn", "#{source}/*", destination, *("|| true" if continue_on_error)]
+      [ :cp, "-rn", "#{source}/{*,.*}", destination, *("|| true" if continue_on_error)]
     end
 end


### PR DESCRIPTION
By default it appears /* doesnt include hidden files. When using sprockets with rails, a .sprockets-manifest.json file is generated which needs to be carried over. Without the manifest file rails apps complain about missing assets. 


Fixes https://github.com/basecamp/kamal/issues/465