### PR TITLE
Copy all files into asset volume

### DIFF
--- a/lib/kamal/commands/app.rb
+++ b/lib/kamal/commands/app.rb
@@ -234,6 +234,6 @@ class Kamal::Commands::App < Kamal::Commands::Base
     end
 
     def copy_contents(source, destination, continue_on_error: false)
-      [ :cp, "-rn", "#{source}/*", destination, *("|| true" if continue_on_error)]
+      [ :cp, "-rnT", "#{source}", destination, *("|| true" if continue_on_error)]
     end
 end

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -84,7 +84,7 @@ class CliAppTest < CliTestCase
 
     run_command("boot", config: :with_assets).tap do |output|
       assert_match "docker tag dhh/app:latest dhh/app:latest", output
-      assert_match "/usr/bin/env mkdir -p .kamal/assets/volumes/app-web-latest ; cp -rn .kamal/assets/extracted/app-web-latest/* .kamal/assets/volumes/app-web-latest ; cp -rn .kamal/assets/extracted/app-web-latest/* .kamal/assets/volumes/app-web-123 || true ; cp -rn .kamal/assets/extracted/app-web-123/* .kamal/assets/volumes/app-web-latest || true", output
+      assert_match "/usr/bin/env mkdir -p .kamal/assets/volumes/app-web-latest ; cp -rnT .kamal/assets/extracted/app-web-latest .kamal/assets/volumes/app-web-latest ; cp -rnT .kamal/assets/extracted/app-web-latest .kamal/assets/volumes/app-web-123 || true ; cp -rnT .kamal/assets/extracted/app-web-123 .kamal/assets/volumes/app-web-latest || true", output
       assert_match "/usr/bin/env mkdir -p .kamal/assets/extracted/app-web-latest && docker stop -t 1 app-web-assets 2> /dev/null || true && docker run --name app-web-assets --detach --rm dhh/app:latest sleep 1000000 && docker cp -L app-web-assets:/public/assets/. .kamal/assets/extracted/app-web-latest && docker stop -t 1 app-web-assets", output
       assert_match /docker run --detach --restart unless-stopped --name app-web-latest --hostname 1.1.1.1-[0-9a-f]{12} /, output
       assert_match "docker container ls --all --filter name=^app-web-123$ --quiet | xargs docker stop", output

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -358,14 +358,14 @@ class CommandsAppTest < ActiveSupport::TestCase
   test "sync asset volumes" do
     assert_equal [
       :mkdir, "-p", ".kamal/assets/volumes/app-web-999", ";",
-      :cp, "-rn", ".kamal/assets/extracted/app-web-999/*", ".kamal/assets/volumes/app-web-999"
+      :cp, "-rnT", ".kamal/assets/extracted/app-web-999", ".kamal/assets/volumes/app-web-999"
     ], new_command(asset_path: "/public/assets").sync_asset_volumes
 
     assert_equal [
       :mkdir, "-p", ".kamal/assets/volumes/app-web-999", ";",
-      :cp, "-rn", ".kamal/assets/extracted/app-web-999/*", ".kamal/assets/volumes/app-web-999", ";",
-      :cp, "-rn", ".kamal/assets/extracted/app-web-999/*", ".kamal/assets/volumes/app-web-998", "|| true", ";",
-      :cp, "-rn", ".kamal/assets/extracted/app-web-998/*", ".kamal/assets/volumes/app-web-999", "|| true",
+      :cp, "-rnT", ".kamal/assets/extracted/app-web-999", ".kamal/assets/volumes/app-web-999", ";",
+      :cp, "-rnT", ".kamal/assets/extracted/app-web-999", ".kamal/assets/volumes/app-web-998", "|| true", ";",
+      :cp, "-rnT", ".kamal/assets/extracted/app-web-998", ".kamal/assets/volumes/app-web-999", "|| true",
     ], new_command(asset_path: "/public/assets").sync_asset_volumes(old_version: 998)
   end
 

--- a/test/integration/docker/deployer/app/Dockerfile
+++ b/test/integration/docker/deployer/app/Dockerfile
@@ -5,4 +5,5 @@ COPY default.conf /etc/nginx/conf.d/default.conf
 ARG COMMIT_SHA
 RUN echo $COMMIT_SHA > /usr/share/nginx/html/version
 RUN mkdir -p /usr/share/nginx/html/versions && echo "version" > /usr/share/nginx/html/versions/$COMMIT_SHA
+RUN mkdir -p /usr/share/nginx/html/versions && echo "hidden" > /usr/share/nginx/html/versions/.hidden
 

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -76,5 +76,7 @@ class MainTest < IntegrationTest
       versions.each do |version|
         assert_equal "200", Net::HTTP.get_response(URI.parse("http://localhost:12345/versions/#{version}")).code
       end
+
+      assert_equal "200", Net::HTTP.get_response(URI.parse("http://localhost:12345/versions/.hidden")).code
     end
 end


### PR DESCRIPTION
Adding -T to the copy command ensures that the files are copied at the same level into the target directory whether it exists or not.

That allows us to drop the `/*` which was not picking up hidden files.

Fixes: https://github.com/basecamp/kamal/issues/465