### PR TITLE
Add option to skip .env check

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -21,6 +21,7 @@ module Kamal::Cli
     class_option :destination, aliases: "-d", desc: "Specify destination to be used for config file (staging -> deploy.staging.yml)"
 
     class_option :skip_hooks, aliases: "-H", type: :boolean, default: false, desc: "Don't run hooks"
+    class_option :skip_env, type: boolean, default: false, desc: "Skip validating the .env file"
 
     def initialize(*)
       super
@@ -75,7 +76,9 @@ module Kamal::Cli
       def mutating
         return yield if KAMAL.holding_lock?
 
-        KAMAL.config.ensure_env_available
+        if !options[:skip_env]
+          KAMAL.config.ensure_env_available
+        end
 
         run_hook "pre-connect"
 


### PR DESCRIPTION
This would allow deploying without having the `.env` file generated locally. This is especially useful for automated deploys which may not have access to the secrets e.g. 1Password.

Ideally this option should only be for deploy but the env check is part of the base command.

Side note: I'm new to the repo and Ruby so please let me know if there are test that should be added or doc updates etc.