### PR TITLE
Remove the env check

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -75,8 +75,6 @@ module Kamal::Cli
       def mutating
         return yield if KAMAL.holding_lock?
 
-        KAMAL.config.ensure_env_available
-
         run_hook "pre-connect"
 
         ensure_run_directory

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -204,13 +204,6 @@ class Kamal::Configuration
     ensure_destination_if_required && ensure_required_keys_present && ensure_valid_kamal_version
   end
 
-  # Will raise KeyError if any secret ENVs are missing
-  def ensure_env_available
-    roles.collect(&:env_file).each(&:to_s)
-
-    true
-  end
-
   def to_h
     {
       roles: role_names,

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -128,14 +128,6 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal "healthcheck-app", @config.healthcheck_service
   end
 
-  test "env with missing secret" do
-    assert_raises(KeyError) do
-      config = Kamal::Configuration.new(@deploy.tap { |c| c.merge!({
-        env: { "secret" => [ "PASSWORD" ] }
-      }) }).ensure_env_available
-    end
-  end
-
   test "valid config" do
     assert @config.valid?
     assert @config_with_roles.valid?

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -5,6 +5,7 @@ class MainTest < IntegrationTest
     kamal :envify
     assert_local_env_file "SECRET_TOKEN=1234"
     assert_remote_env_file "SECRET_TOKEN=1234\nCLEAR_TOKEN=4321"
+    remove_local_env_file
 
     first_version = latest_app_version
 
@@ -62,6 +63,10 @@ class MainTest < IntegrationTest
   private
     def assert_local_env_file(contents)
       assert_equal contents, deployer_exec("cat .env", capture: true)
+    end
+
+    def remove_local_env_file
+      deployer_exec("rm .env")
     end
 
     def assert_remote_env_file(contents)


### PR DESCRIPTION
The env check is not needed anymore as all the commands rely on the env files having already been created remotely.

The only place the env is needed is when running `kamal env push` and that will still raise an appropriate error.