### PR TITLE
Allow custom name for traefik container

### DIFF
--- a/lib/kamal/commands/traefik.rb
+++ b/lib/kamal/commands/traefik.rb
@@ -8,7 +8,7 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
   }
 
   def run
-    docker :run, "--name traefik",
+    docker :run, "--name #{container_name}",
       "--detach",
       "--restart", "unless-stopped",
       *publish_args,
@@ -23,11 +23,11 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
   end
 
   def start
-    docker :container, :start, "traefik"
+    docker :container, :start, container_name
   end
 
   def stop
-    docker :container, :stop, "traefik"
+    docker :container, :stop, container_name
   end
 
   def start_or_run
@@ -35,18 +35,18 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
   end
 
   def info
-    docker :ps, "--filter", "name=^traefik$"
+    docker :ps, "--filter", "name=^#{container_name}$"
   end
 
   def logs(since: nil, lines: nil, grep: nil)
     pipe \
-      docker(:logs, "traefik", (" --since #{since}" if since), (" --tail #{lines}" if lines), "--timestamps", "2>&1"),
+      docker(:logs, container_name, (" --since #{since}" if since), (" --tail #{lines}" if lines), "--timestamps", "2>&1"),
       ("grep '#{grep}'" if grep)
   end
 
   def follow_logs(host:, grep: nil)
     run_over_ssh pipe(
-      docker(:logs, "traefik", "--timestamps", "--tail", "10", "--follow", "2>&1"),
+      docker(:logs, container_name, "--timestamps", "--tail", "10", "--follow", "2>&1"),
       (%(grep "#{grep}") if grep)
     ).join(" "), host: host
   end
@@ -68,7 +68,7 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
   end
 
   def host_env_file_path
-    File.join host_env_directory, "traefik.env"
+    File.join host_env_directory, "#{container_name}.env"
   end
 
   def make_env_directory
@@ -118,5 +118,9 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
 
     def host_port
       config.traefik["host_port"] || CONTAINER_PORT
+    end
+
+    def container_name
+      config.traefik["name"] || "traefik"
     end
 end


### PR DESCRIPTION
Following this discussion [Question: Multiple apps on one host sharing the same traefik instance #257](https://github.com/basecamp/kamal/discussions/257)
it would be interesting to be able to host multiple apps on the same host.

For example to host demo apps for clients, for portfolios, for QA, etc. at minimum cost.
In my case it would enable me to deploy a staging app for each of PRs so the QA can validate them independently.

It is now difficult because each projects would create a container with the same name `traefik`. The deploy would fail because a container with the name `traefik` already exists.

Instead, this PR allows us to give a unique name to the traefik containers.

Performance wise, it's terrible to have multiple instances of traefik, but for these specific use cases performance doesn't matter.
The change is minimal and has no impact on maintenance.

```yml
# USAGE:
traefik:
  name: traefik-my-app-pr-500
  args:
    entrypoints.my-app-pr-500-web.address: ':80'

labels:
  traefik.http.routers.my-app-pr-500-web.entrypoints: my-app-pr-500-web
```