### PR TITLE
Optionally Skip Push for "envify"

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -170,6 +170,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
   end
 
   desc "envify", "Create .env by evaluating .env.erb (or .env.staging.erb -> .env.staging when using -d staging)"
+  option :skip_push, aliases: "-P", type: :boolean, default: false, desc: "Skip .env file push"
   def envify
     if destination = options[:destination]
       env_template_path = ".env.#{destination}.erb"
@@ -182,7 +183,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
     File.write(env_path, ERB.new(File.read(env_template_path)).result, perm: 0600)
 
     load_envs # reload new file
-    invoke "kamal:cli:env:push", options
+    invoke "kamal:cli:env:push", options unless options[:skip_push]
   end
 
   desc "remove", "Remove Traefik, app, accessories, and registry session from servers"

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -353,6 +353,14 @@ class CliMainTest < CliTestCase
     run_command("envify", "-d", "world", config_file: "deploy_for_dest")
   end
 
+  test "envify with skip_push" do
+    File.expects(:read).with(".env.erb").returns("HELLO=<%= 'world' %>")
+    File.expects(:write).with(".env", "HELLO=world", perm: 0600)
+
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push").never
+    run_command("envify", "--skip-push")
+  end
+
   test "remove with confirmation" do
     run_command("remove", "-y", config_file: "deploy_with_accessories").tap do |output|
       assert_match /docker container stop traefik/, output


### PR DESCRIPTION
Pushing ".env" to remote host is not always required. If you just want to manage containers, traefik or accessories and initial push has already been done, that's adding additional step. Additionally - it reduces a risk of pushing incorrect ".env" to remote server.

This PR is adding "—skip_push" flag to "envify" command so it's possible to only generate it locally.