### PR TITLE
Add option to set an absolute directory path

### DIFF
--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -70,8 +70,8 @@ class Kamal::Configuration::Accessory
 
   def directories
     specifics["directories"]&.to_h do |host_to_container_mapping|
-      host_relative_path, container_path = host_to_container_mapping.split(":")
-      [ expand_host_path(host_relative_path), container_path ]
+      host_path, container_path = host_to_container_mapping.split(":")
+      [ expand_host_path(host_path), container_path ]
     end || {}
   end
 
@@ -138,13 +138,17 @@ class Kamal::Configuration::Accessory
 
     def remote_directories_as_volumes
       specifics["directories"]&.collect do |host_to_container_mapping|
-        host_relative_path, container_path = host_to_container_mapping.split(":")
-        [ expand_host_path(host_relative_path), container_path ].join(":")
+        host_path, container_path = host_to_container_mapping.split(":")
+        [ expand_host_path(host_path), container_path ].join(":")
       end || []
     end
 
-    def expand_host_path(host_relative_path)
-      "#{service_data_directory}/#{host_relative_path}"
+    def expand_host_path(host_path)
+      absolute_path?(host_path) ? host_path : "#{service_data_directory}/#{host_path}"
+    end
+
+    def absolute_path?(path)
+      Pathname.new(path).absolute?
     end
 
     def service_data_directory

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -149,8 +149,14 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_match "%", @config.accessory(:mysql).files.keys[2].read
   end
 
-  test "directories" do
+  test "directory with a relative path" do
+    @deploy[:accessories]["mysql"]["directories"] = [ "data:/var/lib/mysql" ]
     assert_equal({"$PWD/app-mysql/data"=>"/var/lib/mysql"}, @config.accessory(:mysql).directories)
+  end
+
+  test "directory with an absolute path" do
+    @deploy[:accessories]["mysql"]["directories"] = [ "/var/data/mysql:/var/lib/mysql" ]
+    assert_equal({"/var/data/mysql"=>"/var/lib/mysql"}, @config.accessory(:mysql).directories)
   end
 
   test "options" do


### PR DESCRIPTION
This PR will introduce the option to set an absolute directory path.   

**Before** - For example, a Redis accessory directory like:
- `data:/data` would create the directory `$PWD/my-appname-redis/data`
- `/var/lib/redis:/data` would create the directory `$PWD/my-appname-redis//var/lib/redis`

**After** - With this change, a Redis accessory directory like:
- `data:/data` would create the directory `$PWD/my-appname-redis/data`
- `/var/lib/redis:/data` would create the directory `/var/lib/redis`

The decision on whether Kamal will create an absolute or relative directory is based on the presence of a leading `/` in the path.

Please note that this change may introduce a breaking change for some users...

resolves #453