### PR TITLE
Fix duplicate error message in pre-build.sample

### DIFF
--- a/lib/kamal/cli/templates/sample_hooks/pre-build.sample
+++ b/lib/kamal/cli/templates/sample_hooks/pre-build.sample
@@ -32,7 +32,7 @@ fi
 current_branch=$(git branch --show-current)
 
 if [ -z "$current_branch" ]; then
-  echo "No git remote set, aborting..." >&2
+  echo "Not on a git branch, aborting..." >&2
   exit 1
 fi
 


### PR DESCRIPTION
The "No git remote set" error message was appropriate for the [previous block](https://github.com/basecamp/kamal/blob/83a2d52ff41eeb9c3240951316792c15223e8c98/lib/kamal/cli/templates/sample_hooks/pre-build.sample#L25-L30) (where it was presumably copy-pasted from), but in this line we have failed the check that determines if we have a git branch checked out, so we should output a different error message.