### PR TITLE
Add ruby hooks

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -136,7 +136,14 @@ module Kamal::Cli
       end
 
       def run_hook(hook, **extra_details)
-        if !options[:skip_hooks] && KAMAL.hook.hook_exists?(hook)
+        return if options[:skip_hooks]
+
+        if KAMAL.ruby_hook.hook_exists?(hook)
+          say "Running the ruby #{hook} hook...", :magenta
+          KAMAL.ruby_hook.run(hook, self)
+        end
+
+        if KAMAL.hook.hook_exists?(hook)
           details = { hosts: KAMAL.hosts.join(","), command: command, subcommand: subcommand }
 
           say "Running the #{hook} hook...", :magenta

--- a/lib/kamal/cli/templates/sample_hooks/pre-connect.rb.sample
+++ b/lib/kamal/cli/templates/sample_hooks/pre-connect.rb.sample
@@ -1,0 +1,16 @@
+# A sample ruby pre-connect hook
+#
+# Ruby hooks are an advanced extension mechanism that
+# should only be used in exceptional scenarios where a
+# regular hook or external helper-script doesn't suffice.
+
+# Ensure the 'moreutils' package is installed on all hosts
+on(KAMAL.hosts | KAMAL.accessory_hosts) do |host|
+  unless execute(:which, "ifdata", raise_on_non_zero_exit: false)
+    info "Installing baseline packages"
+    with DEBIAN_FRONTEND: "noninteractive" do
+      execute(:apt, "update")
+      execute(:apt, "install", "-qq", "-y", "moreutils")
+    end
+  end
+end

--- a/lib/kamal/commander.rb
+++ b/lib/kamal/commander.rb
@@ -104,6 +104,10 @@ class Kamal::Commander
     @hook ||= Kamal::Commands::Hook.new(config)
   end
 
+  def ruby_hook
+    @ruby_hook ||= Kamal::Commands::RubyHook.new(config)
+  end
+
   def lock
     @lock ||= Kamal::Commands::Lock.new(config)
   end

--- a/lib/kamal/commands/ruby_hook.rb
+++ b/lib/kamal/commands/ruby_hook.rb
@@ -1,0 +1,14 @@
+class Kamal::Commands::RubyHook < Kamal::Commands::Base
+  def run(hook, context)
+    context.instance_eval(File.read(hook_file(hook)))
+  end
+
+  def hook_exists?(hook)
+    Pathname.new(hook_file(hook)).exist?
+  end
+
+  private
+    def hook_file(hook)
+      "#{config.hooks_path}/#{hook}.rb"
+    end
+end

--- a/test/integration/docker/deployer/app/.kamal/hooks/post-deploy.rb
+++ b/test/integration/docker/deployer/app/.kamal/hooks/post-deploy.rb
@@ -1,0 +1,2 @@
+FileUtils.mkdir_p "/tmp/#{ENV.fetch('TEST_ID')}"
+FileUtils.touch "/tmp/#{ENV.fetch('TEST_ID')}/post-deploy.rb"

--- a/test/integration/docker/deployer/app/.kamal/hooks/pre-build.rb
+++ b/test/integration/docker/deployer/app/.kamal/hooks/pre-build.rb
@@ -1,0 +1,2 @@
+FileUtils.mkdir_p "/tmp/#{ENV.fetch('TEST_ID')}"
+FileUtils.touch "/tmp/#{ENV.fetch('TEST_ID')}/pre-build.rb"

--- a/test/integration/docker/deployer/app/.kamal/hooks/pre-connect.rb
+++ b/test/integration/docker/deployer/app/.kamal/hooks/pre-connect.rb
@@ -1,0 +1,2 @@
+FileUtils.mkdir_p "/tmp/#{ENV.fetch('TEST_ID')}"
+FileUtils.touch "/tmp/#{ENV.fetch('TEST_ID')}/pre-connect.rb"

--- a/test/integration/docker/deployer/app/.kamal/hooks/pre-deploy.rb
+++ b/test/integration/docker/deployer/app/.kamal/hooks/pre-deploy.rb
@@ -1,0 +1,2 @@
+FileUtils.mkdir_p "/tmp/#{ENV.fetch('TEST_ID')}"
+FileUtils.touch "/tmp/#{ENV.fetch('TEST_ID')}/pre-deploy.rb"

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -94,6 +94,9 @@ class IntegrationTest < ActiveSupport::TestCase
       hooks.each do |hook|
         file = "/tmp/#{ENV["TEST_ID"]}/#{hook}"
         assert_equal "removed '#{file}'", deployer_exec("rm -v #{file}", capture: true).strip
+
+        file = "/tmp/#{ENV["TEST_ID"]}/#{hook}.rb"
+        assert_equal "removed '#{file}'", deployer_exec("rm -v #{file}", capture: true).strip
       end
     end
 


### PR DESCRIPTION
Hi,

with this PR I would like to propose the introduction of **ruby hooks**.

### Goals

* Provide an easy way for Kamal users to add missing
   functionality without having to create & maintain a gem fork

* Make it easier for Kamal contributors to experiment with extensions and
   new feature ideas. Lower the barrier of entry for would-be contributors.

### How do ruby hooks work?

Analogous to the already existing script-hooks.

Just create e.g. `.kamal/hooks/pre-connect.rb` (note the .rb-suffix)
and its contents will be _instance_eval_'ed at pre-connect time.

### What are they good for?

Any extension of functionality that can not reasonably
be achieved with a regular hook or external wrapper script.

For example, here's a hook that I use to enable _service discovery_ and
_split horizon networking_ with Kamal (in less than 100 LOC):

<details>
<summary>.kamal/hooks/pre-connect.rb</summary>

```ruby
# .kamal/hooks/pre-connect.rb

#
# This hook enables docker-compose style
# service-discovery across hosts.
#
# It generates /etc/hosts files on all hosts
# so that plain accessory names (e.g. "redis")
# resolve to the private ip address of the host
# that they reside on.

# EXAMPLE:

# Given a cluster of two hosts with
# the following interfaces:
#
# host0: eth0 = 1.1.1.1, eth1 = 10.0.0.1
# host1: eth0 = 2.2.2.2, eth1 = 10.0.0.2

# You could use the following deploy.yaml:

# cluster_cidr: 10.0.0.0/16
#
# servers:
#   - 1.1.1.1
#   - 2.2.2.2
#
# accessories:
#   redis:
#     hosts:
#       - 1.1.1.1
#
#   postgres:
#     hosts:
#       - 2.2.2.2
#

# Which would result in the following /etc/hosts
# to become effective in all containers on all hosts:
#
# 10.0.0.1 redis
# 10.0.0.2 postgres

cluster_cidr = KAMAL.config.raw_config["cluster_cidr"]

unless cluster_cidr
  say "Service discovery disabled. No 'cluster_cidr' defined in deploy.yaml", :magenta
  return
end

all_hosts = KAMAL.hosts | KAMAL.accessory_hosts

# Ensure ifdata is installed on all hosts
on(all_hosts) do |host|
  unless execute(:which, "ifdata", raise_on_non_zero_exit: false)
    info "Installing baseline packages"
    with DEBIAN_FRONTEND: "noninteractive" do
      execute(:apt, "update")
      execute(:apt, "install", "-qq", "-y", "moreutils")
    end
  end
end

# Generate hosts-file
host_map = []
on(all_hosts) do |host|
  my_ip = JSON.parse(capture(:ip, "-j", "route", "get", cluster_cidr.split('/')[0]))[0]['prefsrc']
  names = KAMAL.config.roles.sort_by(&:name).select { |r| r.hosts.include?(host.hostname) }.map(&:name)
  names += KAMAL.config.accessories.sort_by(&:name).select { |a| a.hosts.include?(host.hostname) }.map(&:name)
  host_map << "#{my_ip} #{names.join(' ')}" unless names.empty?
end
host_map.sort!

say "Using network #{cluster_cidr} for cluster communication...", :magenta
say "# /etc/hosts", :cyan
host_map.each do |entry|
  say entry, :cyan
end

on(all_hosts) do |host|
  docker0_ip = capture(:ifdata, "-pa", "docker0").chomp

  files = []

  # Have systemd DNS server listen on docker0
  # to make it reachable from inside containers
  files << {
    path: "/etc/systemd/resolved.conf",
    after_update: [:systemctl, "restart", "systemd-resolved"],
    body: <<~EOF
      [Resolve]
      ReadEtcHosts=yes
      DNSStubListenerExtra=#{docker0_ip}
    EOF
  }

  # Tell containers to use host DNS server
  files << {
    path: "/etc/docker/daemon.json",
    after_update: [:systemctl, "restart", "docker"],
    body: <<~EOF
      {
        "dns": ["#{docker0_ip}"]
      }
    EOF
  }

  # Generate /etc/hosts
  files << {
    path: %w[/etc/hosts /etc/cloud/templates/hosts.debian.tmpl],
    after_update: nil,
    body: <<~EOF
      127.0.0.1 localhost
      #{host_map.join("\n")}
      ::1 localhost ip6-localhost ip6-loopback
      ff02::1 ip6-allnodes
      ff02::2 ip6-allrouters
    EOF
  }

  files.each do |file|
    paths = file[:path]
    paths = [paths] unless paths.is_a?(Array)
    updated = false
    paths.each do |path|
      want = Digest::SHA256.hexdigest(file[:body])
      have = capture("sha256sum #{path}").split[0].chomp
      if want != have
        upload! StringIO.new(file[:body]), path
        updated = true
      end
    end
    execute(*file[:after_update]) if file[:after_update] && updated
  end
end
```
</details>

Thanks to the neat internal DSL I've found this to be a very pleasant
way to "fill in the blanks".