### PR TITLE
Require sshkit within the sshkit util

### DIFF
--- a/lib/kamal/utils/sensitive.rb
+++ b/lib/kamal/utils/sensitive.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/module/delegation"
+require "sshkit"
 
 class Kamal::Utils::Sensitive
   # So SSHKit knows to redact these values.


### PR DESCRIPTION
Started getting this SSHKit error with Ruby 3.1.4, seems to still work fine with 3.2.2 so guessing it's a default gem thing but not really sure. I built the gem locally and installed it with the change in this PR and Kamal started working as expected again.

``` bash
➜  kamal deploy
/Users/n/.gem/ruby/3.1.4/gems/kamal-1.0.0/lib/kamal/utils/sensitive.rb:5:in `<class:Sensitive>': uninitialized constant Kamal::Utils::Sensitive::SSHKit (NameError)

  include SSHKit::Redaction
          ^^^^^^
	from /Users/n/.gem/ruby/3.1.4/gems/kamal-1.0.0/lib/kamal/utils/sensitive.rb:3:in `<top (required)>'
	from <internal:/Users/n/.rubies/ruby-3.1.4/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/Users/n/.rubies/ruby-3.1.4/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /Users/n/.gem/ruby/3.1.4/gems/zeitwerk-2.5.1/lib/zeitwerk/kernel.rb:27:in `require'
	from /Users/n/.gem/ruby/3.1.4/gems/zeitwerk-2.5.1/lib/zeitwerk/loader/helpers.rb:95:in `const_get'
	from /Users/n/.gem/ruby/3.1.4/gems/zeitwerk-2.5.1/lib/zeitwerk/loader/helpers.rb:95:in `cget'
	from /Users/n/.gem/ruby/3.1.4/gems/zeitwerk-2.5.1/lib/zeitwerk/loader.rb:232:in `block (2 levels) in eager_load'
	from /Users/n/.gem/ruby/3.1.4/gems/zeitwerk-2.5.1/lib/zeitwerk/loader/helpers.rb:26:in `block in ls'
	from /Users/n/.gem/ruby/3.1.4/gems/zeitwerk-2.5.1/lib/zeitwerk/loader/helpers.rb:18:in `each_child'
	from /Users/n/.gem/ruby/3.1.4/gems/zeitwerk-2.5.1/lib/zeitwerk/loader/helpers.rb:18:in `ls'
	from /Users/n/.gem/ruby/3.1.4/gems/zeitwerk-2.5.1/lib/zeitwerk/loader.rb:227:in `block in eager_load'
	from /Users/n/.gem/ruby/3.1.4/gems/zeitwerk-2.5.1/lib/zeitwerk/loader.rb:212:in `synchronize'
	from /Users/n/.gem/ruby/3.1.4/gems/zeitwerk-2.5.1/lib/zeitwerk/loader.rb:212:in `eager_load'
	from /Users/n/.gem/ruby/3.1.4/gems/kamal-1.0.0/lib/kamal.rb:10:in `<top (required)>'
	from <internal:/Users/n/.rubies/ruby-3.1.4/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from <internal:/Users/n/.rubies/ruby-3.1.4/lib/ruby/3.1.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
	from /Users/n/.gem/ruby/3.1.4/gems/kamal-1.0.0/bin/kamal:6:in `<top (required)>'
	from /Users/n/.gem/ruby/3.1.4/bin/kamal:25:in `load'
	from /Users/n/.gem/ruby/3.1.4/bin/kamal:25:in `<main>'
```