### PR TITLE
Enable trim mode with ERB

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -179,7 +179,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
       env_path          = ".env"
     end
 
-    File.write(env_path, ERB.new(File.read(env_template_path)).result, perm: 0600)
+    File.write(env_path, ERB.new(File.read(env_template_path), trim_mode: "-").result, perm: 0600)
 
     load_envs # reload new file
     invoke "kamal:cli:env:push", options

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -346,6 +346,20 @@ class CliMainTest < CliTestCase
     run_command("envify")
   end
 
+  test "envify with blank line trimming" do
+    file = <<~EOF
+      HELLO=<%= 'world' %>
+      <% if true -%>
+      KEY=value
+      <% end -%>
+    EOF
+
+    File.expects(:read).with(".env.erb").returns(file.strip)
+    File.expects(:write).with(".env", "HELLO=world\nKEY=value\n", perm: 0600)
+
+    run_command("envify")
+  end
+
   test "envify with destination" do
     File.expects(:read).with(".env.world.erb").returns("HELLO=<%= 'world' %>")
     File.expects(:write).with(".env.world", "HELLO=world", perm: 0600)


### PR DESCRIPTION
This PR enables trim_mode for blank lines with `<% -%>` in ERB which is what's enabled in Rails so it's fairly familiar for those that have built a Rails app. trim_mode skips creating extra blank lines when there's no output which can be helpful for more complicated envify scripts, for example with AWS secrets manager. I suppose you could move this to a lib file and move some of this setup out of here but it's also not that complicated to really justify doing that. The envify command currently fails with a syntax error if you attempt to end your ERB tags with `-%>`.

``` ruby
<%
  require 'aws-sdk-secretsmanager'
  client = Aws::SecretsManager::Client.new(region: "us-west-2")
-%>

<% client.list_secrets.secret_list.each do |secret| -%>
<% value = JSON.parse(client.get_secret_value(secret_id: secret.arn).secret_string) -%>

<% value.each_pair do |k,v| -%>
<%= k %>=<%= v %>
<% end -%>
<% end -%>
```