### PR TITLE
feature: add NAME=all option for accessory reboot

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -49,17 +49,21 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     end
   end
 
-  desc "reboot [NAME]", "Reboot existing accessory on host (stop container, remove container, start new container)"
+  desc "reboot [NAME]", "Reboot existing accessory on host (stop container, remove container, start new container; use NAME=all to boot all accessories)"
   def reboot(name)
     mutating do
-      with_accessory(name) do |accessory|
-        on(accessory.hosts) do
-          execute *KAMAL.registry.login
-        end
+      if name == "all"
+        KAMAL.accessory_names.each { |accessory_name| reboot(accessory_name) }
+      else
+        with_accessory(name) do |accessory|
+          on(accessory.hosts) do
+            execute *KAMAL.registry.login
+          end
 
-        stop(name)
-        remove_container(name)
-        boot(name, login: false)
+          stop(name)
+          remove_container(name)
+          boot(name, login: false)
+        end
       end
     end
   end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -48,6 +48,18 @@ class CliAccessoryTest < CliTestCase
     run_command("reboot", "mysql")
   end
 
+  test "reboot all" do
+    Kamal::Commands::Registry.any_instance.expects(:login).times(3)
+    Kamal::Cli::Accessory.any_instance.expects(:stop).with("mysql")
+    Kamal::Cli::Accessory.any_instance.expects(:remove_container).with("mysql")
+    Kamal::Cli::Accessory.any_instance.expects(:boot).with("mysql", login: false)
+    Kamal::Cli::Accessory.any_instance.expects(:stop).with("redis")
+    Kamal::Cli::Accessory.any_instance.expects(:remove_container).with("redis")
+    Kamal::Cli::Accessory.any_instance.expects(:boot).with("redis", login: false)
+
+    run_command("reboot", "all")
+  end
+
   test "start" do
     assert_match "docker container start app-mysql", run_command("start", "mysql")
   end


### PR DESCRIPTION
This missing cli option was discusses within [the issue](https://github.com/basecamp/kamal/issues/537)