### PR TITLE
Reset the env before pushing

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -24,6 +24,7 @@ module Kamal::Cli
 
     def initialize(*)
       super
+      @original_env = ENV.to_h.dup
       load_envs
       initialize_commander(options_with_subcommand_class_options)
     end
@@ -35,6 +36,12 @@ module Kamal::Cli
         else
           Dotenv.load(".env")
         end
+      end
+
+      def reload_envs
+        ENV.clear
+        ENV.update(@original_env)
+        load_envs
       end
 
       def options_with_subcommand_class_options

--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -182,8 +182,10 @@ class Kamal::Cli::Main < Kamal::Cli::Base
 
     File.write(env_path, ERB.new(File.read(env_template_path), trim_mode: "-").result, perm: 0600)
 
-    load_envs # reload new file
-    invoke "kamal:cli:env:push", options unless options[:skip_push]
+    unless options[:skip_push]
+      reload_envs
+      invoke "kamal:cli:env:push", options
+    end
   end
 
   desc "remove", "Remove Traefik, app, accessories, and registry session from servers"


### PR DESCRIPTION
Calling `load_envs` again does not load updated env variables, because Dotenv does not overwrite existing values.

To fix this we'll store the original ENV and reset to it before reloading.

Fixes: https://github.com/basecamp/kamal/issues/512