### PR TITLE
Add --skip_push option to setup

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -4,15 +4,13 @@ class Kamal::Cli::Main < Kamal::Cli::Base
   def setup
     print_runtime do
       mutating do
-        invoke_options = deploy_options
-
         say "Ensure Docker is installed...", :magenta
-        invoke "kamal:cli:server:bootstrap", [], invoke_options
+        invoke "kamal:cli:server:bootstrap"
 
         say "Push env files...", :magenta
-        invoke "kamal:cli:env:push", [], invoke_options
+        invoke "kamal:cli:env:push"
 
-        invoke "kamal:cli:accessory:boot", [ "all" ], invoke_options
+        invoke "kamal:cli:accessory:boot", [ "all" ]
         deploy
       end
     end

--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -1,15 +1,18 @@
 class Kamal::Cli::Main < Kamal::Cli::Base
   desc "setup", "Setup all accessories, push the env, and deploy app to servers"
+  option :skip_push, aliases: "-P", type: :boolean, default: false, desc: "Skip image build and push"
   def setup
     print_runtime do
       mutating do
+        invoke_options = deploy_options
+
         say "Ensure Docker is installed...", :magenta
-        invoke "kamal:cli:server:bootstrap"
+        invoke "kamal:cli:server:bootstrap", [], invoke_options
 
         say "Push env files...", :magenta
-        invoke "kamal:cli:env:push"
+        invoke "kamal:cli:env:push", [], invoke_options
 
-        invoke "kamal:cli:accessory:boot", [ "all" ]
+        invoke "kamal:cli:accessory:boot", [ "all" ], invoke_options
         deploy
       end
     end

--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -4,13 +4,15 @@ class Kamal::Cli::Main < Kamal::Cli::Base
   def setup
     print_runtime do
       mutating do
+        invoke_options = deploy_options
+
         say "Ensure Docker is installed...", :magenta
-        invoke "kamal:cli:server:bootstrap"
+        invoke "kamal:cli:server:bootstrap", [], invoke_options
 
         say "Push env files...", :magenta
-        invoke "kamal:cli:env:push"
+        invoke "kamal:cli:env:push", [], invoke_options
 
-        invoke "kamal:cli:accessory:boot", [ "all" ]
+        invoke "kamal:cli:accessory:boot", [ "all" ], invoke_options
         deploy
       end
     end

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -2,8 +2,6 @@ require_relative "cli_test_case"
 
 class CliMainTest < CliTestCase
   test "setup" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
-
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap")
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push")
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ])

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -4,26 +4,12 @@ class CliMainTest < CliTestCase
   test "setup" do
     invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
 
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push", [], invoke_options)
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap")
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push")
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ])
     Kamal::Cli::Main.any_instance.expects(:deploy)
 
     run_command("setup").tap do |output|
-      assert_match /Ensure Docker is installed.../, output
-      assert_match /Push env files.../, output
-    end
-  end
-
-  test "setup with skip_push" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
-
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push", [], invoke_options)
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
-    Kamal::Cli::Main.any_instance.expects(:deploy)
-
-    run_command("setup", "--skip_push").tap do |output|
       assert_match /Ensure Docker is installed.../, output
       assert_match /Push env files.../, output
     end

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -2,12 +2,31 @@ require_relative "cli_test_case"
 
 class CliMainTest < CliTestCase
   test "setup" do
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap")
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push")
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ])
+    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
+
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:deploy)
 
-    run_command("setup")
+    run_command("setup").tap do |output|
+      assert_match /Ensure Docker is installed.../, output
+      assert_match /Push env files.../, output
+    end
+  end
+
+  test "setup with skip_push" do
+    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
+
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:deploy)
+
+    run_command("setup", "--skip_push").tap do |output|
+      assert_match /Ensure Docker is installed.../, output
+      assert_match /Push env files.../, output
+    end
   end
 
   test "deploy" do

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -13,6 +13,36 @@ class CliMainTest < CliTestCase
     end
   end
 
+  test "setup with skip_push" do
+    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
+
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap")
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push")
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ])
+    # deploy
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:pull", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:traefik:boot", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:healthcheck:perform", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:boot", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:prune:all", [], invoke_options)
+
+    run_command("setup", "--skip_push").tap do |output|
+      assert_match /Ensure Docker is installed.../, output
+      assert_match /Push env files.../, output
+      # deploy
+      assert_match /Acquiring the deploy lock/, output
+      assert_match /Log into image registry/, output
+      assert_match /Pull app image/, output
+      assert_match /Ensure Traefik is running/, output
+      assert_match /Ensure app can pass healthcheck/, output
+      assert_match /Detect stale containers/, output
+      assert_match /Prune old containers and images/, output
+      assert_match /Releasing the deploy lock/, output
+    end
+  end
+
   test "deploy" do
     invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
 

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -2,9 +2,11 @@ require_relative "cli_test_case"
 
 class CliMainTest < CliTestCase
   test "setup" do
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap")
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push")
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ])
+    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
+    
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:deploy)
 
     run_command("setup").tap do |output|
@@ -16,9 +18,9 @@ class CliMainTest < CliTestCase
   test "setup with skip_push" do
     invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
 
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap")
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push")
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ])
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
     # deploy
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:pull", [], invoke_options)


### PR DESCRIPTION
Add possibility to skip build and push image on setup if you already have builded image in registry, e.g. after GitLab CI/CD.