### PR TITLE
Supporting multi-dc deploys

### DIFF
--- a/lib/kamal/commands/healthcheck.rb
+++ b/lib/kamal/commands/healthcheck.rb
@@ -1,7 +1,7 @@
 class Kamal::Commands::Healthcheck < Kamal::Commands::Base
 
   def run
-    web = config.role(:web)
+    web = config.role(:web) || config.roles.select(&:running_traefik?).first
 
     docker :run,
       "--detach",

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -90,7 +90,7 @@ class Kamal::Configuration
   end
 
   def primary_web_host
-    role(:web).primary_host
+    (role(:web) || roles.select(&:running_traefik?).first).primary_host
   end
 
   def traefik_hosts

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -249,7 +249,7 @@ class Kamal::Configuration
 
       roles.each do |role|
         if role.hosts.empty?
-          raise ArgumentError, "No servers specified for the #{role.name} role"
+          puts "Warning: No servers specified for the #{role.name} role"
         end
       end
 

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -25,7 +25,7 @@ class Kamal::Configuration
 
       def load_config_file(file)
         if file.exist?
-          YAML.load(ERB.new(IO.read(file)).result).symbolize_keys
+          YAML.load(ERB.new(IO.read(file)).result, aliases: true).symbolize_keys
         else
           raise "Configuration file not found in #{file}"
         end


### PR DESCRIPTION
This is an early sketch for discussion.

This branch: 

- Enables aliases+anchors in yaml.
  - This is huge for DRY within the layered config.yaml and config.staging.yaml to make controlling the large number of roles to sustain a multi-site deployment realistic.
- Drops the requirement to provide a :web role. Let's just use whatever role is running traefik and call it good enough. 
  - This lets us name all of the roles after a datacenter - rather than carrying one awkward :web role.
- Drops the requirement for roles to have hosts. The fact they're empty is harmless in the end if the user is informed. 
  - This let us toggle roles on/off for partial deployments. Very useful in outages.