### PR TITLE
Added logic to detect if curl is installed on servers and, when the OS are debian-like, installing it using apt before installing docker

### DIFF
--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -1,22 +1,37 @@
 class Kamal::Cli::Server < Kamal::Cli::Base
   desc "bootstrap", "Set up Docker to run Kamal apps"
   def bootstrap
-    missing = []
+    missing_curl = []
+    missing_docker = []
 
     on(KAMAL.hosts | KAMAL.accessory_hosts) do |host|
-      unless execute(*KAMAL.docker.installed?, raise_on_non_zero_exit: false)
+
+      unless (execute(*KAMAL.curl.installed?, raise_on_non_zero_exit: false) && execute(*KAMAL.curl.is_installable_with_apt?, raise_on_non_zero_exit: false))
+        if execute(execute *KAMAL.curl.install, raise_on_non_zero_exit: false)
+          info "Missing CURL on #{host}. Installing…"
+          execute *KAMAL.curl.install
+        else
+          missing_curl << host
+        end
+      end
+
+      unless (!missing_curl.include(host) && execute(*KAMAL.docker.installed?, raise_on_non_zero_exit: false))
         if execute(*KAMAL.docker.superuser?, raise_on_non_zero_exit: false)
           info "Missing Docker on #{host}. Installing…"
           execute *KAMAL.docker.install
         else
-          missing << host
+          missing_docker << host
         end
       end
 
       execute(*KAMAL.server.ensure_run_directory)
     end
 
-    if missing.any?
+    if missing_curl.any?
+      raise "Curl is not installed on #{missing.join(", ")} and can't be automatically installed. Please, install curl manually and run 'kamal setup'."
+    end
+
+    if missing_docker.any?
       raise "Docker is not installed on #{missing.join(", ")} and can't be automatically installed without having root access and the `curl` command available. Install Docker manually: https://docs.docker.com/engine/install/"
     end
   end

--- a/lib/kamal/commands/curl.rb
+++ b/lib/kamal/commands/curl.rb
@@ -1,0 +1,18 @@
+class Kamal::Commands::Curl < Kamal::Commands::Base
+    # Install Docker using the https://github.com/docker/docker-install convenience script.
+    def install
+      [ "apt-get", "--assume-yes install", "curl" ]
+    end
+  
+    # Checks the curl client version. Fails if curl is not installed.
+    def installed?
+      curl "--version"
+    end
+
+    # 
+    def is_installable_with_apt?
+      [ cat, "/etc/debian_version" ]
+    end
+
+  end
+  

--- a/test/commands/curl_test.rb
+++ b/test/commands/curl_test.rb
@@ -1,0 +1,23 @@
+require "test_helper"
+
+class CommandsCurlTest < ActiveSupport::TestCase
+  setup do
+    @config = {
+      service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" }, servers: [ "1.1.1.1" ]
+    }
+    @curl = Kamal::Commands::Curl.new(Kamal::Configuration.new(@config))
+  end
+
+  test "install" do
+    assert_equal "apt-get --assume-yes install curl", @curl.install.join(" ")
+  end
+
+  test "installed?" do
+    assert_equal "curl --version", @curl.installed?.join(" ")
+  end
+
+  test "is_installable_with_apt?" do
+    assert_equal "cat \"/etc/debian_version\"", @curl.installed?.join(" ")
+  end
+
+end


### PR DESCRIPTION
Hello everyone.

This PR is a follow-up from my comment [here](https://github.com/basecamp/kamal/issues/338#issuecomment-1793721838) where basically I understood that the server should have curl already installed, [but documentation says that kamal setup should actually install it when not installed on a server.](https://github.com/basecamp/kamal-site/blob/main/_docs/installation.md#L48)

This PR is intended to: 
- Define a Kamal::Commands for curl that is able to check wherever curl is installed using `--version` and that curl is installed with apt on Debian-like OSs or return a understandable error when the installation was not possible (E. G. unrecognized OS or not being a superuser);
- Upon `kamal setup`, check that curl is installed and try the installation; 
- Define unit tests to check that the methods I defined are returning the right results.

I hope the code is actually in continuity with the style of the repo as my Ruby knowledge is pretty basic. I'm available further follow-up and any improvements to what I have done to meet the requirements of the project.