### PR TITLE
Enable yaml aliases

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -25,7 +25,9 @@ class Kamal::Configuration
 
       def load_config_file(file)
         if file.exist?
-          YAML.load(ERB.new(IO.read(file)).result).symbolize_keys
+          # Newer Psych doesn't load aliases by default
+          load_method = YAML.respond_to?(:unsafe_load) ? :unsafe_load : :load
+          YAML.send(load_method, ERB.new(IO.read(file)).result).symbolize_keys
         else
           raise "Configuration file not found in #{file}"
         end

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -296,6 +296,19 @@ class CliMainTest < CliTestCase
     end
   end
 
+  test "config with aliases" do
+    run_command("config", config_file: "deploy_with_aliases").tap do |output|
+      config = YAML.load(output)
+
+      assert_equal ["web", "web_tokyo", "workers", "workers_tokyo"], config[:roles]
+      assert_equal ["1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4"], config[:hosts]
+      assert_equal "999", config[:version]
+      assert_equal "registry.digitalocean.com/dhh/app", config[:repository]
+      assert_equal "registry.digitalocean.com/dhh/app:999", config[:absolute_image]
+      assert_equal "app-999", config[:service_with_version]
+    end
+  end
+
   test "init" do
     Pathname.any_instance.expects(:exist?).returns(false).times(3)
     Pathname.any_instance.stubs(:mkpath)

--- a/test/fixtures/deploy_with_aliases.yml
+++ b/test/fixtures/deploy_with_aliases.yml
@@ -1,0 +1,36 @@
+# helper aliases
+chicago_hosts: &chicago_hosts
+  hosts:
+    - 1.1.1.1
+    - 1.1.1.2
+tokyo_hosts: &tokyo_hosts
+  hosts:
+    - 1.1.1.3
+    - 1.1.1.4
+web_common: &web_common
+  env:
+    ROLE: "web"
+  traefik: true
+
+# actual config
+service: app
+image: dhh/app
+servers:
+  web:
+    <<: *chicago_hosts
+    <<: *web_common
+  web_tokyo:
+    <<: *tokyo_hosts
+    <<: *web_common
+  workers:
+    cmd: bin/jobs
+    <<: *chicago_hosts
+  workers_tokyo:
+    cmd: bin/jobs
+    <<: *tokyo_hosts
+env:
+  REDIS_URL: redis://x/y
+registry:
+  server: registry.digitalocean.com
+  username: user
+  password: pw


### PR DESCRIPTION
Enable aliases for more exotic templating situations.

This is super useful for D.R.Y. when configuring a number of roles and you hit the limits of what's reasonable with ERB.

One example is configuring roles based on datacenters and wanting to pass a specific env var to each, eg:
```
chicago_defaults: &chicago_defaults
  env:
    DC: "chi"
ashburn_defaults: &ashburn_defaults
  env:
    DC: "ash"

service: app
image: dhh/app
servers:
  web:
    <<: *chicago_defaults
    hosts:
      - 1.1.1.1
      - 1.1.1.2
  workers:
    cmd: bin/jobs
    <<: *chicago_defaults
    hosts:
      - 1.1.1.3
      - 1.1.1.4
   
  web_ashburn:
    <<: *ashburn_defaults
    hosts:
      - 2.1.1.1
      - 2.1.1.2
  workers_ashburn:
    cmd: bin/jobs
    <<: *ashburn_defaults
    hosts:
      - 2.1.1.3
      - 2.1.1.4
```
This can be done explicitly, but depending on the number of env vars, roles and hosts involved it quickly unwieldy.

I'd prefer to support this but not encourage it as it definitely cranks up the complexity.