### PR TITLE
Add ability to stop containers asynchronously

### DIFF
--- a/lib/kamal/cli/async/stopper.rb
+++ b/lib/kamal/cli/async/stopper.rb
@@ -1,0 +1,108 @@
+require "kamal/sshkit_with_ext"
+
+class Kamal::Cli::Async::Stopper
+    attr_accessor :app_commands, :version
+    def initialize(app_commands, version:, ssh_context:)
+        @app_commands = app_commands
+        @version = version
+        @ssh_context = ssh_context
+    end
+
+    def stop
+      stop_async_and_record_stop_time
+      kill_zombie_containers
+      clean_stop_records
+    end
+  
+    def stop_async_and_record_stop_time
+      container_ids = capture_with_info(*app_commands.container_id_for_version(version)).split("\n")
+      container_ids = container_ids.reject{|id| parse_stop_records.map(&:first).include?(id)}
+      unless container_ids.empty?
+        info "Stopping #{container_ids.join(', ')} asynchronously..."
+        execute_stop_command(container_ids)
+        record_stop_time(container_ids, async_stop_records)
+      end
+    end
+
+    def record_stop_time(container_ids, async_stop_records)
+      stop_time = (Time.now.utc + (app_commands.config.stop_wait_time || 0)).iso8601
+      to_append = container_ids.map do |container_id|
+        "#{container_id},#{stop_time}"
+      end
+
+      execute :echo , "\"#{to_append.join("\n")}\"", ">>", async_stop_records
+    end
+
+
+    def kill_zombie_containers
+      active_containers = self.active_containers
+      zombie_containers = parse_stop_records.filter do |container_id, stop_time|
+        active_containers.include?(container_id) && stop_time < Time.now.utc
+      end
+
+      for container_id, stop_time in zombie_containers
+        warning "Container #{container_id} failed to be stopped asynchronously. Waiting for it to stop..."
+        execute *app_commands.stop_container(container_id)
+      end
+    end
+
+    def clean_stop_records
+      active_containers = self.active_containers
+      relevant_records = parse_stop_records.filter do |container_id, stop_time|
+        active_containers.include?(container_id)
+      end
+
+      write_stop_records(relevant_records)
+    end
+
+    def write_stop_records(records)
+      file_content = records.map do |container_id, stop_time|
+        "#{container_id},#{stop_time}"
+      end.join("\n")
+      execute :echo, "\"#{file_content}\"", ">", async_stop_records
+    end
+
+    def parse_stop_records
+      touch_stop_records_file
+      text = capture_with_info(*[:cat, async_stop_records])
+      text.split("\n").map do |line|
+        container_id, stop_time = line.split(',')
+        [container_id, Time.parse(stop_time)]
+      end
+    end
+    
+    def async_stop_records
+      "#{app_commands.config.run_directory}/#{[app_commands.config.service, app_commands.config.destination, 'async_stop_records'].compact.join('-')}"
+    end
+
+    private
+
+      def active_containers
+        capture_with_info(*@app_commands.list_active_containers, "--quiet").split("\n")
+      end
+
+      def execute_stop_command(container_ids)
+        execute *app_commands.stop_containers_async(container_ids)
+      end
+    
+      def touch_stop_records_file
+        execute :touch, async_stop_records
+      end
+
+
+      def execute(*arguments)
+        @ssh_context.execute(*arguments)
+      end
+
+      def capture_with_info(*arguments)
+        @ssh_context.capture_with_info(*arguments)
+      end
+
+      def info(*arguments)
+        @ssh_context.info(*arguments)
+      end
+
+      def warning(*arguments)
+        @ssh_context.warning(*arguments)
+      end
+end

--- a/lib/kamal/commands/app/containers.rb
+++ b/lib/kamal/commands/app/containers.rb
@@ -3,6 +3,10 @@ module Kamal::Commands::App::Containers
     docker :container, :ls, "--all", *filter_args
   end
 
+  def list_active_containers
+    docker :container, :ls, *filter_args
+  end
+
   def list_container_names
     [ *list_containers, "--format", "'{{ .Names }}'" ]
   end

--- a/lib/kamal/configuration/role.rb
+++ b/lib/kamal/configuration/role.rb
@@ -158,6 +158,10 @@ class Kamal::Configuration::Role
     File.join config.run_directory, "assets", "volumes", container_name(version)
   end
 
+  def stop_async?
+    specializations["stop_asynchronously"] || false
+  end
+
   private
     attr_accessor :config
 

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -104,6 +104,11 @@ class CliAppTest < CliTestCase
     end
   end
 
+  test "stop_async" do
+    Kamal::Cli::Async::Stopper.any_instance.expects(:stop).once
+    run_command("stop_async")
+  end
+  
   test "stale_containers" do
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=role=web", "--format", "\"{{.Names}}\"", "|", "while read line; do echo ${line#app-web-}; done", raise_on_non_zero_exit: false)

--- a/test/cli/async/stopper_test.rb
+++ b/test/cli/async/stopper_test.rb
@@ -1,0 +1,99 @@
+require 'test_helper'
+
+class Kamal::Cli::Async::StopperTest < ActiveSupport::TestCase
+
+  setup do
+    @version = "999"
+    @stop_wait_time = 600
+    raw_config = { service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" }, servers: [ "1.1.1.1" ], env: { "secret" => [ "RAILS_MASTER_KEY" ] }, stop_wait_time: @stop_wait_time }
+    config = Kamal::Configuration.new(raw_config, destination: nil, version: @version)
+    @app_commands = Kamal::Commands::App.new(config, role: "web")
+  end
+
+  test "stops all containers asynchronously and records the expected maximum stop time" do
+    freeze_time do
+      with_local_backend do |ssh_context|
+        @app_commands.expects(:container_id_for_version).returns('echo "12345678\n87654321"')
+        stopper = Kamal::Cli::Async::Stopper.new(@app_commands, version: @version, ssh_context: ssh_context)
+        stopper.expects(:execute_stop_command).with(["12345678", "87654321"])
+        stopper.stop_async_and_record_stop_time
+        assert_equal [ ["12345678", Time.now + @stop_wait_time], ["87654321", Time.now + @stop_wait_time] ], stopper.parse_stop_records
+      end.tap do |output|
+        assert_match "Stopping 12345678, 87654321 asynchronously...\n", output
+      end
+    end
+  end
+
+  test "only stops containers that are not being stopped already" do
+    freeze_time do
+      with_local_backend do |ssh_context|
+        @app_commands.expects(:container_id_for_version).returns('echo "12345678\n87654321"')
+        stopper = Kamal::Cli::Async::Stopper.new(@app_commands, version: @version, ssh_context: ssh_context)
+        stopper.write_stop_records([["12345678",Time.now], ["0000001",Time.now]])
+        stopper.expects(:execute_stop_command).with(["87654321"])
+        stopper.stop_async_and_record_stop_time
+        assert_equal [ ["12345678", Time.now], ["0000001", Time.now],["87654321", Time.now + @stop_wait_time] ], stopper.parse_stop_records
+      end.tap do |output|
+        assert_match "Stopping 87654321 asynchronously...\n", output
+      end
+    end
+  end
+  
+  test "clears stop records for containers that already_stopped" do
+    with_local_backend do |ssh_context|
+      stopper = Kamal::Cli::Async::Stopper.new(@app_commands, version: @version, ssh_context: ssh_context)
+      stopper.write_stop_records([["12345678",Time.at(0)],["0000001", Time.at(0)]])
+      stopper.stubs(:active_containers).returns(["12345678", "87654321"])
+
+      stopper.clean_stop_records
+      assert_equal [ ["12345678", Time.at(0)] ], stopper.parse_stop_records
+    end
+  end
+
+  test "kills zombie containers synchronously if needed" do
+    freeze_time do
+      ssh_context = mock
+      stopper = Kamal::Cli::Async::Stopper.new(@app_commands, version: @version, ssh_context: ssh_context)
+      ssh_context.stubs(:execute).with(:touch, ".kamal/app-async_stop_records")
+      stopper.stubs(:active_containers).returns(["12345678", "87654321"])
+      ssh_context.stubs(:capture_with_info).with(:cat, stopper.async_stop_records)
+        .returns("12345678,#{Time.now.utc - 20.minutes}\n0000001,#{Time.now.utc - 20.minutes},87654321,#{Time.now.utc + 20.minutes}")
+      
+      ssh_context.expects(:warning).with("Container 12345678 failed to be stopped asynchronously. Waiting for it to stop...")
+      ssh_context.expects(:execute).with(:docker, :stop, "-t", @stop_wait_time, "12345678")
+
+      stopper.kill_zombie_containers
+    end
+  end
+
+  test "stops asynchronously, clears the records, and kills zombies" do
+    stopper = Kamal::Cli::Async::Stopper.new(@app_commands, version: @version, ssh_context: nil)
+    stopper.expects(:stop_async_and_record_stop_time)
+    stopper.expects(:clean_stop_records)
+    stopper.expects(:kill_zombie_containers)
+
+    stopper.stop
+  end
+
+  test "can retrieve active containers" do
+    ssh_context = mock
+    ssh_context.stubs(:capture_with_info).with(*@app_commands.list_active_containers, "--quiet").returns("12345678\n87654321")
+    stopper = Kamal::Cli::Async::Stopper.new(@app_commands, version: @version, ssh_context: ssh_context)
+    assert_equal ["12345678", "87654321"], stopper.send(:active_containers)
+  end
+   
+  private
+
+    def with_local_backend
+      stdouted do
+        SSHKit::Backend::Local.new.tap do |backend|
+          Dir.mktmpdir do |tmp_dir|
+            backend.within tmp_dir do
+              backend.execute :mkdir, "-p", ".kamal"
+              yield backend
+            end
+          end
+        end
+      end
+    end
+end

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -103,6 +103,17 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command.stop(version: "123").join(" ")
   end
 
+  test "stop_containers_async" do
+    expected_command = "nohup sh -c 'echo \"container1\ncontainer2\" | xargs docker stop' > /dev/null 2>&1 & disown"
+    assert_equal expected_command, new_command.stop_containers_async(['container1', 'container2']).join(" ")
+  end
+
+  test "stop_containers_async with custom stop wait time" do
+    @config[:stop_wait_time] = 30
+    expected_command = "nohup sh -c 'echo \"container1\ncontainer2\" | xargs docker stop -t 30' > /dev/null 2>&1 & disown"
+    assert_equal expected_command, new_command.stop_containers_async(['container1', 'container2']).join(" ")
+  end
+
   test "info" do
     assert_equal \
       "docker ps --filter label=service=app --filter label=role=web",

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -313,4 +313,13 @@ class ConfigurationTest < ActiveSupport::TestCase
     end
     assert_match /bar isn't defined/, error.message
   end
+  
+  test "stop_asynchronously" do
+    assert_not @config.role(:web).stop_async?
+    raw_config_with_stop_async = @deploy_with_roles.dup
+    raw_config_with_stop_async[:servers]["workers"]["stop_asynchronously"] = true
+    config_with_stop_async = Kamal::Configuration.new(raw_config_with_stop_async)
+    assert_not config_with_stop_async.role(:web).stop_async?
+    assert config_with_stop_async.role(:workers).stop_async?
+  end
 end


### PR DESCRIPTION
## Motivation

We've used Kamal to move some **long-running jobs** (ffmpeg transcoding) from AWS to Hetzner. The savings in $$-to-big-tech are amazing, thanks a lot for this project 🙌

The only problem we have is that we cannot find a way to prevent our jobs from being stopped midway while also having quick deployments as part of our Monolith's CI/CD system. 

The simplest solution I could think of is:
- Kamal fires a `docker stop` command with a generous grace period and forgets about my workers.
- The worker stops picking up new jobs upon receiving the SIGTERM, and exits after finishing the current job.
- Just in case something goes wrong, Kamal persists the containers that should be dying and makes sure they are dead once the grace period is over.

I gave a bit more context on this discussion: https://github.com/basecamp/kamal/discussions/491


## Implementation

### `stop_asynchronously`
New configuration flag that can be applied per role: `stop_asynchronously`. This is more or less how we are using it
```
  flong_running_workers:
    hosts: 
      - MY IPS
    cmd: long_running_job_worker --do-not-pick-jobs-after-sigterm --grace-period-until-sigkill 600
    stop_asynchronously: true

stop_wait_time: 601
```

### Running docker stop in the background

The command that is run is something like:
```
nohup sh -c 'echo "CONTAINER_IDS" | xargs docker stop -t 3600' > /dev/null 2>&1 & disown
```

### Keeping track of stopped containers

We persist the records in a simple plain text file that looks like this:
```
# CONTAINER_ID,STOP_TIME
root@web-staging:~# cat .kamal/happyscribe-media-worker-staging-async_stop_records 
4bf1c771bcec,2023-11-12 08:18:20 UTC
```


If the container is still up in a subsequent deploy that happens after the recorded stop time, then Kamal stops it synchronously.

## Closing thoughts

I understand long-running jobs may not be the focus of this tool, and therefore the extra complexity in this PR might not be justified. The reason I built this is that I'd rather maintain a fork of Kamal than deploy our own Kubernetes cluster. Guidance on reducing this complexity would be greatly appreciated if you think this can be a good fit for Kamal.

Also: I am not very sure the way I encapsulated this behavior is in line with Kamal's architecture. I am more than open to feedback and happy to do any modification that would align better with the project.

