### PR TITLE
Add allow_empty_roles to control aborting on roles with no hosts.

### DIFF
--- a/lib/kamal/cli/templates/deploy.yml
+++ b/lib/kamal/cli/templates/deploy.yml
@@ -91,3 +91,8 @@ registry:
 # Caution: there's no support for role renaming yet, so be careful to cleanup
 #          the previous role on the deployed hosts.
 # primary_web_role: web
+
+# Controls if we abort when see a role with no hosts. Disabling this may be
+# useful for more complex deploy configurations.
+#
+# allow_empty_roles: false

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -165,6 +165,16 @@ class ConfigurationTest < ActiveSupport::TestCase
     end
   end
 
+  test "allow_empty_roles" do
+    assert_silent do
+      Kamal::Configuration.new @deploy.merge(servers: { "web" => %w[ web ], "workers" => { "hosts" => %w[ ] } }, allow_empty_roles: true)
+    end
+
+    assert_raises(ArgumentError) do
+      Kamal::Configuration.new @deploy.merge(servers: { "web" => %w[], "workers" => { "hosts" => %w[] } }, allow_empty_roles: true)
+    end
+  end
+
   test "volume_args" do
     assert_equal ["--volume", "/local/path:/container/path"], @config.volume_args
   end


### PR DESCRIPTION
Add allow_empty_roles to control aborting on roles with no hosts.

This added flexibility allows you to define base roles that might not necessarily exist in each deploy destination.

eg:

config/deploy.yml
```
servers:
  web:
    cmd: bin/web
    <other important common config>

  jobs:
    cmd: bin/jobs
    <other important common config>
```

config/deploy.beta.yml
```
servers:
  web:
    cmd: bin/web
    hosts:
    - 1.1.1.1
    - 1.1.1.2

# No jobs on betas!
```

config/deploy.production.yml
```
servers:
  web:
    hosts:
    - 1.1.1.3
    - 1.1.1.4

  jobs:
    hosts:
    - 1.1.1.5
    - 1.1.1.6
```

config/deploy.staging.yml
```
servers:
  web:
    hosts:
    - 1.1.1.7
    - 1.1.1.8

  jobs:
    hosts:
    - 1.1.1.9
    - 1.1.1.10
```
without this a `kamal deploy -d beta` would fail with `No servers specified for the jobs role`. 