### PR TITLE
Add docker-setup hook

### DIFF
--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -19,5 +19,7 @@ class Kamal::Cli::Server < Kamal::Cli::Base
     if missing.any?
       raise "Docker is not installed on #{missing.join(", ")} and can't be automatically installed without having root access and the `curl` command available. Install Docker manually: https://docs.docker.com/engine/install/"
     end
+
+    run_hook "docker-setup"
   end
 end

--- a/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
+++ b/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+# A sample docker-setup hook
+#
+# Sets up a Docker network which can then be used by the application’s containers
+
+ssh user@example.com docker network create kamal

--- a/test/cli/server_test.rb
+++ b/test/cli/server_test.rb
@@ -23,10 +23,13 @@ class CliServerTest < CliTestCase
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with('[ "${EUID:-$(id -u)}" -eq 0 ] || command -v sudo >/dev/null || command -v su >/dev/null', raise_on_non_zero_exit: false).returns(true).at_least_once
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:curl, "-fsSL", "https://get.docker.com", "|", :sh).at_least_once
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:mkdir, "-p", ".kamal").returns("").at_least_once
+    Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).returns(true)
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(".kamal/hooks/docker-setup", anything).at_least_once
 
     run_command("bootstrap").tap do |output|
       ("1.1.1.1".."1.1.1.4").map do |host|
         assert_match "Missing Docker on #{host}. Installing…", output
+        assert_match "Running the docker-setup hook", output
       end
     end
   end

--- a/test/integration/docker/deployer/app/.kamal/hooks/docker-setup
+++ b/test/integration/docker/deployer/app/.kamal/hooks/docker-setup
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Docker set up!"
+mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/docker-setup


### PR DESCRIPTION
This allows the user to make any necessary configuration changes to Docker before setting up any containers, allowing those configuration changes to take effect from the outset.

My primary motivation for adding this was wanting all the containers to be on the same Docker network. This change means the `docker-setup` hook script can ensure the network exists before deployment rather than needing to do so manually. This should be more broadly useful for any general Docker configuration that may be necessary by the user, however. The new hook point is necessary so it can be done _after_ we ensure Docker is installed but _before_ deploying any containers.

I’ve tested this manually but don’t fully understand the way hooks are being tested so would appreciate some assistance getting the new test to pass.