### PR TITLE
Role specific logging configuration

### DIFF
--- a/lib/kamal/commands/app.rb
+++ b/lib/kamal/commands/app.rb
@@ -21,7 +21,7 @@ class Kamal::Commands::App < Kamal::Commands::Base
       "-e", "KAMAL_VERSION=\"#{config.version}\"",
       *role_config.env_args,
       *role_config.health_check_args,
-      *config.logging_args,
+      *role_config.logging_args,
       *config.volume_args,
       *role_config.asset_volume_args,
       *role_config.label_args,

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -6,7 +6,7 @@ require "erb"
 require "net/ssh/proxy/jump"
 
 class Kamal::Configuration
-  delegate :service, :image, :servers, :env, :labels, :registry, :stop_wait_time, :hooks_path, to: :raw_config, allow_nil: true
+  delegate :service, :image, :servers, :env, :labels, :registry, :stop_wait_time, :hooks_path, :logging, to: :raw_config, allow_nil: true
   delegate :argumentize, :optionize, to: Kamal::Utils
 
   attr_reader :destination, :raw_config
@@ -141,9 +141,9 @@ class Kamal::Configuration
   end
 
   def logging_args
-    if raw_config.logging.present?
-      optionize({ "log-driver" => raw_config.logging["driver"] }.compact) +
-        argumentize("--log-opt", raw_config.logging["options"])
+    if logging.present?
+      optionize({ "log-driver" => logging["driver"] }.compact) +
+        argumentize("--log-opt", logging["options"])
     else
       argumentize("--log-opt", { "max-size" => "10m" })
     end

--- a/lib/kamal/configuration/role.rb
+++ b/lib/kamal/configuration/role.rb
@@ -38,7 +38,7 @@ class Kamal::Configuration::Role
 
   def logging_args
     args = config.logging || {}
-    args.deep_merge!(specializations['logging']) if specializations['logging'].present?
+    args.deep_merge!(specializations["logging"]) if specializations["logging"].present?
 
     if args.any?
       optionize({ "log-driver" => args["driver"] }.compact) +

--- a/lib/kamal/configuration/role.rb
+++ b/lib/kamal/configuration/role.rb
@@ -36,6 +36,18 @@ class Kamal::Configuration::Role
     argumentize "--label", labels
   end
 
+  def logging_args
+    args = config.logging || {}
+    args.deep_merge!(specializations['logging']) if specializations['logging'].present?
+
+    if args.any?
+      optionize({ "log-driver" => args["driver"] }.compact) +
+        argumentize("--log-opt", args["options"])
+    else
+      config.logging_args
+    end
+  end
+
 
   def env
     if config.env && config.env["secret"]


### PR DESCRIPTION
# Problem
Logging configuration is shared across all containers which is problematic if containers require specific configuration. Example: Sending logs to specific log groups when using `awslogs` driver.

# Solution
Add `logging` to the role configuration.

# Examples
## Basic
```yml
servers:
  web:
    hosts: ['1.1.1.1']
    logging:
      driver: local
      options:
         max-size: 100M
  job:
    hosts: ['1.1.1.2']
    logging:
      driver: local
      options:
         max-size: 10M
```
## Deep Merge
I used `deep_merge` so the configuration would be inherited from the root configuration.
```yml
servers:
  web:
    hosts: ['1.1.1.1']
    logging:
      options:
         max-size: 100M

logging:
  driver: local
```