### PR TITLE
Try to match primary_role when roles are filtered

### DIFF
--- a/lib/kamal/commander.rb
+++ b/lib/kamal/commander.rb
@@ -36,7 +36,8 @@ class Kamal::Commander
   end
 
   def primary_host
-    specific_hosts&.first || specific_roles&.first&.primary_host || config.primary_host
+    # Given a list of specific roles, make an effort to match up with the primary_role
+    specific_hosts&.first || specific_roles&.detect { |role| role.name == config.primary_role }&.primary_host || specific_roles&.first&.primary_host || config.primary_host
   end
 
   def primary_role

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -100,6 +100,15 @@ class CommanderTest < ActiveSupport::TestCase
     assert_equal({ in: :groups, limit: 1, wait: 2 }, @kamal.boot_strategy)
   end
 
+  test "try to match the primary role from a list of specific roles" do
+    configure_with(:deploy_primary_web_role_override)
+
+    @kamal.specific_roles = [ "web_*" ]
+    assert_equal [ "web_chicago", "web_tokyo" ], @kamal.roles.map(&:name)
+    assert_equal "web_tokyo", @kamal.primary_role
+    assert_equal "1.1.1.3", @kamal.primary_host
+  end
+
   private
     def configure_with(variant)
       @kamal = Kamal::Commander.new.tap do |kamal|


### PR DESCRIPTION
Make an effort to match the primary_role from a list of specific roles.

eg: given a config like
```
primary_role: web_site2

servers:
  web_site1:
    traefik: true
    hosts:
    - 1.1.1.1
    - 1.1.1.2

  jobs_site1:
    hosts:
    - 1.1.1.3
    - 1.1.1.4

  web_site2:
    traefik: true
    hosts:
    - 2.1.1.1
    - 2.1.1.2

  jobs_site2:
    hosts:
    - 2.1.1.3
    - 2.1.1.4
```
and if we filter by site2:
```
$ bin/kamal lock release -d staging -r *_site2 -H
  INFO [366c0fe0] Running /usr/bin/env mkdir -p .kamal on 2.1.1.3   <-- oops! first jobs node
```
Things will run on the first role + first host in the specific roles array, which is a bit unexpected given the primary_role we requested. 

With this change it'll make an effort to match the primary_role:
```
$ bin/kamal lock release -d staging -r *_site2 -H
  INFO [478deb96] Running /usr/bin/env mkdir -p .kamal on 2.1.1.1
```
Much nicer.

This also fixes a role filtered deploy issue we're seeing:
```
$ bin/kamal deploy -d staging -r *_sc_chi -H
<snip>
  INFO [5fba68d3] Running docker container ls --all --filter name=^healthcheck-foo-staging-a68cf68d02fc0922a2ee85a1d8c9d69af7fc4a39_uncommitted_d6efcf639bf13e59$ --quiet | xargs docker container rm on foo-staging-console-01
  INFO [5fba68d3] Finished in 0.323 seconds with exit status 123 (failed).
Releasing the deploy lock...
  Finished all in 124.8 seconds
  ERROR (SSHKit::Command::Failed): Exception while executing on host foo-staging-console-01: docker exit status: 125
docker stdout: Nothing written
docker stderr: docker: open .kamal/env/roles/foo-web_sc_chi-staging.env: no such file or directory.
See 'docker run --help'.
```
or
```
$ bin/kamal deploy -d staging -r console,web -H
<snip>
Releasing the deploy lock...
  Finished all in 85.0 seconds
  ERROR (SSHKit::Command::Failed): Exception while executing on host foo-staging-console-101: docker exit status: 125
docker stdout: Nothing written
docker stderr: docker: open .kamal/env/roles/foo-web-staging.env: no such file or directory.
See 'docker run --help'.
```
where kamal attempts to use the primary_role env on whatever role happens to come first.