### PR TITLE
Error out when roles or host filters don't match anything

### DIFF
--- a/lib/kamal/commander.rb
+++ b/lib/kamal/commander.rb
@@ -28,11 +28,27 @@ class Kamal::Commander
   end
 
   def specific_roles=(role_names)
-    @specific_roles = Kamal::Utils.filter_specific_items(role_names, config.roles) if role_names.present?
+    if role_names.present?
+      @specific_roles = Kamal::Utils.filter_specific_items(role_names, config.roles)
+
+      if @specific_roles.empty?
+        raise ArgumentError, "No --roles match for #{role_names.join(',')}"
+      end
+
+      @specific_roles
+    end
   end
 
   def specific_hosts=(hosts)
-    @specific_hosts = Kamal::Utils.filter_specific_items(hosts, config.all_hosts) if hosts.present?
+    if hosts.present?
+      @specific_hosts = Kamal::Utils.filter_specific_items(hosts, config.all_hosts)
+
+      if @specific_hosts.empty?
+        raise ArgumentError, "No --hosts match for #{hosts.join(',')}"
+      end
+
+      @specific_hosts
+    end
   end
 
   def primary_host

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -24,8 +24,10 @@ class CommanderTest < ActiveSupport::TestCase
     @kamal.specific_hosts = [ "*" ]
     assert_equal [ "1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4" ], @kamal.hosts
 
-    @kamal.specific_hosts = [ "*miss" ]
-    assert_equal [], @kamal.hosts
+    exception = assert_raises(ArgumentError) do
+      @kamal.specific_hosts = [ "*miss" ]
+    end
+    assert_match /hosts match for \*miss/, exception.message
   end
 
   test "filtering hosts by filtering roles" do
@@ -33,6 +35,11 @@ class CommanderTest < ActiveSupport::TestCase
 
     @kamal.specific_roles = [ "web" ]
     assert_equal [ "1.1.1.1", "1.1.1.2" ], @kamal.hosts
+
+    exception = assert_raises(ArgumentError) do
+      @kamal.specific_roles = [ "*miss" ]
+    end
+    assert_match /roles match for \*miss/, exception.message
   end
 
   test "filtering roles" do
@@ -50,8 +57,10 @@ class CommanderTest < ActiveSupport::TestCase
     @kamal.specific_roles = [ "*" ]
     assert_equal [ "web", "workers" ], @kamal.roles.map(&:name)
 
-    @kamal.specific_roles = [ "*miss" ]
-    assert_equal [], @kamal.roles.map(&:name)
+    exception = assert_raises(ArgumentError) do
+      @kamal.specific_roles = [ "*miss" ]
+    end
+    assert_match /roles match for \*miss/, exception.message
   end
 
   test "filtering roles by filtering hosts" do


### PR DESCRIPTION
Raise an error when either the filtered hosts or roles are empty.

Keeps us from confusingly running things on the primary_host when nothing matches.

eg: given
```
servers:
  web:
    traefik: true
    hosts:
    - 1.1.1.1
    - 1.1.1.2

  jobs:
    hosts:
    - 1.1.1.3
    - 1.1.1.4
```
These should fail
```
$ bin/kamal lock release -d staging -r intentional_miss
  INFO [0f6fb993] Running /usr/bin/env mkdir -p .kamal on 1.1.1.1

$ bin/kamal lock release -d staging -h intentional_miss
  INFO [68394a4b] Running /usr/bin/env mkdir -p .kamal on 1.1.1.1
```
but they run anyway. 

The deploy is worse though, instead of failing when nothing matches the filter, it'll just run a normal deploy to all hosts, really the opposite of what we want. eg:
```
$ bin/kamal deploy -d staging -r intentional_miss -H
Acquiring the deploy lock...
Log into image registry...
  INFO [b51e6587] Running docker login -u [REDACTED] -p [REDACTED] as mkent@localhost
  INFO [b51e6587] Finished in 1.396 seconds with exit status 0 (successful).
Build and push app image...
  INFO [2d95b1ab] Running docker --version && docker buildx version as mkent@localhost
  INFO [2d95b1ab] Finished in 0.095 seconds with exit status 0 (successful).
The following paths have uncommitted changes:
 M bin/kamal
 M config/deploy.staging.yml
  INFO [717fd98f] Running docker buildx build --push --platform linux/amd64 --builder kamal-foo-native-remote -t basecamp/foo-rails:e45b4e8301b55ef3cd16f539f5d124d1744114ab_uncommitted_be9bf8640bf84276 <redacted> . as mkent@localhost
 DEBUG [717fd98f] Command: docker buildx build --push --platform linux/amd64 --builder kamal-foo-native-remote -t basecamp/foo-rails:e45b4e8301b55ef3cd16f539f5d124d1744114ab_uncommitted_be9bf8640bf84276 <redacted> .
 DEBUG [717fd98f] 	#0 building with "kamal-foo-native-remote" instance using docker-container driver
<snip>
```