### PR TITLE
Fix duplicate role env vars

### DIFF
--- a/lib/kamal/configuration/role.rb
+++ b/lib/kamal/configuration/role.rb
@@ -239,7 +239,7 @@ class Kamal::Configuration::Role
         clear_app_env  = config.env["secret"] ? Array(config.env["clear"]) : Array(config.env["clear"] || config.env)
         clear_role_env = specialized_env["secret"] ? Array(specialized_env["clear"]) : Array(specialized_env["clear"] || specialized_env)
 
-        new_env["clear"] = (clear_app_env + clear_role_env).uniq
+        new_env["clear"] = clear_app_env.to_h.merge(clear_role_env.to_h)
       end
     end
 


### PR DESCRIPTION
Noted this while doing some role based overrides mixed with secrets:
```
app@foo:~$ rg REDIS_SHARED_HOST .kamal/env/roles/foo-web-staging.env
26:REDIS_SHARED_HOST=foo-staging-redis-shared-primary
35:REDIS_SHARED_HOST=foo-staging-redis-shared-local
```
oddly enough if does work as they're loaded in the right order, but it's certainly confusing.

The simplest fix seems to be to convert things to hashes and merge them instead of adding the array. 

I've added a test and verified the current behaviour
```
$ bin/test test/configuration/role_test.rb
Run options: --seed 2085

# Running:

.......................F

Failure:
ConfigurationRoleTest#test_env_overwritten_by_role_with_secrets [/Users/mkent/Work/basecamp/kamal/test/configuration/role_test.rb:202]:
--- expected
+++ actual
@@ -1,3 +1,4 @@
 "REDIS_PASSWORD=secret456
+REDIS_URL=redis://a/b
 REDIS_URL=redis://c/d
 "

bin/test Users/mkent/Work/basecamp/kamal/test/configuration/role_test.rb:179

Finished in 0.009148s, 2623.5243 runs/s, 5902.9296 assertions/s.
24 runs, 54 assertions, 1 failures, 0 errors, 0 skips
```
and the new fix.
