### PR TITLE
Accessory CLI respects `--hosts`

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -5,11 +5,11 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
       if name == "all"
         KAMAL.accessory_names.each { |accessory_name| boot(accessory_name) }
       else
-        with_accessory(name) do |accessory|
+        with_accessory(name) do |accessory, hosts|
           directories(name)
           upload(name)
 
-          on(accessory.hosts) do
+          on(hosts) do
             execute *KAMAL.registry.login if login
             execute *KAMAL.auditor.record("Booted #{name} accessory"), verbosity: :debug
             execute *accessory.run
@@ -22,8 +22,8 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   desc "upload [NAME]", "Upload accessory files to host", hide: true
   def upload(name)
     mutating do
-      with_accessory(name) do |accessory|
-        on(accessory.hosts) do
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) do
           accessory.files.each do |(local, remote)|
             accessory.ensure_local_file_present(local)
 
@@ -39,8 +39,8 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   desc "directories [NAME]", "Create accessory directories on host", hide: true
   def directories(name)
     mutating do
-      with_accessory(name) do |accessory|
-        on(accessory.hosts) do
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) do
           accessory.directories.keys.each do |host_path|
             execute *accessory.make_directory(host_path)
           end
@@ -55,8 +55,8 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
       if name == "all"
         KAMAL.accessory_names.each { |accessory_name| reboot(accessory_name) }
       else
-        with_accessory(name) do |accessory|
-          on(accessory.hosts) do
+        with_accessory(name) do |accessory, hosts|
+          on(hosts) do
             execute *KAMAL.registry.login
           end
 
@@ -71,8 +71,8 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   desc "start [NAME]", "Start existing accessory container on host"
   def start(name)
     mutating do
-      with_accessory(name) do |accessory|
-        on(accessory.hosts) do
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) do
           execute *KAMAL.auditor.record("Started #{name} accessory"), verbosity: :debug
           execute *accessory.start
         end
@@ -83,8 +83,8 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   desc "stop [NAME]", "Stop existing accessory container on host"
   def stop(name)
     mutating do
-      with_accessory(name) do |accessory|
-        on(accessory.hosts) do
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) do
           execute *KAMAL.auditor.record("Stopped #{name} accessory"), verbosity: :debug
           execute *accessory.stop, raise_on_non_zero_exit: false
         end
@@ -107,8 +107,8 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     if name == "all"
       KAMAL.accessory_names.each { |accessory_name| details(accessory_name) }
     else
-      with_accessory(name) do |accessory|
-        on(accessory.hosts) { puts capture_with_info(*accessory.info) }
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) { puts capture_with_info(*accessory.info) }
       end
     end
   end
@@ -117,7 +117,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   option :interactive, aliases: "-i", type: :boolean, default: false, desc: "Execute command over ssh for an interactive shell (use for console/bash)"
   option :reuse, type: :boolean, default: false, desc: "Reuse currently running container instead of starting a new one"
   def exec(name, cmd)
-    with_accessory(name) do |accessory|
+    with_accessory(name) do |accessory, hosts|
       case
       when options[:interactive] && options[:reuse]
         say "Launching interactive command with via SSH from existing container...", :magenta
@@ -129,14 +129,14 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
       when options[:reuse]
         say "Launching command from existing container...", :magenta
-        on(accessory.hosts) do
+        on(hosts) do
           execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{name} accessory"), verbosity: :debug
           capture_with_info(*accessory.execute_in_existing_container(cmd))
         end
 
       else
         say "Launching command from new container...", :magenta
-        on(accessory.hosts) do
+        on(hosts) do
           execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{name} accessory"), verbosity: :debug
           capture_with_info(*accessory.execute_in_new_container(cmd))
         end
@@ -150,12 +150,12 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   option :grep, aliases: "-g", desc: "Show lines with grep match only (use this to fetch specific requests by id)"
   option :follow, aliases: "-f", desc: "Follow logs on primary server (or specific host set by --hosts)"
   def logs(name)
-    with_accessory(name) do |accessory|
+    with_accessory(name) do |accessory, hosts|
       grep = options[:grep]
 
       if options[:follow]
         run_locally do
-          info "Following logs on #{accessory.hosts}..."
+          info "Following logs on #{hosts}..."
           info accessory.follow_logs(grep: grep)
           exec accessory.follow_logs(grep: grep)
         end
@@ -163,7 +163,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
         since = options[:since]
         lines = options[:lines].presence || ((since || grep) ? nil : 100) # Default to 100 lines if since or grep isn't set
 
-        on(accessory.hosts) do
+        on(hosts) do
           puts capture_with_info(*accessory.logs(since: since, lines: lines, grep: grep))
         end
       end
@@ -192,8 +192,8 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   desc "remove_container [NAME]", "Remove accessory container from host", hide: true
   def remove_container(name)
     mutating do
-      with_accessory(name) do |accessory|
-        on(accessory.hosts) do
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) do
           execute *KAMAL.auditor.record("Remove #{name} accessory container"), verbosity: :debug
           execute *accessory.remove_container
         end
@@ -204,8 +204,8 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   desc "remove_image [NAME]", "Remove accessory image from host", hide: true
   def remove_image(name)
     mutating do
-      with_accessory(name) do |accessory|
-        on(accessory.hosts) do
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) do
           execute *KAMAL.auditor.record("Removed #{name} accessory image"), verbosity: :debug
           execute *accessory.remove_image
         end
@@ -216,8 +216,8 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   desc "remove_service_directory [NAME]", "Remove accessory directory used for uploaded files and data directories from host", hide: true
   def remove_service_directory(name)
     mutating do
-      with_accessory(name) do |accessory|
-        on(accessory.hosts) do
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) do
           execute *accessory.remove_service_directory
         end
       end
@@ -227,7 +227,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   private
     def with_accessory(name)
       if accessory = KAMAL.accessory(name)
-        yield accessory
+        yield accessory, accessory_hosts(accessory)
       else
         error_on_missing_accessory(name)
       end
@@ -239,5 +239,13 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
       error \
         "No accessory by the name of '#{name}'" +
         (options ? " (options: #{options.to_sentence})" : "")
+    end
+
+    def accessory_hosts(accessory)
+      if KAMAL.specific_hosts&.any?
+        KAMAL.specific_hosts & accessory.hosts
+      else
+        accessory.hosts
+      end
     end
 end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -148,6 +148,30 @@ class CliAccessoryTest < CliTestCase
     assert_match "rm -rf app-mysql", run_command("remove_service_directory", "mysql")
   end
 
+  test "hosts param respected" do
+    Kamal::Cli::Accessory.any_instance.expects(:directories).with("redis")
+    Kamal::Cli::Accessory.any_instance.expects(:upload).with("redis")
+
+    run_command("boot", "redis", "--hosts", "1.1.1.1").tap do |output|
+      assert_match /docker login.*on 1.1.1.1/, output
+      refute_match /docker login.*on 1.1.1.2/, output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --log-opt max-size=\"10m\" --publish 6379:6379 --env-file .kamal/env/accessories/app-redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      refute_match "docker run --name app-redis --detach --restart unless-stopped --log-opt max-size=\"10m\" --publish 6379:6379 --env-file .kamal/env/accessories/app-redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
+    end
+  end
+
+  test "hosts param intersects hosts" do
+    Kamal::Cli::Accessory.any_instance.expects(:directories).with("redis")
+    Kamal::Cli::Accessory.any_instance.expects(:upload).with("redis")
+
+    run_command("boot", "redis", "--hosts", "1.1.1.1,1.1.1.3").tap do |output|
+      assert_match /docker login.*on 1.1.1.1/, output
+      refute_match /docker login.*on 1.1.1.3/, output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --log-opt max-size=\"10m\" --publish 6379:6379 --env-file .kamal/env/accessories/app-redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      refute_match "docker run --name app-redis --detach --restart unless-stopped --log-opt max-size=\"10m\" --publish 6379:6379 --env-file .kamal/env/accessories/app-redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.3", output
+    end
+  end
+
   private
     def run_command(*command)
       stdouted { Kamal::Cli::Accessory.start([*command, "-c", "test/fixtures/deploy_with_accessories.yml"]) }

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -160,7 +160,7 @@ class CliAccessoryTest < CliTestCase
     end
   end
 
-  test "hosts param intersects hosts" do
+  test "hosts param intersected with configuration" do
     Kamal::Cli::Accessory.any_instance.expects(:directories).with("redis")
     Kamal::Cli::Accessory.any_instance.expects(:upload).with("redis")
 


### PR DESCRIPTION
# Problem
Accessory CLI does not respect the `--hosts` parameter - all hosts are pulled from the accessory configuration.

I.e.
- `kamal accessory logs redis --hosts 1.1.1.2`
- `kamal accessory boot all --hosts 1.1.1.3` - this is my use case when scaling up our app

# Solution
This PR intersects the accessory hosts configuration with the specified `--hosts`.