### PR TITLE
Allow env vars to be passed in from the host.

### DIFF
--- a/lib/kamal/env_file.rb
+++ b/lib/kamal/env_file.rb
@@ -3,7 +3,7 @@ class Kamal::EnvFile
   def initialize(env)
     @env = env
   end
-  
+
   def to_s
     env_file = StringIO.new.tap do |contents|
       if (secrets = @env["secret"]).present?
@@ -19,6 +19,10 @@ class Kamal::EnvFile
           contents << docker_env_file_line(key, value)
         end
       end
+
+      @env["host"]&.each do |key|
+        contents << docker_host_env_file_line(key)
+      end
     end.string
 
     # Ensure the file has some contents to avoid the SSHKIT empty file warning
@@ -26,10 +30,14 @@ class Kamal::EnvFile
   end
 
   alias to_str to_s
-  
+
   private
     def docker_env_file_line(key, value)
       "#{key.to_s}=#{escape_docker_env_file_value(value)}\n"
+    end
+
+    def docker_host_env_file_line(key)
+      "#{key.to_s}\n"
     end
 
     # Escape a value to make it safe to dump in a docker file.

--- a/test/env_file_test.rb
+++ b/test/env_file_test.rb
@@ -90,6 +90,14 @@ class EnvFileTest < ActiveSupport::TestCase
     ENV.delete "PASSWORD"
   end
 
+  test "env file variable from host" do
+    env = {
+      "host" => [ "DATABASE_URL" ]
+    }
+
+    assert_equal "DATABASE_URL\n", Kamal::EnvFile.new(env).to_s
+  end
+
   test "stringIO conversion" do
     env = {
       "foo" => "bar",


### PR DESCRIPTION
We are creating our VMs with our DATABASE_URL, etc already configured as an environment variable on the VM.

This change allows us to set:
```yaml
env:
  host:
    - DATABASE_URL
```
And when the container loads the environment file it will load the DATABASE_URL from the host machine.