### PR TITLE
Remove accessory env file from host, when accessory is removed

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -173,7 +173,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     end
   end
 
-  desc "remove [NAME]", "Remove accessory container, image and data directory from host (use NAME=all to remove all accessories)"
+  desc "remove [NAME]", "Remove accessory container, image, data directory and env file from host (use NAME=all to remove all accessories)"
   option :confirmed, aliases: "-y", type: :boolean, default: false, desc: "Proceed without confirmation question"
   def remove(name)
     confirming "This will remove all containers, images and data directories for #{name}. Are you sure?" do
@@ -222,6 +222,17 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     end
   end
 
+  desc "remove_env_file [NAME]", "Remove accessory env file from host", hide: true
+  def remove_env_file(name)
+    with_lock do
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) do
+          execute *accessory.remove_env_file
+        end
+      end
+    end
+  end
+
   private
     def with_accessory(name)
       if KAMAL.config.accessory(name)
@@ -254,6 +265,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
         remove_container(name)
         remove_image(name)
         remove_service_directory(name)
+        remove_env_file(name)
       end
     end
 end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -156,6 +156,7 @@ class CliAccessoryTest < CliTestCase
     Kamal::Cli::Accessory.any_instance.expects(:remove_container).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:remove_image).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:remove_service_directory).with("mysql")
+    Kamal::Cli::Accessory.any_instance.expects(:remove_env_file).with("mysql")
 
     run_command("remove", "mysql", "-y")
   end
@@ -165,10 +166,12 @@ class CliAccessoryTest < CliTestCase
     Kamal::Cli::Accessory.any_instance.expects(:remove_container).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:remove_image).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:remove_service_directory).with("mysql")
+    Kamal::Cli::Accessory.any_instance.expects(:remove_env_file).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:stop).with("redis")
     Kamal::Cli::Accessory.any_instance.expects(:remove_container).with("redis")
     Kamal::Cli::Accessory.any_instance.expects(:remove_image).with("redis")
     Kamal::Cli::Accessory.any_instance.expects(:remove_service_directory).with("redis")
+    Kamal::Cli::Accessory.any_instance.expects(:remove_env_file).with("redis")
 
     run_command("remove", "all", "-y")
   end
@@ -183,6 +186,10 @@ class CliAccessoryTest < CliTestCase
 
   test "remove_service_directory" do
     assert_match "rm -rf app-mysql", run_command("remove_service_directory", "mysql")
+  end
+
+  test "remove_env_file" do
+    assert_match "rm -f .kamal/env/accessories/app-mysql.env", run_command("remove_env_file", "mysql")
   end
 
   test "hosts param respected" do


### PR DESCRIPTION
I was surprised that `kamal accessory remove [name]` does not delete the .env file in the `~/.kamal/env/accessories` directory.      
This PR would add that functionality.