### PR TITLE
Allow custom user and port for builder host

### DIFF
--- a/lib/kamal/cli/build.rb
+++ b/lib/kamal/cli/build.rb
@@ -114,8 +114,11 @@ class Kamal::Cli::Build < Kamal::Cli::Base
     def connect_to_remote_host(remote_host)
       remote_uri = URI.parse(remote_host)
       if remote_uri.scheme == "ssh"
-        options = { user: remote_uri.user, port: remote_uri.port }.compact
-        on(remote_uri.host, options) do
+        host = SSHKit::Host.new(
+          hostname: remote_uri.host,
+          ssh_options: { user: remote_uri.user, port: remote_uri.port }.compact
+        )
+        on(host, options) do
           execute "true"
         end
       end

--- a/lib/kamal/sshkit_with_ext.rb
+++ b/lib/kamal/sshkit_with_ext.rb
@@ -80,7 +80,8 @@ class SSHKit::Backend::Netssh
   module LimitConcurrentStartsInstance
     private
       def with_ssh(&block)
-        host.ssh_options = self.class.config.ssh_options.merge(host.ssh_options || {})
+        host.ssh_options = (host.ssh_options || {}).merge({ port: host.port, user: host.user }.compact)
+        host.ssh_options = self.class.config.ssh_options.merge(host.ssh_options)
         self.class.pool.with(
           method(:start_with_concurrency_limit),
           String(host.hostname),

--- a/lib/kamal/sshkit_with_ext.rb
+++ b/lib/kamal/sshkit_with_ext.rb
@@ -80,8 +80,7 @@ class SSHKit::Backend::Netssh
   module LimitConcurrentStartsInstance
     private
       def with_ssh(&block)
-        host.ssh_options = (host.ssh_options || {}).merge({ port: host.port, user: host.user }.compact)
-        host.ssh_options = self.class.config.ssh_options.merge(host.ssh_options)
+        host.ssh_options = self.class.config.ssh_options.merge(host.ssh_options || {})
         self.class.pool.with(
           method(:start_with_concurrency_limit),
           String(host.hostname),

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -79,6 +79,14 @@ class CliBuildTest < CliTestCase
     end
   end
 
+  test "create remote with custom ports" do
+    run_command("create", fixture: :with_remote_builder_and_custom_ports).tap do |output|
+      assert_match "Running /usr/bin/env true on 1.1.1.5", output
+      assert_match "docker context create kamal-app-native-remote-amd64 --description 'kamal-app-native-remote amd64 native host' --docker 'host=ssh://app@1.1.1.5:2122'", output
+      assert_match "docker buildx create --name kamal-app-native-remote kamal-app-native-remote-amd64 --platform linux/amd64", output
+    end
+  end
+
   test "create with error" do
     stub_setup
     SSHKit::Backend::Abstract.any_instance.stubs(:execute)

--- a/test/fixtures/deploy_with_remote_builder_and_custom_ports.yml
+++ b/test/fixtures/deploy_with_remote_builder_and_custom_ports.yml
@@ -1,0 +1,45 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+    - "1.1.1.2"
+  workers:
+    - "1.1.1.3"
+    - "1.1.1.4"
+registry:
+  username: user
+  password: pw
+
+accessories:
+  mysql:
+    image: mysql:5.7
+    host: 1.1.1.3
+    port: 3306
+    env:
+      clear:
+        MYSQL_ROOT_HOST: '%'
+      secret:
+        - MYSQL_ROOT_PASSWORD
+    files:
+      - test/fixtures/files/my.cnf:/etc/mysql/my.cnf
+    directories:
+      - data:/var/lib/mysql
+  redis:
+    image: redis:latest
+    roles:
+      - web
+    port: 6379
+    directories:
+      - data:/data
+
+readiness_delay: 0
+
+ssh:
+  user: root
+  port: 22
+
+builder:
+  remote:
+    arch: amd64
+    host: ssh://app@1.1.1.5:2122


### PR DESCRIPTION
When `ssh` options are set, they overwrite custom username and password passed via ssh builder uri. Passing part of uri for sshkit is fine, as it then properly extracts username and password and forwards it as `host.ssh_options` (in which case it's no longer empty)