### PR TITLE
Mention Sprockets config in deploy template

### DIFF
--- a/lib/kamal/cli/templates/deploy.yml
+++ b/lib/kamal/cli/templates/deploy.yml
@@ -77,6 +77,10 @@ registry:
 # Bridge fingerprinted assets, like JS and CSS, between versions to avoid
 # hitting 404 on in-flight requests. Combines all files from new and old
 # version inside the asset_path.
+#
+# If your app is using Sprockets gem, ensure it has `config.assets.manifest`
+# set. See https://github.com/basecamp/kamal/issues/626 for details
+#
 # asset_path: /rails/public/assets
 
 # Configure rolling deploys by setting a wait time between batches of restarts.

--- a/lib/kamal/cli/templates/deploy.yml
+++ b/lib/kamal/cli/templates/deploy.yml
@@ -78,8 +78,8 @@ registry:
 # hitting 404 on in-flight requests. Combines all files from new and old
 # version inside the asset_path.
 #
-# If your app is using Sprockets gem, ensure it has `config.assets.manifest`
-# set. See https://github.com/basecamp/kamal/issues/626 for details
+# If your app is using the Sprockets gem, ensure it sets `config.assets.manifest`.
+# See https://github.com/basecamp/kamal/issues/626 for details
 #
 # asset_path: /rails/public/assets
 


### PR DESCRIPTION
This is the fix for https://github.com/basecamp/kamal/issues/626. I've added the hint to the deploy.yml template to save time for people who using Sprockets with Kamal.

I was also considering adding a message on gem post-install. But as for me, a comment is more noticeable.

