### PR TITLE
Add a missing base64 require

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     kamal (1.3.0)
       activesupport (>= 7.0)
+      base64 (~> 0.2)
       bcrypt_pbkdf (~> 1.0)
       concurrent-ruby (~> 1.2)
       dotenv (~> 2.8)

--- a/kamal.gemspec
+++ b/kamal.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "ed25519", "~> 1.2"
   spec.add_dependency "bcrypt_pbkdf", "~> 1.0"
   spec.add_dependency "concurrent-ruby", "~> 1.2"
+  spec.add_dependency "base64", "~> 0.2"
 
   spec.add_development_dependency "debug"
   spec.add_development_dependency "mocha"

--- a/lib/kamal/commands/lock.rb
+++ b/lib/kamal/commands/lock.rb
@@ -1,5 +1,6 @@
 require "active_support/duration"
 require "time"
+require "base64"
 
 class Kamal::Commands::Lock < Kamal::Commands::Base
   def acquire(message, version)


### PR DESCRIPTION
We observed this today during a routine `bin/kamal envify -d staging`:
```
Acquiring the deploy lock...
  ERROR (NameError): Exception while executing on host foo-staging-app-01: uninitialized constant Kamal::Commands::Lock::Base64
/Users/mkent/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/kamal-1.3.0/lib/kamal/commands/lock.rb:26:in `write_lock_details'
/Users/mkent/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/kamal-1.3.0/lib/kamal/commands/lock.rb:8:in `acquire'
/Users/mkent/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/kamal-1.3.0/lib/kamal/cli/base.rb:109:in `block (2 levels) in acquire_lock'
/Users/mkent/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sshkit-1.21.7/lib/sshkit/backends/abstract.rb:31:in `instance_exec'
/Users/mkent/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sshkit-1.21.7/lib/sshkit/backends/abstract.rb:31:in `run'
/Users/mkent/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/sshkit-1.21.7/lib/sshkit/runners/parallel.rb:12:in `block (2 levels) in execute'
```
I'm guessing one of the underlying gems we bundle installed stopped requiring base64, but I haven't tracked down which one.

While we're at it, this also prepares for the moving of base64 from default to a bundled gem in ruby 3.4 (see https://github.com/rails/rails/pull/48907).