### PR TITLE
Be a bit more patient during tests

### DIFF
--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -103,7 +103,7 @@ class IntegrationTest < ActiveSupport::TestCase
       assert_equal "200", code
     end
 
-    def wait_for_healthy(timeout: 20)
+    def wait_for_healthy(timeout: 30)
       timeout_at = Time.now + timeout
       while docker_compose("ps -a | tail -n +2 | grep -v '(healthy)' | wc -l", capture: true) != "0"
         if timeout_at < Time.now


### PR DESCRIPTION
Doing lots of local testing today and I'm seeing reasonably consistent local failures at 20 seconds:

```
[+] Running 7/7
 ✔ Container kamal-test-vm2-1            Removed                                                                                                                             1.2s
 ✔ Container kamal-test-load_balancer-1  Removed                                                                                                                             0.0s
 ✔ Container kamal-test-vm1-1            Removed                                                                                                                             1.2s
 ✔ Container kamal-test-deployer-1       Removed                                                                                                                             1.2s
 ✔ Container kamal-test-registry-1       Removed                                                                                                                             0.1s
 ✔ Container kamal-test-shared-1         Removed                                                                                                                             1.2s
 ✔ Network kamal-test_default            Removed                                                                                                                             0.0s
E

Error:
MainTest#test_config:
RuntimeError: Container not healthy after 20 seconds
    /Users/mkent/Work/basecamp/kamal/test/integration/integration_test.rb:111:in `wait_for_healthy'
    /Users/mkent/Work/basecamp/kamal/test/integration/integration_test.rb:8:in `block in <class:IntegrationTest>'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:445:in `instance_exec'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:445:in `block in make_lambda'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:199:in `block (2 levels) in halting'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:687:in `block (2 levels) in default_terminator'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:686:in `catch'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:686:in `block in default_terminator'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:200:in `block in halting'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:595:in `block in invoke_before'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:595:in `each'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:595:in `invoke_before'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/callbacks.rb:106:in `run_callbacks'
    /Users/mkent/.rbenv/versions/3.2.0/lib/ruby/gems/3.2.0/gems/activesupport-7.0.4.3/lib/active_support/testing/setup_and_teardown.rb:41:in `before_setup'


bin/test Users/mkent/Work/basecamp/kamal/test/integration/main_test.rb:45
<snip>
Finished in 206.054114s, 1.9655 runs/s, 5.6975 assertions/s.
405 runs, 1174 assertions, 0 failures, 1 errors, 0 skips
```
Suggest we wait a bit longer.