### PR TITLE
Allow local builds using a different arch than native

### DIFF
--- a/lib/kamal/commands/builder/multiarch.rb
+++ b/lib/kamal/commands/builder/multiarch.rb
@@ -10,7 +10,7 @@ class Kamal::Commands::Builder::Multiarch < Kamal::Commands::Builder::Base
   def push
     docker :buildx, :build,
       "--push",
-      "--platform", "linux/amd64,linux/arm64",
+      "--platform", platform_names,
       "--builder", builder_name,
       *build_options,
       build_context
@@ -25,5 +25,13 @@ class Kamal::Commands::Builder::Multiarch < Kamal::Commands::Builder::Base
   private
     def builder_name
       "kamal-#{config.service}-multiarch"
+    end
+
+    def platform_names
+      if local_arch
+        "linux/#{local_arch}"
+      else
+        "linux/amd64,linux/arm64"
+      end
     end
 end

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -37,6 +37,14 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "target multiarch local when arch is set" do
+    builder = new_builder_command(builder: { "local" => { "arch" => "amd64" } })
+    assert_equal "multiarch", builder.name
+    assert_equal \
+      "docker buildx build --push --platform linux/amd64 --builder kamal-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile .",
+      builder.push.join(" ")
+  end
+
   test "target native remote when only remote is set" do
     builder = new_builder_command(builder: { "remote" => { "arch" => "amd64" }, "cache" => { "type" => "gha" } })
     assert_equal "native/remote", builder.name


### PR DESCRIPTION
You may want to build single-arch images locally, but for a different architecture than the native one.