### PR TITLE
require missing net/scp dependency

### DIFF
--- a/lib/kamal/sshkit_with_ext.rb
+++ b/lib/kamal/sshkit_with_ext.rb
@@ -1,5 +1,6 @@
 require "sshkit"
 require "sshkit/dsl"
+require "net/scp"
 require "active_support/core_ext/hash/deep_merge"
 require "json"
 


### PR DESCRIPTION
## Preface
A couple of days ago, the github actions I have that automate the deployment of rails apps with kamal, started failing when running `kamal envify`, with the following error:
```
<internal:/Users/juan/.rbenv/versions/3.2.2/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require': cannot load such file -- net/scp (LoadError)
  ...
```

I tracked down the issue to one of the most recent releases of capistrano/sshkit, which removed `require 'net/scp'`
The capistrano release which no longer requires net/scp is [v1.22.0](https://github.com/capistrano/sshkit/commit/2ab75aab368656259b0eee70ca1eaecd80c270a8) introduced in https://github.com/capistrano/sshkit/pull/524

## Steps to reproduce
- install kamal on a fresh ruby environment
- run any command which makes use of scp functionality (e.g. `kamal envify`)

## The fix
- adding the require explicitly in `lib/kamal/sshkit_with_ext.rb` brings back the scp functionality.

I believe this is very similar to #635 which @mdkent did 2 weeks ago

This change fixes #644 
