### PR TITLE
Add in a server exec command for running ad-hoc commands directly on the server

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -106,7 +106,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
     end
   end
 
-  desc "exec [CMD]", "Execute a custom command on servers (use --help to show options)"
+  desc "exec [CMD]", "Execute a custom command on servers within the app container (use --help to show options)"
   option :interactive, aliases: "-i", type: :boolean, default: false, desc: "Execute command over ssh for an interactive shell (use for console/bash)"
   option :reuse, type: :boolean, default: false, desc: "Reuse currently running container instead of starting a new one"
   def exec(cmd)

--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -1,12 +1,12 @@
 class Kamal::Cli::Server < Kamal::Cli::Base
-  desc "exec", "Run a custom command on the server(use --help to show options)"
+  desc "exec", "Run a custom command on the server (use --help to show options)"
   option :interactive, type: :boolean, aliases: "-i", default: false, desc: "Run the command interactively(use for console/bash)"
   def exec(cmd)
     hosts = KAMAL.hosts | KAMAL.accessory_hosts
 
     case
     when options[:interactive]
-      host = hosts.first
+      host = KAMAL.primary_host
 
       say "Running '#{cmd}' on #{host} interactively...", :magenta
 

--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -1,6 +1,6 @@
 class Kamal::Cli::Server < Kamal::Cli::Base
   desc "exec", "Run a custom command on the server (use --help to show options)"
-  option :interactive, type: :boolean, aliases: "-i", default: false, desc: "Run the command interactively(use for console/bash)"
+  option :interactive, type: :boolean, aliases: "-i", default: false, desc: "Run the command interactively (use for console/bash)"
   def exec(cmd)
     hosts = KAMAL.hosts | KAMAL.accessory_hosts
 

--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -1,4 +1,26 @@
 class Kamal::Cli::Server < Kamal::Cli::Base
+  desc "exec", "Run a custom command on the server(use --help to show options)"
+  option :interactive, type: :boolean, aliases: "-i", default: false, desc: "Run the command interactively(use for console/bash)"
+  def exec(cmd)
+    hosts = KAMAL.hosts | KAMAL.accessory_hosts
+
+    case
+    when options[:interactive]
+      host = hosts.first
+
+      say "Running '#{cmd}' on #{host} interactively...", :magenta
+
+      run_locally { exec KAMAL.server.run_over_ssh(cmd, host: host) }
+    else
+      say "Running '#{cmd}' on #{hosts.join(', ')}...", :magenta
+
+      on(hosts) do |host|
+        execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{host}"), verbosity: :debug
+        puts_by_host host, capture_with_info(cmd)
+      end
+    end
+  end
+
   desc "bootstrap", "Set up Docker to run Kamal apps"
   def bootstrap
     missing = []

--- a/test/cli/server_test.rb
+++ b/test/cli/server_test.rb
@@ -1,6 +1,20 @@
 require_relative "cli_test_case"
 
 class CliServerTest < CliTestCase
+  test "running a command with exec" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture)
+    .with("date", verbosity: 1)
+    .returns("Today")
+
+    hosts = "1.1.1.1".."1.1.1.4"
+    run_command("exec", "date").tap do |output|
+      hosts.map do |host|
+        assert_match "Running 'date' on #{hosts.to_a.join(', ')}...", output
+        assert_match "App Host: #{host}\nToday", output
+      end
+    end
+  end
+
   test "bootstrap already installed" do
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:docker, "-v", raise_on_non_zero_exit: false).returns(true).at_least_once
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:mkdir, "-p", ".kamal").returns("").at_least_once


### PR DESCRIPTION
This PR adds a `kamal server exec` command to the CLI which was mentioned in this discussion thread: https://github.com/basecamp/kamal/discussions/371

Running an interactive command against the server, same option that you pass for an accessory or app container:
```
$ kamal server exec --interactive "/bin/bash"
Running '/bin/bash' on 867.53.0.9 interactively...
root@server-1:~#
```

Running a command across all matching servers/roles/etc., output is displayed for each host:

```
$ kamal server exec "date"     
Running 'date' on 867.53.0.9...
  INFO [8c0d0725] Running /usr/bin/env date on 867.53.0.9
  INFO [8c0d0725] Finished in 0.192 seconds with exit status 0 (successful).
App Host: 867.53.0.9
Mon May 13 20:45:58 UTC 2024
```

You can pass all of the usual filters such as role or host to target those specific servers:
```
$ kamal server exec "date" -r web
Running 'date' on 867.53.0.9...
  INFO [62769fed] Running /usr/bin/env date on 867.53.0.9
  INFO [62769fed] Finished in 0.182 seconds with exit status 0 (successful).
App Host: 867.53.0.9
Mon May 13 20:55:41 UTC 2024
```