### PR TITLE
Add support for multiple published ports on an accessory.

### DIFF
--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -23,14 +23,16 @@ class Kamal::Configuration::Accessory
     hosts_from_host || hosts_from_hosts || hosts_from_roles
   end
 
-  def port
-    if port = specifics["port"]&.to_s
-      port.include?(":") ? port : "#{port}:#{port}"
-    end
+  def ports
+    Array(specifics["port"]).map do |port|
+      if port = port&.to_s
+        port.include?(":") ? port : "#{port}:#{port}"
+      end
+    end.compact
   end
 
   def publish_args
-    argumentize "--publish", port if port
+    argumentize "--publish", ports if ports.any?
   end
 
   def labels

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -51,7 +51,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
         "monitoring" => {
           "image" => "monitoring:latest",
           "roles" => [ "web" ],
-          "port" => "4321:4321",
+          "port" => ["4321:4321", "8080:80"],
           "labels" => {
             "cache" => true
           },
@@ -74,9 +74,10 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal "app-redis", @config.accessory(:redis).service_name
   end
 
-  test "port" do
-    assert_equal "3306:3306", @config.accessory(:mysql).port
-    assert_equal "6379:6379", @config.accessory(:redis).port
+  test "ports" do
+    assert_equal ["3306:3306"], @config.accessory(:mysql).ports
+    assert_equal ["6379:6379"], @config.accessory(:redis).ports
+    assert_equal ["4321:4321", "8080:80"], @config.accessory(:monitoring).ports
   end
 
   test "host" do


### PR DESCRIPTION
I am deploying graphite as an accessory and have the need to publish multiple ports from my accessory. I have to do so very hacky things in the config right now to get it to work.

This should allow multiple ports to be published without breaking the existing interface. This is how you'd publish multiple ports with this PR:

```yaml
accessories:
  graphite:
    host: 1.1.1.1
    image: graphiteapp/graphite-statsd:latest
    port:
      - 8125:8125/udp
      - 8080:80
      - 2003
    volumes:
      - /mnt/graphite/config:/opt/graphite/conf
      - /mnt/graphite/data:/opt/graphite/storage
      - /mnt/graphite/statsd_config:/opt/statsd/config
```

Happy to make any changes that are needed.