### PR TITLE
Informative message on lock error

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -123,6 +123,7 @@ module Kamal::Cli
         yield
       rescue SSHKit::Runner::ExecuteError => e
         if e.message =~ /cannot create directory/
+          say "Deploy lock already in place!", :red
           on(KAMAL.primary_host) { puts capture_with_debug(*KAMAL.lock.status) }
           raise LockError, "Deploy lock found. Run 'kamal lock help' for more information"
         else

--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -124,7 +124,7 @@ module Kamal::Cli
       rescue SSHKit::Runner::ExecuteError => e
         if e.message =~ /cannot create directory/
           on(KAMAL.primary_host) { puts capture_with_debug(*KAMAL.lock.status) }
-          raise LockError, "Deploy lock found. See https://kamal-deploy.org/docs/commands#checking-and-setting-the-lock"
+          raise LockError, "Deploy lock found. Run 'kamal lock help' for more information"
         else
           raise e
         end

--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -124,7 +124,7 @@ module Kamal::Cli
       rescue SSHKit::Runner::ExecuteError => e
         if e.message =~ /cannot create directory/
           on(KAMAL.primary_host) { puts capture_with_debug(*KAMAL.lock.status) }
-          raise LockError, "Deploy lock found"
+          raise LockError, "Deploy lock found. See https://kamal-deploy.org/docs/commands#checking-and-setting-the-lock"
         else
           raise e
         end

--- a/test/integration/lock_test.rb
+++ b/test/integration/lock_test.rb
@@ -10,7 +10,7 @@ class LockTest < IntegrationTest
     assert_match /Locked by: Deployer at .*\nVersion: #{latest_app_version}\nMessage: Integration Tests/m, status
 
     error = kamal :deploy, capture: true, raise_on_error: false
-    assert_match /Deploy lock found/m, error
+    assert_match /Deploy lock found. Run 'kamal lock help' for more information/m, error
 
     kamal :lock, :release
 


### PR DESCRIPTION
_Edit: I originally proposed linking to the documentation on the website, but @adrienpoly  and @acidtib suggested referring to `kamal lock help` instead. I've updated the description to match._ 

Recently I aborted a kamal deploy with `cmd-c` and upon trying to deploy again, I got the lock error message:

`Deploy lock found.` 

Unfortunately it took some googling to find out what this meant, and that I had to release the lock manually to proceed. 

To mitigate others having the same experience, this PR does two things: 

1) Adds "Run 'kamal lock help' for more information" to the error message, giving the user some pointers on what to do about this situation.
2) Adds a header in red over the lock status message that is already printed, to make it clearer that this information is relevant to the error message you just received. (I didn't understand that at first glance, so thinking others might not either).

Put together this is how it looks in use:

Current, without this PR:
<img width="429" alt="image" src="https://github.com/basecamp/kamal/assets/14905290/3154a05e-4452-45be-b6f4-326a0800c1b8">

Suggested, with this PR:
<img width="733" alt="image" src="https://github.com/basecamp/kamal/assets/14905290/9bbea16c-0385-4c24-9c94-0d374c447359">

Do you think this could work and be helpful? If not, there might be other ways to make the experience of locking oneself out more intuitive.