### PR TITLE
Set KAMAL_DESTINATION for envify command

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -175,6 +175,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
   option :skip_push, aliases: "-P", type: :boolean, default: false, desc: "Skip .env file push"
   def envify
     if destination = options[:destination]
+      ENV['KAMAL_DESTINATION'] = destination
       env_template_path = ".env.#{destination}.erb"
       env_path          = ".env.#{destination}"
     else

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -122,12 +122,12 @@ class CliMainTest < CliTestCase
       refute_match /Running the post-deploy hook.../, output
     end
   end
-  
+
   test "deploy without healthcheck if primary host doesn't have traefik" do
     invoke_options = { "config_file" => "test/fixtures/deploy_workers_only.yml", "version" => "999", "skip_hooks" => false }
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:healthcheck:perform", [], invoke_options).never
-    
+
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:traefik:boot", [], invoke_options)
@@ -407,8 +407,8 @@ class CliMainTest < CliTestCase
   end
 
   test "envify with destination" do
-    File.expects(:read).with(".env.world.erb").returns("HELLO=<%= 'world' %>")
-    File.expects(:write).with(".env.world", "HELLO=world", perm: 0600)
+    File.expects(:read).with(".env.world.erb").returns("DESTINATION=<%= ENV['KAMAL_DESTINATION'] %>\nHELLO=<%= 'world' %>")
+    File.expects(:write).with(".env.world", "DESTINATION=world\nHELLO=world", perm: 0600)
 
     run_command("envify", "-d", "world", config_file: "deploy_for_dest")
   end


### PR DESCRIPTION
Since destinations usually map to an environment such as a Rails environment it'd be helpful to load the current destination so that you can more easily use a destination template file. I made the assumption that we load the clear variables from Kamal but right now envify just loads the template and writes the output destination file, no clear/secret loading from Kamal. 

For example:

.env.template.erb

```
# Generated by kamal envify, to regenerate run `kamal envify -d <%= ENV['KAMAL_DESTINATION'] %>`

RAILS_ENV=<%= ENV['KAMAL_DESTINATION'] %>

API_KEY_EXAMPLE=<%= `op read "op://hey-#{ENV['KAMAL_DESTINATION']}/API_KEY_EXAMPLE/credential" -n`.strip %>
```

.env.staging.erb and .env.production.erb
```
<%= 
  ERB.new(File.read(".env.template.erb"), trim_mode: "-").result(binding)
%>
```

Which would generate something like this when running `kamal envify -d staging`:

```
# Generated by kamal envify, to regenerate run `kamal envify -d staging`

RAILS_ENV=staging

API_KEY_EXAMPLE=secret
```

#352 is related from the perspective of having a template for your destination files.