### PR TITLE
Bump default Traefik image to 2.10

### DIFF
--- a/lib/kamal/commands/traefik.rb
+++ b/lib/kamal/commands/traefik.rb
@@ -1,7 +1,7 @@
 class Kamal::Commands::Traefik < Kamal::Commands::Base
   delegate :argumentize, :optionize, to: Kamal::Utils
 
-  DEFAULT_IMAGE = "traefik:v2.9"
+  DEFAULT_IMAGE = "traefik:v2.10"
   CONTAINER_PORT = 80
   DEFAULT_ARGS = {
     'log.level' => 'DEBUG'

--- a/test/integration/docker/deployer/app/config/deploy.yml
+++ b/test/integration/docker/deployer/app/config/deploy.yml
@@ -24,7 +24,7 @@ traefik:
   args:
     accesslog: true
     accesslog.format: json
-  image: registry:4443/traefik:v2.9
+  image: registry:4443/traefik:v2.10
 accessories:
   busybox:
     image: registry:4443/busybox:1.36.0

--- a/test/integration/docker/deployer/setup.sh
+++ b/test/integration/docker/deployer/setup.sh
@@ -19,7 +19,7 @@ push_image_to_registry_4443() {
 
 install_kamal
 push_image_to_registry_4443 nginx 1-alpine-slim
-push_image_to_registry_4443 traefik v2.9
+push_image_to_registry_4443 traefik v2.10
 push_image_to_registry_4443 busybox 1.36.0
 
 # .ssh is on a shared volume that persists between runs. Clean it up as the

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -32,7 +32,7 @@ class MainTest < IntegrationTest
     assert_match /Traefik Host: vm2/, details
     assert_match /App Host: vm1/, details
     assert_match /App Host: vm2/, details
-    assert_match /traefik:v2.9/, details
+    assert_match /traefik:v2.10/, details
     assert_match /registry:4443\/app:#{first_version}/, details
 
     audit = kamal :audit, capture: true

--- a/test/integration/traefik_test.rb
+++ b/test/integration/traefik_test.rb
@@ -52,11 +52,11 @@ class TraefikTest < IntegrationTest
 
   private
     def assert_traefik_running
-      assert_match /traefik:v2.9   "\/entrypoint.sh/, traefik_details
+      assert_match /traefik:v2.10   "\/entrypoint.sh/, traefik_details
     end
 
     def assert_traefik_not_running
-      refute_match /traefik:v2.9   "\/entrypoint.sh/, traefik_details
+      refute_match /traefik:v2.10   "\/entrypoint.sh/, traefik_details
     end
 
     def traefik_details


### PR DESCRIPTION
Traefik 2.10 was released on April 24, 2023, since this 2.9 branch didn't get any updates and security fixes.

The 2.10 branch already got 7 patch releases, and even 2.11 was [released one day ago](https://github.com/traefik/traefik/releases/tag/v2.11.0).

This PR bumps default Traefik image to 2.10, after a couple of patch releases I plan to update default image to 2.11.