### PR TITLE
Add a simple validation to the service name to prevent setup issues

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -284,7 +284,7 @@ class Kamal::Configuration
     end
 
     def ensure_valid_service_name
-      raise ArgumentError, "Service name can only include alphanumeric characters and hyphens" unless raw_config[:service] =~ /^[a-z0-9-]+$/
+      raise ArgumentError, "Service name can only include alphanumeric characters, hyphens, and underscores" unless raw_config[:service] =~ /^[a-z0-9-_]+$/
 
       true
     end

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -218,7 +218,7 @@ class Kamal::Configuration
 
 
   def valid?
-    ensure_destination_if_required && ensure_required_keys_present && ensure_valid_kamal_version
+    ensure_destination_if_required && ensure_required_keys_present && ensure_valid_kamal_version && ensure_valid_service_name
   end
 
   def to_h
@@ -279,6 +279,12 @@ class Kamal::Configuration
           end
         end
       end
+
+      true
+    end
+
+    def ensure_valid_service_name
+      raise ArgumentError, "Service name can only include alphanumeric characters and hyphens" unless raw_config[:service] =~ /^[a-z0-9-]+$/
 
       true
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -43,7 +43,7 @@ class ConfigurationTest < ActiveSupport::TestCase
   end
 
   test "service name valid" do
-    assert Kamal::Configuration.new(@deploy.tap { _1[:service] = "hey-app1" }).valid?
+    assert Kamal::Configuration.new(@deploy.tap { _1[:service] = "hey-app1_primary" }).valid?
   end
 
   test "service name invalid" do

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -42,6 +42,16 @@ class ConfigurationTest < ActiveSupport::TestCase
     end
   end
 
+  test "service name valid" do
+    assert Kamal::Configuration.new(@deploy.tap { _1[:service] = "hey-app1" }).valid?
+  end
+
+  test "service name invalid" do
+    assert_raise(ArgumentError) do
+      Kamal::Configuration.new @deploy.tap { _1[:service] = "app.com" }
+    end
+  end
+
   test "roles" do
     assert_equal %w[ web ], @config.roles.collect(&:name)
     assert_equal %w[ web workers ], @config_with_roles.roles.collect(&:name)
@@ -299,7 +309,7 @@ class ConfigurationTest < ActiveSupport::TestCase
 
     assert_equal "alternate_web", config.primary_role
     assert_equal "1.1.1.4", config.primary_host
-    assert config.role(:alternate_web).primary? 
+    assert config.role(:alternate_web).primary?
     assert config.role(:alternate_web).running_traefik?
   end
 


### PR DESCRIPTION
Including dots in your service name is going to cause issues with traefik and initial Kamal setup. 

This PR adds a simple regex to validate that the service name is alphanumeric and can include hyphens `/^[a-z0-9-]+$/`.

Feels a bit like overkill but just trying to ease everyone's first impression of Kamal to make it easier to get up and running. 

Closes #671.