### PR TITLE
enable volumes, directories and files for any role

### DIFF
--- a/lib/kamal/commands/traefik.rb
+++ b/lib/kamal/commands/traefik.rb
@@ -1,5 +1,7 @@
 class Kamal::Commands::Traefik < Kamal::Commands::Base
   delegate :argumentize, :optionize, to: Kamal::Utils
+  delegate :volume_args, to: :volumes_config
+  attr_accessor :volumes_config
 
   DEFAULT_IMAGE = "traefik:v2.9"
   CONTAINER_PORT = 80
@@ -15,6 +17,11 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
     "traefik.http.services.unavailable.loadbalancer.server.port" => "0"
   }
 
+  def initialize(config)
+    super(config)
+    @volumes_config = Kamal::Configuration::VolumesFilesAndFolders.new "traefik", config.traefik
+  end
+
   def run
     docker :run, "--name traefik",
       "--detach",
@@ -24,6 +31,7 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
       *env_args,
       *config.logging_args,
       *label_args,
+      *volume_args,
       *docker_options_args,
       image,
       "--providers.docker",

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -1,10 +1,11 @@
 class Kamal::Configuration::Accessory
   delegate :argumentize, :optionize, to: Kamal::Utils
-
-  attr_accessor :name, :specifics
+  delegate :volume_args, :directories, :files, to: :volumes_config
+  attr_accessor :name, :specifics, :volumes_config
 
   def initialize(name, config:)
     @name, @config, @specifics = name.inquiry, config, config.raw_config["accessories"][name]
+    @volumes_config = Kamal::Configuration::VolumesFilesAndFolders.new service_name, @specifics
   end
 
   def service_name
@@ -61,28 +62,6 @@ class Kamal::Configuration::Accessory
     argumentize "--env-file", host_env_file_path
   end
 
-  def files
-    specifics["files"]&.to_h do |local_to_remote_mapping|
-      local_file, remote_file = local_to_remote_mapping.split(":")
-      [ expand_local_file(local_file), expand_remote_file(remote_file) ]
-    end || {}
-  end
-
-  def directories
-    specifics["directories"]&.to_h do |host_to_container_mapping|
-      host_path, container_path = host_to_container_mapping.split(":")
-      [ expand_host_path(host_path), container_path ]
-    end || {}
-  end
-
-  def volumes
-    specific_volumes + remote_files_as_volumes + remote_directories_as_volumes
-  end
-
-  def volume_args
-    argumentize "--volume", volumes
-  end
-
   def option_args
     if args = specifics["options"]
       optionize args
@@ -100,59 +79,6 @@ class Kamal::Configuration::Accessory
 
     def default_labels
       { "service" => service_name }
-    end
-
-    def expand_local_file(local_file)
-      if local_file.end_with?("erb")
-        with_clear_env_loaded { read_dynamic_file(local_file) }
-      else
-        Pathname.new(File.expand_path(local_file)).to_s
-      end
-    end
-
-    def with_clear_env_loaded
-      (env["clear"] || env).each { |k, v| ENV[k] = v }
-      yield
-    ensure
-      (env["clear"] || env).each { |k, v| ENV.delete(k) }
-    end
-
-    def read_dynamic_file(local_file)
-      StringIO.new(ERB.new(IO.read(local_file)).result)
-    end
-
-    def expand_remote_file(remote_file)
-      service_name + remote_file
-    end
-
-    def specific_volumes
-      specifics["volumes"] || []
-    end
-
-    def remote_files_as_volumes
-      specifics["files"]&.collect do |local_to_remote_mapping|
-        _, remote_file = local_to_remote_mapping.split(":")
-        "#{service_data_directory + remote_file}:#{remote_file}"
-      end || []
-    end
-
-    def remote_directories_as_volumes
-      specifics["directories"]&.collect do |host_to_container_mapping|
-        host_path, container_path = host_to_container_mapping.split(":")
-        [ expand_host_path(host_path), container_path ].join(":")
-      end || []
-    end
-
-    def expand_host_path(host_path)
-      absolute_path?(host_path) ? host_path : "#{service_data_directory}/#{host_path}"
-    end
-
-    def absolute_path?(path)
-      Pathname.new(path).absolute?
-    end
-
-    def service_data_directory
-      "$PWD/#{service_name}"
     end
 
     def hosts_from_host

--- a/lib/kamal/configuration/volumes_files_and_folders.rb
+++ b/lib/kamal/configuration/volumes_files_and_folders.rb
@@ -1,0 +1,91 @@
+class Kamal::Configuration::VolumesFilesAndFolders
+  delegate :argumentize, :optionize, to: Kamal::Utils
+  delegate :argumentize, to: Kamal::Utils
+
+  def initialize(service_name, config)
+    @config = config
+    @service_name = service_name
+  end
+
+  def volume_args
+    argumentize "--volume", volumes
+  end
+
+  def directories
+    config["directories"]&.to_h do |host_to_container_mapping|
+      host_path, container_path = host_to_container_mapping.split(":")
+      [ expand_host_path(host_path), container_path ]
+    end || {}
+  end
+
+  def files
+    config["files"]&.to_h do |local_to_remote_mapping|
+      local_file, remote_file = local_to_remote_mapping.split(":")
+      [ expand_local_file(local_file), expand_remote_file(remote_file) ]
+    end || {}
+  end
+
+  private
+    attr_reader :config, :service_name
+
+    def env
+      config["env"] || {}
+    end
+
+    def volumes
+      config_volumes + remote_files_as_volumes + remote_directories_as_volumes
+    end
+
+    def with_clear_env_loaded
+      (env["clear"] || env).each { |k, v| ENV[k] = v }
+      yield
+    ensure
+      (env["clear"] || env).each { |k, v| ENV.delete(k) }
+    end
+
+    def read_dynamic_file(local_file)
+      StringIO.new(ERB.new(IO.read(local_file)).result)
+    end
+
+    def expand_local_file(local_file)
+      if local_file.end_with?("erb")
+        with_clear_env_loaded { read_dynamic_file(local_file) }
+      else
+        Pathname.new(File.expand_path(local_file)).to_s
+      end
+    end
+
+    def expand_remote_file(remote_file)
+      service_name + remote_file
+    end
+
+    def config_volumes
+      config["volumes"] || []
+    end
+
+    def remote_files_as_volumes
+      config["files"]&.collect do |local_to_remote_mapping|
+        _, remote_file = local_to_remote_mapping.split(":")
+        "#{service_data_directory + remote_file}:#{remote_file}"
+      end || []
+    end
+
+    def remote_directories_as_volumes
+      config["directories"]&.collect do |host_to_container_mapping|
+        host_path, container_path = host_to_container_mapping.split(":")
+        [ expand_host_path(host_path), container_path ].join(":")
+      end || []
+    end
+
+    def absolute_path?(path)
+      Pathname.new(path).absolute?
+    end
+
+    def expand_host_path(host_path)
+      absolute_path?(host_path) ? host_path : "#{service_data_directory}/#{host_path}"
+    end
+
+    def service_data_directory
+      "$PWD/#{service_name}"
+    end
+end

--- a/test/configuration/volumes_files_and_folders_test.rb
+++ b/test/configuration/volumes_files_and_folders_test.rb
@@ -1,0 +1,53 @@
+require "test_helper"
+
+class ConfigurationVolumesFilesAndFoldersTest < ActiveSupport::TestCase
+  setup do
+    @deploy = {
+      service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" },
+      servers: {
+        "web" => [ "1.1.1.1", "1.1.1.2" ],
+      },
+      traefik: {
+        "files" => [
+          "config/traefik.yaml:/etc/traefik/traefik.yaml",
+        ],
+        "directories" => [
+          "config/traefik.d:/etc/traefik/traefik.d"
+        ],
+        "volumes" => [
+          "/mnt/certs:/etc/traefik/certs"
+        ],
+      },
+      accessories: {
+        "mysql" => {
+          "files" => [
+            "config/mysql/my.cnf:/etc/mysql/my.cnf",
+            "db/structure.sql:/docker-entrypoint-initdb.d/structure.sql"
+          ],
+          "directories" => [
+            "data:/var/lib/mysql"
+          ]
+        },
+        "redis" => {
+          "volumes" => [
+            "/var/lib/redis:/data"
+          ],
+
+        }
+      }
+    }
+
+    @config = Kamal::Configuration.new(@deploy)
+    @traefik = Kamal::Commands::Traefik.new(@config)
+  end
+
+
+  test "volume args for accessories" do
+    assert_equal ["--volume", "$PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf", "--volume", "$PWD/app-mysql/docker-entrypoint-initdb.d/structure.sql:/docker-entrypoint-initdb.d/structure.sql", "--volume", "$PWD/app-mysql/data:/var/lib/mysql"], @config.accessory(:mysql).volume_args
+    assert_equal ["--volume", "/var/lib/redis:/data"], @config.accessory(:redis).volume_args
+  end
+
+  test "volume args for traefik" do
+    assert_equal ["--volume", "/mnt/certs:/etc/traefik/certs", "--volume", "$PWD/traefik/etc/traefik/traefik.yaml:/etc/traefik/traefik.yaml", "--volume", "$PWD/traefik/config/traefik.d:/etc/traefik/traefik.d"], @traefik.volume_args
+  end
+end


### PR DESCRIPTION
For the app, the traefic role, and any accessory you can configure files, volumes, and directories from your project to be accessible inside the docker container.

The files and directories are uploaded to the host and mounted via docker volumes to the docker container.
This worked previously only for accessories. So I moved code related to this from accessory configuration to a new class to make it useable for the traefik proxy and the main app as well.

With this change we can add in the config for traefik volumes, files and folders

```
traefik:
  files:
    - config/traefik.yaml:/etc/traefik/traefik.yaml
  directories:
    - config/traefik.d:/etc/traefik/traefik.d
  volumes:
    - /mnt/volume-data/letsencrypt/acme.json:/letsencrypt/acme.json
```

For the main app config it looks like this:

```
volumes:
  - "/mnt/volume-data/wordpress-data:/var/www/html"
files:
  - apache.conf:/etc/apache2/sites-enabled/wp3.conf
directories:
  - config/apache/:/etc/conf-avail
```

And it works as it currently does for accessories.
```
accessories:
  redis:
    files:
      - config/redis.conf:/etc/redis/redis.conf
    directories:
      - config/conf.d:/etc/conf/conf.d
    volumes:
      - /mnt/volume-data/conf/conf.json:/conf/conf.json
```
