### PR TITLE
Replace \`service\` by 'service' so it doesn't get executed by bash

### DIFF
--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -24,7 +24,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   def validate_image
     pipe \
       docker(:inspect, "-f", "'{{ .Config.Labels.service }}'", config.absolute_image),
-      [:grep, "-x", config.service, "||", "(echo \"Image #{config.absolute_image} is missing the `service` label\" && exit 1)"]
+      [:grep, "-x", config.service, "||", "(echo \"Image #{config.absolute_image} is missing the 'service' label\" && exit 1)"]
   end
 
 


### PR DESCRIPTION
Fixes #694