### PR TITLE
Relax `dotenv` version

### DIFF
--- a/kamal.gemspec
+++ b/kamal.gemspec
@@ -15,7 +15,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "sshkit", "~> 1.21"
   spec.add_dependency "net-ssh", "~> 7.0"
   spec.add_dependency "thor", "~> 1.2"
-  spec.add_dependency "dotenv", "~> 2.8"
+  spec.add_dependency "dotenv", ">= 2.8", "< 4"
   spec.add_dependency "zeitwerk", "~> 2.5"
   spec.add_dependency "ed25519", "~> 1.2"
   spec.add_dependency "bcrypt_pbkdf", "~> 1.0"


### PR DESCRIPTION
Looking at the [breaking changes listed](https://github.com/bkeepers/dotenv/blob/c9ecfa4e5598593dbadcf6c610cf5d8a9ed0bec1/Changelog.md) for `dotenv`, it seems to only affect Rails applications that are directly using `dotenv` and are upgrading between versions of `dotenv`.

Presumably, if they were using `dotenv` directly, they would have the version of `dotenv` in their `Gemfile` that works for them, and we're safe to allow a newer version.