### PR TITLE
Install docker with curl or wget

### DIFF
--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -17,7 +17,7 @@ class Kamal::Cli::Server < Kamal::Cli::Base
     end
 
     if missing.any?
-      raise "Docker is not installed on #{missing.join(", ")} and can't be automatically installed without having root access and the `curl` command available. Install Docker manually: https://docs.docker.com/engine/install/"
+      raise "Docker is not installed on #{missing.join(", ")} and can't be automatically installed without having root access and either `wget` or `curl`. Install Docker manually: https://docs.docker.com/engine/install/"
     end
   end
 end

--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -70,6 +70,10 @@ module Kamal::Commands
         [ :xargs, command ].flatten
       end
 
+      def shell(command)
+        [ :sh, "-c", "'#{command.flatten.join(" ").gsub("'", "'\\''")}'" ]
+      end
+
       def docker(*args)
         args.compact.unshift :docker
       end

--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -62,6 +62,10 @@ module Kamal::Commands
         combine *commands, by: ">"
       end
 
+      def any(*commands)
+        combine *commands, by: "||"
+      end
+
       def xargs(command)
         [ :xargs, command ].flatten
       end

--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -24,7 +24,10 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   def validate_image
     pipe \
       docker(:inspect, "-f", "'{{ .Config.Labels.service }}'", config.absolute_image),
-      [:grep, "-x", config.service, "||", "(echo \"Image #{config.absolute_image} is missing the 'service' label\" && exit 1)"]
+      any(
+        [:grep, "-x", config.service],
+        "(echo \"Image #{config.absolute_image} is missing the 'service' label\" && exit 1)"
+      )
   end
 
 

--- a/lib/kamal/commands/docker.rb
+++ b/lib/kamal/commands/docker.rb
@@ -1,7 +1,7 @@
 class Kamal::Commands::Docker < Kamal::Commands::Base
   # Install Docker using the https://github.com/docker/docker-install convenience script.
   def install
-    pipe [ :curl, "-fsSL", "https://get.docker.com" ], :sh
+    pipe get_docker, :sh
   end
 
   # Checks the Docker client version. Fails if Docker is not installed.
@@ -18,4 +18,13 @@ class Kamal::Commands::Docker < Kamal::Commands::Base
   def superuser?
     [ '[ "${EUID:-$(id -u)}" -eq 0 ] || command -v sudo >/dev/null || command -v su >/dev/null' ]
   end
+
+  private
+    def get_docker
+      shell \
+        any \
+          [ :curl, "-fsSL", "https://get.docker.com" ],
+          [ :wget, "-O -", "https://get.docker.com" ],
+          [ :echo, "\"exit 1\"" ]
+    end
 end

--- a/lib/kamal/commands/traefik.rb
+++ b/lib/kamal/commands/traefik.rb
@@ -39,7 +39,7 @@ class Kamal::Commands::Traefik < Kamal::Commands::Base
   end
 
   def start_or_run
-    combine start, run, by: "||"
+    any start, run
   end
 
   def info

--- a/test/cli/server_test.rb
+++ b/test/cli/server_test.rb
@@ -21,7 +21,7 @@ class CliServerTest < CliTestCase
   test "bootstrap install as root user" do
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:docker, "-v", raise_on_non_zero_exit: false).returns(false).at_least_once
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with('[ "${EUID:-$(id -u)}" -eq 0 ] || command -v sudo >/dev/null || command -v su >/dev/null', raise_on_non_zero_exit: false).returns(true).at_least_once
-    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:curl, "-fsSL", "https://get.docker.com", "|", :sh).at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:sh, "-c", "'curl -fsSL https://get.docker.com || wget -O - https://get.docker.com || echo \"exit 1\"'", "|", :sh).at_least_once
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:mkdir, "-p", ".kamal").returns("").at_least_once
 
     run_command("bootstrap").tap do |output|

--- a/test/commands/docker_test.rb
+++ b/test/commands/docker_test.rb
@@ -9,7 +9,7 @@ class CommandsDockerTest < ActiveSupport::TestCase
   end
 
   test "install" do
-    assert_equal "curl -fsSL https://get.docker.com | sh", @docker.install.join(" ")
+    assert_equal "sh -c 'curl -fsSL https://get.docker.com || wget -O - https://get.docker.com || echo \"exit 1\"' | sh", @docker.install.join(" ")
   end
 
   test "installed?" do


### PR DESCRIPTION
If curl is not available to download the docker install script, try with wget instead.

If neither is available or both fail, return a simple failing script so that we don't carry on regardless.

Fixes: https://github.com/basecamp/kamal/issues/395