### PR TITLE
Update condition to copy sample hooks

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -152,13 +152,13 @@ class Kamal::Cli::Main < Kamal::Cli::Base
       puts "Created .env file"
     end
 
-    unless (hooks_dir = Pathname.new(File.expand_path(".kamal/hooks"))).exist?
-      hooks_dir.mkpath
-      Pathname.new(File.expand_path("templates/sample_hooks", __dir__)).each_child do |sample_hook|
-        FileUtils.cp sample_hook, hooks_dir, preserve: true
-      end
-      puts "Created sample hooks in .kamal/hooks"
+    hooks_dir = Pathname.new(File.expand_path(".kamal/hooks"))
+    puts "Hooks directory already exists in .kamal/hooks" if hooks_dir.exist?
+    hooks_dir.mkpath
+    Pathname.new(File.expand_path("templates/sample_hooks", __dir__)).each_child do |sample_hook|
+      FileUtils.cp sample_hook, hooks_dir, preserve: true
     end
+    puts "Created sample hooks in .kamal/hooks"
 
     if options[:bundle]
       if (binstub = Pathname.new(File.expand_path("bin/kamal"))).exist?


### PR DESCRIPTION
If .kamal/hooks file exists but sample hooks are deleted. `kamal init` command is not creating sample hooks.

#### Results for /bin/test 
```bash
Finished in 274.016546s, 1.5291 runs/s, 4.6713 assertions/s.
419 runs, 1280 assertions, 0 failures, 0 errors, 0 skips
```
---

Step 1:

```bash
kamal init
Created configuration file in config/deploy.yml 
Created sample hooks in .kamal/hooks
```

Step 2:

```bash
git status
 On branch main
 Changes to be committed:
   (use "git restore --staged <file>..." to unstage)
 	new file:   .kamal/hooks/post-deploy.sample
 	new file:   .kamal/hooks/post-traefik-reboot.sample
 	new file:   .kamal/hooks/pre-build.sample
 	new file:   .kamal/hooks/pre-connect.sample
 	new file:   .kamal/hooks/pre-deploy.sample
 	new file:   .kamal/hooks/pre-traefik-reboot.sample
 	new file:   config/deploy.yml
```

Delete sample hook files now. Keep the folder.

Step 3:

```bash
kamal init
Created configuration file in config/deploy.yml
```

Delete folder as well.

Step 4:

```bash
kamal init
Config file already exists in config/deploy.yml (remove first to create a new one)
Created sample hooks in .kamal/hooks
```