### PR TITLE
Include error message on failure

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -158,8 +158,8 @@ module Kamal::Cli
           say "Running the #{hook} hook...", :magenta
           run_locally do
             execute *KAMAL.hook.run(hook, **details, **extra_details)
-          rescue SSHKit::Command::Failed
-            raise HookError.new("Hook `#{hook}` failed")
+          rescue SSHKit::Command::Failed => e
+            raise HookError.new("Hook `#{hook}` failed:\n#{e.message}")
           end
         end
       end

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -51,7 +51,8 @@ class CliBuildTest < CliTestCase
   test "push pre-build hook failure" do
     fail_hook("pre-build")
 
-    assert_raises(Kamal::Cli::HookError) { run_command("push") }
+    error = assert_raises(Kamal::Cli::HookError) { run_command("push") }
+    assert_equal "Hook `pre-build` failed:\nfailed", error.message
 
     assert @executions.none? { |args| args[0..2] == [ :docker, :buildx, :build ] }
   end


### PR DESCRIPTION
When a hook fails, dump the error message so we can see the output.