### PR TITLE
Tidy up role and host commander setup

### DIFF
--- a/lib/kamal/commander/specifics.rb
+++ b/lib/kamal/commander/specifics.rb
@@ -1,0 +1,49 @@
+class Kamal::Commander::Specifics
+  attr_reader :primary_host, :primary_role, :hosts, :roles
+  delegate :stable_sort!, to: Kamal::Utils
+
+  def initialize(config, specific_hosts, specific_roles)
+    @config, @specific_hosts, @specific_roles = config, specific_hosts, specific_roles
+
+    @roles, @hosts = specified_roles, specified_hosts
+
+    @primary_host = specific_hosts&.first || primary_specific_role&.primary_host || config.primary_host
+    @primary_role = primary_or_first_role(roles_on(primary_host))
+
+    stable_sort!(roles) { |role| role == primary_role ? 0 : 1 }
+    stable_sort!(hosts) { |host| roles_on(host).any? { |role| role == primary_role } ? 0 : 1 }
+  end
+
+  def roles_on(host)
+    roles.select { |role| role.hosts.include?(host.to_s) }
+  end
+
+  def traefik_hosts
+    specific_hosts || config.traefik_hosts
+  end
+
+  def accessory_hosts
+    specific_hosts || config.accessories.flat_map(&:hosts)
+  end
+
+  private
+    attr_reader :config, :specific_hosts, :specific_roles
+
+    def primary_specific_role
+      primary_or_first_role(specific_roles) if specific_roles.present?
+    end
+
+    def primary_or_first_role(roles)
+      roles.detect { |role| role == config.primary_role } || roles.first
+    end
+
+    def specified_roles
+      (specific_roles || config.roles) \
+        .select { |role| ((specific_hosts || config.all_hosts) & role.hosts).any? }
+    end
+
+    def specified_hosts
+      (specific_hosts || config.all_hosts) \
+        .select { |host| (specific_roles || config.roles).flat_map(&:hosts).include?(host) }
+    end
+end

--- a/lib/kamal/utils.rb
+++ b/lib/kamal/utils.rb
@@ -74,4 +74,8 @@ module Kamal::Utils
 
     matches
   end
+
+  def stable_sort!(elements, &block)
+    elements.sort_by!.with_index { |element, index| [ block.call(element), index ] }
+  end
 end

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -119,9 +119,10 @@ class CommanderTest < ActiveSupport::TestCase
     configure_with(:deploy_primary_web_role_override)
 
     @kamal.specific_roles = [ "web_*" ]
-    assert_equal [ "web_chicago", "web_tokyo" ], @kamal.roles.map(&:name)
+    assert_equal [ "web_tokyo", "web_chicago" ], @kamal.roles.map(&:name)
     assert_equal "web_tokyo", @kamal.primary_role.name
     assert_equal "1.1.1.3", @kamal.primary_host
+    assert_equal [ "1.1.1.3", "1.1.1.4", "1.1.1.1", "1.1.1.2" ], @kamal.hosts
   end
 
   private


### PR DESCRIPTION
Extract Kamal::Commander::Specifics to deal with host and role setup and ensure that primary hosts and roles always come first. This means that in a rolling deploy we deploy to the primary ones first.

This will be important when we remove the healthcheck step as we want to confirm the primary host can be deployed to before completing a deployment for other roles.

By setting the hosts and roles all together in one place we can sort the primary ones to the front without creating infinite loops.