### PR TITLE
Accept any runtime in the hook tests

### DIFF
--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -38,7 +38,7 @@ class CliTestCase < ActiveSupport::TestCase
         .with { |arg1, arg2| arg1 == :rm && arg2 == ".kamal/locks/app/details" }
     end
 
-    def assert_hook_ran(hook, output, version:, service_version:, hosts:, command:, subcommand: nil, runtime: nil)
+    def assert_hook_ran(hook, output, version:, service_version:, hosts:, command:, subcommand: nil, runtime: false)
       performer = `whoami`.strip
 
       assert_match "Running the #{hook} hook...\n", output
@@ -52,7 +52,7 @@ class CliTestCase < ActiveSupport::TestCase
         KAMAL_HOSTS=\"#{hosts}\"\s
         KAMAL_COMMAND=\"#{command}\"\s
         #{"KAMAL_SUBCOMMAND=\\\"#{subcommand}\\\"\\s" if subcommand}
-        #{"KAMAL_RUNTIME=\\\"#{runtime}\\\"\\s" if runtime}
+        #{"KAMAL_RUNTIME=\\\"\\d+\\\"\\s" if runtime}
         ;\s/usr/bin/env\s\.kamal/hooks/#{hook} }x
 
       assert_match expected, output

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -68,7 +68,7 @@ class CliMainTest < CliTestCase
       assert_match /Ensure app can pass healthcheck/, output
       assert_match /Detect stale containers/, output
       assert_match /Prune old containers and images/, output
-      assert_hook_ran "post-deploy", output, **hook_variables, runtime: 0
+      assert_hook_ran "post-deploy", output, **hook_variables, runtime: true
     end
   end
 
@@ -211,7 +211,7 @@ class CliMainTest < CliTestCase
       assert_hook_ran "pre-deploy", output, **hook_variables
       assert_match /Running the pre-deploy hook.../, output
       assert_match /Ensure app can pass healthcheck/, output
-      assert_hook_ran "post-deploy", output, **hook_variables, runtime: "0"
+      assert_hook_ran "post-deploy", output, **hook_variables, runtime: true
     end
   end
 
@@ -273,7 +273,7 @@ class CliMainTest < CliTestCase
       assert_match "docker tag dhh/app:123 dhh/app:latest", output
       assert_match "docker run --detach --restart unless-stopped --name app-web-123", output
       assert_match "docker container ls --all --filter name=^app-web-version-to-rollback$ --quiet | xargs docker stop", output, "Should stop the container that was previously running"
-      assert_hook_ran "post-deploy", output, **hook_variables, runtime: "0"
+      assert_hook_ran "post-deploy", output, **hook_variables, runtime: true
     end
   end
 


### PR DESCRIPTION
Occasionally in CI things run slowly and it takes more that 1 second for a cli test to run, so let's allow any value for the runtime in the hook checks.