### PR TITLE
Allow capital letters to match valid service name, such as in MyApp

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -301,7 +301,7 @@ class Kamal::Configuration
     end
 
     def ensure_valid_service_name
-      raise ArgumentError, "Service name can only include alphanumeric characters, hyphens, and underscores" unless raw_config[:service] =~ /^[a-z0-9_-]+$/
+      raise ArgumentError, "Service name can only include alphanumeric characters, hyphens, and underscores" unless raw_config[:service] =~ /^[a-z0-9_-]+$/i
 
       true
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -44,6 +44,7 @@ class ConfigurationTest < ActiveSupport::TestCase
 
   test "service name valid" do
     assert Kamal::Configuration.new(@deploy.tap { _1[:service] = "hey-app1_primary" }).valid?
+    assert Kamal::Configuration.new(@deploy.tap { _1[:service] = "MyApp" }).valid?
   end
 
   test "service name invalid" do


### PR DESCRIPTION
Currently if your service name has capital letters, such as in `MyApp`, it triggers the new `ensure_valid_service_name` validation error. The error message states `alphanumeric characters`, but does not allow capital letters.

This change allows capital letters in the service name, such as `MyApp`.

Fixes #769 