### PR TITLE
Take accessory hosts into account for --hosts

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -88,7 +88,7 @@ class Kamal::Configuration
 
 
   def all_hosts
-    roles.flat_map(&:hosts).uniq
+    (roles + accessories).flat_map(&:hosts).uniq
   end
 
   def primary_host

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -107,6 +107,10 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal "Specify one of `host`, `hosts` or `roles` for accessory `mysql`", exception.message
   end
 
+  test "all hosts" do
+    assert_equal [ "1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4", "1.1.1.5", "1.1.1.6", "1.1.1.7" ], @config.all_hosts
+  end
+
   test "label args" do
     assert_equal [ "--label", "service=\"app-mysql\"" ], @config.accessory(:mysql).label_args
     assert_equal [ "--label", "service=\"app-redis\"", "--label", "cache=\"true\"" ], @config.accessory(:redis).label_args


### PR DESCRIPTION
```yml
servers:
  web:
    host: 1.2.3.5

accessories:
  service:
    host: 1.2.3.4
```

```bash
$ kamal accessory details service -h 1.2.3.4
  ERROR (ArgumentError): No --hosts match for 1.2.3.4
```

This happens because an accessory host is not included in all hosts. The PR fixes the issue.
