### PR TITLE
Skip shell option value if it's nil

### DIFF
--- a/lib/kamal/utils.rb
+++ b/lib/kamal/utils.rb
@@ -18,10 +18,11 @@ module Kamal::Utils
 
   # Returns a list of shell-dashed option arguments. If the value is true, it's treated like a value-less option.
   def optionize(args, with: nil)
+    args = flatten_args(args).reject { |(_key, value)| value.nil? }
     options = if with
-      flatten_args(args).collect { |(key, value)| value == true ? "--#{key}" : "--#{key}#{with}#{escape_shell_value(value)}" }
+      args.collect { |(key, value)| value == true ? "--#{key}" : "--#{key}#{with}#{escape_shell_value(value)}" }
     else
-      flatten_args(args).collect { |(key, value)| [ "--#{key}", value == true ? nil : escape_shell_value(value) ] }
+      args.collect { |(key, value)| [ "--#{key}", value == true ? nil : escape_shell_value(value) ] }
     end
 
     options.flatten.compact

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -21,6 +21,11 @@ class UtilsTest < ActiveSupport::TestCase
       Kamal::Utils.optionize({ foo: "bar", baz: "qux", quux: true }, with: "=")
   end
 
+  test "optionize reject nil value" do
+    assert_equal [ "--foo", "\"bar\"", "--baz", "\"qux\"" ], \
+      Kamal::Utils.optionize({ foo: "bar", baz: "qux", quux: nil })
+  end
+
   test "no redaction from #to_s" do
     assert_equal "secret", Kamal::Utils.sensitive("secret").to_s
   end


### PR DESCRIPTION
I think `optionize` shouldn't output the key which value is nil, we should treate nil as removing the key. If we need a key-only argument, the value should be `true` instead of `nil`.

eg.

production environment, we use http provider for traerik

```yaml
# config/deploy.yaml
traefik:
  args:
    providers.http.endpoint: "http://app:3000/v1/traefik/routes"
```

development environment, we are changing http provider to file provier

```yaml
# config/deploy.dev.yaml
traefik:
  args:
    providers.http.endpoint: null
    providers.file.directory: "/etc/traefik/enabled-sites"
    providers.file.watch: true
```

