### PR TITLE
Add "tag_uncommitted" option to "builder"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kamal (1.4.0)
+    kamal (0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
       bcrypt_pbkdf (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kamal (0)
+    kamal (1.4.1)
       activesupport (>= 7.0)
       base64 (~> 0.2)
       bcrypt_pbkdf (~> 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    kamal (1.4.1)
+    kamal (1.4.2)
       activesupport (>= 7.0)
       base64 (~> 0.2)
       bcrypt_pbkdf (~> 1.0)

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -328,7 +328,7 @@ class Kamal::Configuration
     def git_version
       @git_version ||=
         if Kamal::Git.used?
-          if Kamal::Git.uncommitted_changes.present? && !builder.git_archive?
+          if Kamal::Git.uncommitted_changes.present? && !builder.git_archive? && builder.tag_uncommitted?
             uncommitted_suffix = "_uncommitted_#{SecureRandom.hex(8)}"
           end
           [ Kamal::Git.revision, uncommitted_suffix ].compact.join

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -35,6 +35,14 @@ class Kamal::Configuration::Builder
     @options["secrets"] || []
   end
 
+  def tag_uncommitted?
+    @options["tag_uncommitted"] != false
+  end
+
+  def 
+    @options["build_args"] || {}
+  end
+
   def dockerfile
     @options["dockerfile"] || "Dockerfile"
   end

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -39,10 +39,6 @@ class Kamal::Configuration::Builder
     @options["tag_uncommitted"] != false
   end
 
-  def 
-    @options["build_args"] || {}
-  end
-
   def dockerfile
     @options["dockerfile"] || "Dockerfile"
   end

--- a/lib/kamal/version.rb
+++ b/lib/kamal/version.rb
@@ -1,3 +1,3 @@
 module Kamal
-  VERSION = ""
+  VERSION = "1.4.1"
 end

--- a/lib/kamal/version.rb
+++ b/lib/kamal/version.rb
@@ -1,3 +1,3 @@
 module Kamal
-  VERSION = "1.4.1"
+  VERSION = "1.4.2"
 end

--- a/lib/kamal/version.rb
+++ b/lib/kamal/version.rb
@@ -1,3 +1,3 @@
 module Kamal
-  VERSION = "1.4.0"
+  VERSION = ""
 end


### PR DESCRIPTION
Discussed in issue https://github.com/basecamp/kamal/issues/775

This adds an option to builder so it doesn't mess up remote building when there are uncommitted local changes. Defaults to the same behaviour as now, so should not disrupt anyone's workflow, assuming there is anyone who actually wants that behaviour of making random build tags that can't be deployed later.

Apologies for the "Bump version" commits... this is my very first pull request..! I guess I shouldn't have run `bin/release`...

Usage is really simple:

```
builder:
  multiarch: false
  tag_uncommitted: false
  remote:
    arch: amd64
    host: ssh://[redacted]@[redacted]
```

With that line, now the random tag won't be added when there are uncommitted changes.

TODO: mention this in the docs?