### PR TITLE
Allow glob matches for roles and hosts

### DIFF
--- a/lib/kamal/utils.rb
+++ b/lib/kamal/utils.rb
@@ -66,13 +66,12 @@ module Kamal::Utils
     Array(filters).select do |filter|
       matches += Array(items).select do |item|
         # Only allow * for a wildcard
-        pattern = Regexp.escape(filter).gsub('\*', ".*")
         # items are roles or hosts
-        (item.respond_to?(:name) ? item.name : item).match(/^#{pattern}$/)
+        File.fnmatch(filter, item.to_s, File::FNM_EXTGLOB)
       end
     end
 
-    matches
+    matches.uniq
   end
 
   def stable_sort!(elements, &block)

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -24,6 +24,9 @@ class CommanderTest < ActiveSupport::TestCase
     @kamal.specific_hosts = [ "*" ]
     assert_equal [ "1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4" ], @kamal.hosts
 
+    @kamal.specific_hosts = [ "1.1.1.[12]" ]
+    assert_equal [ "1.1.1.1", "1.1.1.2" ], @kamal.hosts
+
     exception = assert_raises(ArgumentError) do
       @kamal.specific_hosts = [ "*miss" ]
     end
@@ -55,6 +58,9 @@ class CommanderTest < ActiveSupport::TestCase
     assert_equal [ "web", "workers" ], @kamal.roles.map(&:name)
 
     @kamal.specific_roles = [ "*" ]
+    assert_equal [ "web", "workers" ], @kamal.roles.map(&:name)
+
+    @kamal.specific_roles = [ "w{eb,orkers}" ]
     assert_equal [ "web", "workers" ], @kamal.roles.map(&:name)
 
     exception = assert_raises(ArgumentError) do


### PR DESCRIPTION
This lets you do things like:

```
kamal details -h '1.1.1.[1-9]'
kamal details -r 'w{eb,orkers}'
```