### PR TITLE
Apply --hosts and --roles filters to traefik hosts as well

### DIFF
--- a/lib/kamal/commander/specifics.rb
+++ b/lib/kamal/commander/specifics.rb
@@ -19,7 +19,7 @@ class Kamal::Commander::Specifics
   end
 
   def traefik_hosts
-    specific_hosts || config.traefik_hosts
+    config.traefik_hosts & specified_hosts
   end
 
   def accessory_hosts

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -131,6 +131,20 @@ class CommanderTest < ActiveSupport::TestCase
     assert_equal [ "1.1.1.3", "1.1.1.4", "1.1.1.1", "1.1.1.2" ], @kamal.hosts
   end
 
+  test "traefik hosts should observe filtered roles" do
+    configure_with(:deploy_with_aliases)
+
+    @kamal.specific_roles = [ "web_tokyo" ]
+    assert_equal [ "1.1.1.3", "1.1.1.4" ], @kamal.traefik_hosts
+  end
+
+  test "traefik hosts should observe filtered hosts" do
+    configure_with(:deploy_with_aliases)
+
+    @kamal.specific_hosts = [ "1.1.1.4" ]
+    assert_equal [ "1.1.1.4" ], @kamal.traefik_hosts
+  end
+
   private
     def configure_with(variant)
       @kamal = Kamal::Commander.new.tap do |kamal|

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -83,6 +83,15 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal [ "1.1.1.1", "1.1.1.2", "1.1.1.3" ], config.traefik_hosts
   end
 
+  test "filtered traefik hosts" do
+    assert_equal [ "1.1.1.1", "1.1.1.2" ], @config_with_roles.traefik_hosts
+
+    @deploy_with_roles[:servers]["workers"]["traefik"] = true
+    config = Kamal::Configuration.new(@deploy_with_roles)
+
+    assert_equal [ "1.1.1.1", "1.1.1.2", "1.1.1.3" ], config.traefik_hosts
+  end
+
   test "version no git repo" do
     ENV.delete("VERSION")
 


### PR DESCRIPTION
Given a config like
```
web_rw_ash:
  hosts:
    - foo-staging-default-jobs-101
    - foo-staging-default-jobs-102
web_sc_chi:
  hosts:
    - foo-staging-default-jobs-01
    - foo-staging-default-jobs-02
```
I observed this while trying to show deploy and show details on a single role:
```
$ bin/kamal details -d staging -r web_sc_chi -H
  INFO [f0be9496] Running docker ps --filter name=^traefik$ on foo-staging-default-jobs-101
  INFO [83cfb3ac] Running docker ps --filter name=^traefik$ on foo-staging-default-jobs-102
  INFO [18d0a41a] Running docker ps --filter name=^traefik$ on foo-staging-default-jobs-01
  INFO [029d4529] Running docker ps --filter name=^traefik$ on foo-staging-default-jobs-02
<snip>
```
this PR fixes it by filtering traefik hosts.