### PR TITLE
Add --target option to Builder to support multi-stage Docker builds

### DIFF
--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -3,7 +3,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   class BuilderError < StandardError; end
 
   delegate :argumentize, to: Kamal::Utils
-  delegate :args, :secrets, :dockerfile, :local_arch, :local_host, :remote_arch, :remote_host, :cache_from, :cache_to, :ssh, :git_archive?, to: :builder_config
+  delegate :args, :secrets, :dockerfile, :target, :local_arch, :local_host, :remote_arch, :remote_host, :cache_from, :cache_to, :ssh, :git_archive?, to: :builder_config
 
   def clean
     docker :image, :rm, "--force", config.absolute_image
@@ -24,7 +24,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   end
 
   def build_options
-    [ *build_tags, *build_cache, *build_labels, *build_args, *build_secrets, *build_dockerfile, *build_ssh ]
+    [ *build_tags, *build_cache, *build_labels, *build_args, *build_secrets, *build_dockerfile, *build_target, *build_ssh ]
   end
 
   def build_context
@@ -71,6 +71,10 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
       else
         raise BuilderError, "Missing #{dockerfile}"
       end
+    end
+
+    def build_target
+      argumentize "--target", target if target.present?
     end
 
     def build_ssh

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -38,6 +38,10 @@ class Kamal::Configuration::Builder
   def dockerfile
     @options["dockerfile"] || "Dockerfile"
   end
+  
+  def target
+    @options["target"]
+  end
 
   def context
     @options["context"] || (git_archive? ? "-" : ".")

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -38,7 +38,7 @@ class Kamal::Configuration::Builder
   def dockerfile
     @options["dockerfile"] || "Dockerfile"
   end
-  
+
   def target
     @options["target"]
   end

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -83,6 +83,13 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     end
   end
 
+  test "build target" do
+    builder = new_builder_command(builder: { "target" => "prod" })
+    assert_equal \
+      "-t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --target prod",
+      builder.target.build_options.join(" ")
+  end
+
   test "build context" do
     builder = new_builder_command(builder: { "context" => ".." })
     assert_equal \


### PR DESCRIPTION
The builder config now supports specifying a target, e.g.:

config/deploy.yml
```
builder:
  target: prod
```

for a Dockerfile that's structured like:
```
ARG RUBY_VERSION=3.2.2
FROM registry.docker.com/library/ruby:$RUBY_VERSION-slim as base

... etc ...

FROM base as build

... etc ...

FROM base as app

ENTRYPOINT ["/rails/bin/docker-entrypoint"]

# Start the server by default, this can be overwritten at runtime
EXPOSE 3000
CMD ["./bin/rails", "server"]

FROM app as prod

ENV RAILS_ENV="production" 

FROM app as staging

ENV RAILS_ENV="staging" 
```
