### PR TITLE
Warn on missing builder

### DIFF
--- a/lib/kamal/cli/build.rb
+++ b/lib/kamal/cli/build.rb
@@ -30,7 +30,7 @@ class Kamal::Cli::Build < Kamal::Cli::Base
           end
         rescue SSHKit::Command::Failed => e
           if e.message =~ /(no builder)|(no such file or directory)/
-            error "Missing compatible builder, so creating a new one first"
+            warn "Missing compatible builder, so creating a new one first"
 
             if cli.create
               KAMAL.with_verbosity(:debug) { execute *KAMAL.builder.push }

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -34,7 +34,7 @@ class CliBuildTest < CliTestCase
       .returns(true)
 
     run_command("push").tap do |output|
-      assert_match /Missing compatible builder, so creating a new one first/, output
+      assert_match /WARN Missing compatible builder, so creating a new one first/, output
     end
   end
 


### PR DESCRIPTION
We are going to try to create a builder if one is missing, so let's warn rather than report it as an error.