### PR TITLE
Build from within a git clone by default

### DIFF
--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -78,8 +78,8 @@ module Kamal::Commands
         args.compact.unshift :docker
       end
 
-      def git(*args)
-        args.compact.unshift :git
+      def git(*args, path: nil)
+        [ :git, *([ "-C", path ] if path), *args.compact ]
       end
 
       def tags(**details)

--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -2,6 +2,7 @@ require "active_support/core_ext/string/filters"
 
 class Kamal::Commands::Builder < Kamal::Commands::Base
   delegate :create, :remove, :push, :clean, :pull, :info, :validate_image, to: :target
+  delegate :clone_directory, :build_directory, to: :"config.builder"
 
   def name
     target.class.to_s.remove("Kamal::Commands::Builder::").underscore.inquiry
@@ -51,6 +52,23 @@ class Kamal::Commands::Builder < Kamal::Commands::Base
         ensure_local_docker_installed,
         ensure_local_buildx_installed
     end
+  end
+
+  def create_clone_directory
+    make_directory clone_directory
+  end
+
+  def clone
+    git :clone, Kamal::Git.root, path: clone_directory
+  end
+
+  def clone_reset_steps
+    [
+      git(:remote, "set-url", :origin, Kamal::Git.root, path: build_directory),
+      git(:fetch, :origin, path: build_directory),
+      git(:reset, "--hard", Kamal::Git.revision, path: build_directory),
+      git(:clean, "-fdx", path: build_directory)
+    ]
   end
 
   private

--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -3,7 +3,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   class BuilderError < StandardError; end
 
   delegate :argumentize, to: Kamal::Utils
-  delegate :args, :secrets, :dockerfile, :target, :local_arch, :local_host, :remote_arch, :remote_host, :cache_from, :cache_to, :ssh, :git_archive?, to: :builder_config
+  delegate :args, :secrets, :dockerfile, :target, :local_arch, :local_host, :remote_arch, :remote_host, :cache_from, :cache_to, :ssh, to: :builder_config
 
   def clean
     docker :image, :rm, "--force", config.absolute_image
@@ -11,16 +11,6 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
 
   def pull
     docker :pull, config.absolute_image
-  end
-
-  def push
-    if git_archive?
-      pipe \
-        git(:archive, "--format=tar", :HEAD),
-        build_and_push
-    else
-      build_and_push
-    end
   end
 
   def build_options

--- a/lib/kamal/commands/builder/multiarch.rb
+++ b/lib/kamal/commands/builder/multiarch.rb
@@ -13,6 +13,15 @@ class Kamal::Commands::Builder::Multiarch < Kamal::Commands::Builder::Base
       docker(:buildx, :ls)
   end
 
+  def push
+    docker :buildx, :build,
+      "--push",
+      "--platform", platform_names,
+      "--builder", builder_name,
+      *build_options,
+      build_context
+  end
+
   private
     def builder_name
       "kamal-#{config.service}-multiarch"
@@ -24,14 +33,5 @@ class Kamal::Commands::Builder::Multiarch < Kamal::Commands::Builder::Base
       else
         "linux/amd64,linux/arm64"
       end
-    end
-
-    def build_and_push
-      docker :buildx, :build,
-        "--push",
-        "--platform", platform_names,
-        "--builder", builder_name,
-        *build_options,
-        build_context
     end
 end

--- a/lib/kamal/commands/builder/native.rb
+++ b/lib/kamal/commands/builder/native.rb
@@ -11,11 +11,10 @@ class Kamal::Commands::Builder::Native < Kamal::Commands::Builder::Base
     # No-op on native
   end
 
-  private
-    def build_and_push
-      combine \
-        docker(:build, *build_options, build_context),
-        docker(:push, config.absolute_image),
-        docker(:push, config.latest_image)
-    end
+  def push
+    combine \
+      docker(:build, *build_options, build_context),
+      docker(:push, config.absolute_image),
+      docker(:push, config.latest_image)
+  end
 end

--- a/lib/kamal/commands/builder/native/cached.rb
+++ b/lib/kamal/commands/builder/native/cached.rb
@@ -7,11 +7,10 @@ class Kamal::Commands::Builder::Native::Cached < Kamal::Commands::Builder::Nativ
     docker :buildx, :rm, builder_name
   end
 
-  private
-    def build_and_push
-      docker :buildx, :build,
-        "--push",
-        *build_options,
-        build_context
-    end
+  def push
+    docker :buildx, :build,
+      "--push",
+      *build_options,
+      build_context
+  end
 end

--- a/lib/kamal/commands/builder/native/remote.rb
+++ b/lib/kamal/commands/builder/native/remote.rb
@@ -17,6 +17,15 @@ class Kamal::Commands::Builder::Native::Remote < Kamal::Commands::Builder::Nativ
       docker(:buildx, :ls)
   end
 
+  def push
+    docker :buildx, :build,
+    "--push",
+    "--platform", platform,
+    "--builder", builder_name,
+    *build_options,
+    build_context
+  end
+
 
   private
     def builder_name
@@ -46,14 +55,5 @@ class Kamal::Commands::Builder::Native::Remote < Kamal::Commands::Builder::Nativ
 
     def remove_buildx
       docker :buildx, :rm, builder_name
-    end
-
-    def build_and_push
-      docker :buildx, :build,
-      "--push",
-      "--platform", platform,
-      "--builder", builder_name,
-      *build_options,
-      build_context
     end
 end

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -336,7 +336,7 @@ class Kamal::Configuration
     def git_version
       @git_version ||=
         if Kamal::Git.used?
-          if Kamal::Git.uncommitted_changes.present? && !builder.git_archive?
+          if Kamal::Git.uncommitted_changes.present? && !builder.git_clone?
             uncommitted_suffix = "_uncommitted_#{SecureRandom.hex(8)}"
           end
           [ Kamal::Git.revision, uncommitted_suffix ].compact.join

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -96,7 +96,7 @@ class Kamal::Configuration::Builder
   end
 
   def clone_directory
-    @clone_directory ||= File.join Dir.tmpdir, "kamal-clones", [ @service, @destination, pwd_sha ].compact.join("-")
+    @clone_directory ||= File.join Dir.tmpdir, "kamal-clones", [ @service, pwd_sha ].compact.join("-")
   end
 
   def build_directory

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -3,6 +3,8 @@ class Kamal::Configuration::Builder
     @options = config.raw_config.builder || {}
     @image = config.image
     @server = config.registry["server"]
+    @service = config.service
+    @destination = config.destination
 
     valid?
   end
@@ -44,7 +46,7 @@ class Kamal::Configuration::Builder
   end
 
   def context
-    @options["context"] || (git_archive? ? "-" : ".")
+    @options["context"] || "."
   end
 
   def local_arch
@@ -89,8 +91,21 @@ class Kamal::Configuration::Builder
     @options["ssh"]
   end
 
-  def git_archive?
+  def git_clone?
     Kamal::Git.used? && @options["context"].nil?
+  end
+
+  def clone_directory
+    @clone_directory ||= File.join Dir.tmpdir, "kamal-clones", [ @service, @destination, pwd_sha ].compact.join("-")
+  end
+
+  def build_directory
+    @build_directory ||=
+      if git_clone?
+        File.join clone_directory, repo_basename, repo_relative_pwd
+      else
+        "."
+      end
   end
 
   private
@@ -122,5 +137,17 @@ class Kamal::Configuration::Builder
 
     def cache_to_config_for_registry
       [ "type=registry", @options["cache"]&.fetch("options", nil), "ref=#{cache_image_ref}" ].compact.join(",")
+    end
+
+    def repo_basename
+      File.basename(Kamal::Git.root)
+    end
+
+    def repo_relative_pwd
+      Dir.pwd.delete_prefix(Kamal::Git.root)
+    end
+
+    def pwd_sha
+      Digest::SHA256.hexdigest(Dir.pwd)[0..12]
     end
 end

--- a/lib/kamal/git.rb
+++ b/lib/kamal/git.rb
@@ -16,4 +16,8 @@ module Kamal::Git
   def uncommitted_changes
     `git status --porcelain`.strip
   end
+
+  def root
+    `git rev-parse --show-toplevel`.strip
+  end
 end

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -9,7 +9,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "cache" => { "type" => "gha" } })
     assert_equal "multiarch", builder.name
     assert_equal \
-      "git archive --format=tar HEAD | docker buildx build --push --platform linux/amd64,linux/arm64 --builder kamal-app-multiarch -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile -",
+      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder kamal-app-multiarch -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile .",
       builder.push.join(" ")
   end
 
@@ -17,7 +17,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "multiarch" => false })
     assert_equal "native", builder.name
     assert_equal \
-      "git archive --format=tar HEAD | docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile - && docker push dhh/app:123 && docker push dhh/app:latest",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . && docker push dhh/app:123 && docker push dhh/app:latest",
       builder.push.join(" ")
   end
 
@@ -25,7 +25,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "multiarch" => false, "cache" => { "type" => "gha" } })
     assert_equal "native/cached", builder.name
     assert_equal \
-      "git archive --format=tar HEAD | docker buildx build --push -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile -",
+      "docker buildx build --push -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile .",
       builder.push.join(" ")
   end
 
@@ -33,7 +33,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "local" => {}, "remote" => {}, "cache" => { "type" => "gha" } })
     assert_equal "multiarch/remote", builder.name
     assert_equal \
-      "git archive --format=tar HEAD | docker buildx build --push --platform linux/amd64,linux/arm64 --builder kamal-app-multiarch-remote -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile -",
+      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder kamal-app-multiarch-remote -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile .",
       builder.push.join(" ")
   end
 
@@ -41,7 +41,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "local" => { "arch" => "amd64" } })
     assert_equal "multiarch", builder.name
     assert_equal \
-      "git archive --format=tar HEAD | docker buildx build --push --platform linux/amd64 --builder kamal-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile -",
+      "docker buildx build --push --platform linux/amd64 --builder kamal-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile .",
       builder.push.join(" ")
   end
 
@@ -49,7 +49,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "remote" => { "arch" => "amd64" }, "cache" => { "type" => "gha" } })
     assert_equal "native/remote", builder.name
     assert_equal \
-      "git archive --format=tar HEAD | docker buildx build --push --platform linux/amd64 --builder kamal-app-native-remote -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile -",
+      "docker buildx build --push --platform linux/amd64 --builder kamal-app-native-remote -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile .",
       builder.push.join(" ")
   end
 
@@ -100,21 +100,21 @@ class CommandsBuilderTest < ActiveSupport::TestCase
   test "native push with build args" do
     builder = new_builder_command(builder: { "multiarch" => false, "args" => { "a" => 1, "b" => 2 } })
     assert_equal \
-      "git archive --format=tar HEAD | docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" --file Dockerfile - && docker push dhh/app:123 && docker push dhh/app:latest",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" --file Dockerfile . && docker push dhh/app:123 && docker push dhh/app:latest",
       builder.push.join(" ")
   end
 
   test "multiarch push with build args" do
     builder = new_builder_command(builder: { "args" => { "a" => 1, "b" => 2 } })
     assert_equal \
-      "git archive --format=tar HEAD | docker buildx build --push --platform linux/amd64,linux/arm64 --builder kamal-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" --file Dockerfile -",
+      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder kamal-app-multiarch -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" --file Dockerfile .",
       builder.push.join(" ")
   end
 
   test "native push with build secrets" do
     builder = new_builder_command(builder: { "multiarch" => false, "secrets" => [ "a", "b" ] })
     assert_equal \
-      "git archive --format=tar HEAD | docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"a\" --secret id=\"b\" --file Dockerfile - && docker push dhh/app:123 && docker push dhh/app:latest",
+      "docker build -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"a\" --secret id=\"b\" --file Dockerfile . && docker push dhh/app:123 && docker push dhh/app:latest",
       builder.push.join(" ")
   end
 
@@ -161,5 +161,9 @@ class CommandsBuilderTest < ActiveSupport::TestCase
   private
     def new_builder_command(additional_config = {})
       Kamal::Commands::Builder.new(Kamal::Configuration.new(@config.merge(additional_config), version: "123"))
+    end
+
+    def build_directory
+      "#{Dir.tmpdir}/kamal-clones/app/kamal/"
     end
 end

--- a/test/configuration/builder_test.rb
+++ b/test/configuration/builder_test.rb
@@ -140,7 +140,7 @@ class ConfigurationBuilderTest < ActiveSupport::TestCase
   end
 
   test "context" do
-    assert_equal "-", @config.builder.context
+    assert_equal ".", @config.builder.context
   end
 
   test "setting context" do

--- a/test/fixtures/deploy_without_clone.yml
+++ b/test/fixtures/deploy_without_clone.yml
@@ -1,0 +1,39 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+    - "1.1.1.2"
+  workers:
+    - "1.1.1.3"
+    - "1.1.1.4"
+registry:
+  username: user
+  password: pw
+
+accessories:
+  mysql:
+    image: mysql:5.7
+    host: 1.1.1.3
+    port: 3306
+    env:
+      clear:
+        MYSQL_ROOT_HOST: '%'
+      secret:
+        - MYSQL_ROOT_PASSWORD
+    files:
+      - test/fixtures/files/my.cnf:/etc/mysql/my.cnf
+    directories:
+      - data:/var/lib/mysql
+  redis:
+    image: redis:latest
+    roles:
+      - web
+    port: 6379
+    directories:
+      - data:/data
+
+readiness_delay: 0
+
+builder:
+  context: "."


### PR DESCRIPTION
Docker does not respect the .dockerignore file when building from a tar. See https://github.com/docker/buildx/issues/2353.

Thanks to @jpdombrowski for pointing this out in https://github.com/basecamp/kamal/pull/700.

Instead by default we'll make a local clone into a tmp directory and build from there. Subsequent builds will reset the clone to match the checkout.

Compared to building directly in the repo, we'll have more reproducible builds and avoid accidentally including local changes.

Compared to using a git archive:
1. .dockerignore is respected
2. We'll have faster builds - docker can be smarter about caching the build context on subsequent builds from a directory

To build from the repo directly, set the build context to "." in the config.

If there are uncommitted changes, we'll warn about them either being included or ignored depending on whether we build from the clone.