### PR TITLE
Set sshkit minimum version to 1.22.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       dotenv (~> 2.8)
       ed25519 (~> 1.2)
       net-ssh (~> 7.0)
-      sshkit (~> 1.21)
+      sshkit (>= 1.22.2, < 2.0)
       thor (~> 1.2)
       zeitwerk (~> 2.5)
 
@@ -75,6 +75,8 @@ GEM
     mutex_m (0.2.0)
     net-scp (4.0.0)
       net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.2.1)
     nokogiri (1.16.0-arm64-darwin)
       racc (~> 1.4)
@@ -151,9 +153,11 @@ GEM
       rubocop-rails
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    sshkit (1.21.7)
+    sshkit (1.22.2)
+      base64
       mutex_m
       net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
     stringio (3.1.0)
     thor (1.3.0)

--- a/kamal.gemspec
+++ b/kamal.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.executables = %w[ kamal ]
 
   spec.add_dependency "activesupport", ">= 7.0"
-  spec.add_dependency "sshkit", "~> 1.21"
+  spec.add_dependency "sshkit", ">= 1.22.2", "< 2.0"
   spec.add_dependency "net-ssh", "~> 7.0"
   spec.add_dependency "thor", "~> 1.2"
   spec.add_dependency "dotenv", "~> 2.8"


### PR DESCRIPTION
This includes a fix for a bug in the eviction thread that could cause this error:

```
[ERROR (IOError): Exception while executing on host foo: closed stream]
```

See https://github.com/capistrano/sshkit/pull/534