### PR TITLE
Fix the header template of the docker-setup hook

### DIFF
--- a/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
+++ b/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/bin/sh
 
 # A sample docker-setup hook
 #


### PR DESCRIPTION
I know that is a very simple PR, but I lot like 40 minutes before realized that the issue was this header from the template :sweat_smile: 