### PR TITLE
Use /bin/sh in docker-setup.sample

### DIFF
--- a/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
+++ b/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
@@ -1,4 +1,4 @@
-#!/usr/bin/env ruby
+#!/bin/sh
 
 # A sample docker-setup hook
 #


### PR DESCRIPTION
The `docker-setup.sample` hook file contains shell code, however the file's shebang is for ruby code.
Unless I'm missing something, the shebang should mark the file to be executed using shell.
This humble PR corrects this.