### PR TITLE
Fix the multiarch disabled + remote set

### DIFF
--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -11,11 +11,11 @@ class Kamal::Commands::Builder < Kamal::Commands::Base
 
   def target
     case
-    when !config.builder.multiarch? && !config.builder.cached?
+    when !config.builder.multiarch? && !config.builder.cached? && !config.builder.remote?
       native
-    when !config.builder.multiarch? && config.builder.cached?
+    when !config.builder.multiarch? && config.builder.cached? && !config.builder.remote?
       native_cached
-    when config.builder.local? && config.builder.remote?
+    when config.builder.multiarch? && config.builder.local? && config.builder.remote?
       multiarch_remote
     when config.builder.remote?
       native_remote

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -53,6 +53,14 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "target native remote when multiarch is disabled and remote is set" do
+    builder = new_builder_command(builder: { "multiarch" => false, "remote" => { "arch" => "amd64" } })
+    assert_equal "native/remote", builder.name
+    assert_equal \
+      "docker buildx build --push --platform linux/amd64 --builder kamal-app-native-remote -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile .",
+      builder.push.join(" ")
+  end
+
   test "build args" do
     builder = new_builder_command(builder: { "args" => { "a" => 1, "b" => 2 } })
     assert_equal \


### PR DESCRIPTION
When we call the kamal with remote only set(no local) + multiarch disabled, it calls the native builder instead of remote builder