### PR TITLE
Check that we have valid contexts before building

### DIFF
--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -1,7 +1,8 @@
 require "active_support/core_ext/string/filters"
 
 class Kamal::Commands::Builder < Kamal::Commands::Base
-  delegate :create, :remove, :push, :clean, :pull, :info, :validate_image, to: :target
+  delegate :create, :remove, :push, :clean, :pull, :info, :context_hosts, :config_context_hosts, :validate_image,
+    to: :target
 
   include Clone
 

--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -2,6 +2,8 @@
 class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   class BuilderError < StandardError; end
 
+  ENDPOINT_DOCKER_HOST_INSPECT = "'{{.Endpoints.docker.Host}}'"
+
   delegate :argumentize, to: Kamal::Utils
   delegate :args, :secrets, :dockerfile, :target, :local_arch, :local_host, :remote_arch, :remote_host, :cache_from, :cache_to, :ssh, to: :builder_config
 
@@ -30,6 +32,13 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
       )
   end
 
+  def context_hosts
+    :true
+  end
+
+  def config_context_hosts
+    []
+  end
 
   private
     def build_tags
@@ -73,5 +82,9 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
 
     def builder_config
       config.builder
+    end
+
+    def context_host(builder_name)
+      docker :context, :inspect, builder_name, "--format", ENDPOINT_DOCKER_HOST_INSPECT
     end
 end

--- a/lib/kamal/commands/builder/multiarch.rb
+++ b/lib/kamal/commands/builder/multiarch.rb
@@ -22,6 +22,10 @@ class Kamal::Commands::Builder::Multiarch < Kamal::Commands::Builder::Base
       build_context
   end
 
+  def context_hosts
+    docker :buildx, :inspect, builder_name, "> /dev/null"
+  end
+
   private
     def builder_name
       "kamal-#{config.service}-multiarch"

--- a/lib/kamal/commands/builder/multiarch/remote.rb
+++ b/lib/kamal/commands/builder/multiarch/remote.rb
@@ -12,6 +12,16 @@ class Kamal::Commands::Builder::Multiarch::Remote < Kamal::Commands::Builder::Mu
       super
   end
 
+  def context_hosts
+    chain \
+      context_host(builder_name_with_arch(local_arch)),
+      context_host(builder_name_with_arch(remote_arch))
+  end
+
+  def config_context_hosts
+    [ local_host, remote_host ].compact
+  end
+
   private
     def builder_name
       super + "-remote"

--- a/lib/kamal/commands/builder/native/cached.rb
+++ b/lib/kamal/commands/builder/native/cached.rb
@@ -1,6 +1,6 @@
 class Kamal::Commands::Builder::Native::Cached < Kamal::Commands::Builder::Native
   def create
-    docker :buildx, :create, "--use", "--driver=docker-container"
+    docker :buildx, :create, "--name", builder_name, "--use", "--driver=docker-container"
   end
 
   def remove
@@ -13,4 +13,13 @@ class Kamal::Commands::Builder::Native::Cached < Kamal::Commands::Builder::Nativ
       *build_options,
       build_context
   end
+
+  def context_hosts
+    docker :buildx, :inspect, builder_name, "> /dev/null"
+  end
+
+  private
+    def builder_name
+      "kamal-#{config.service}-native-cached"
+    end
 end

--- a/lib/kamal/commands/builder/native/remote.rb
+++ b/lib/kamal/commands/builder/native/remote.rb
@@ -26,6 +26,14 @@ class Kamal::Commands::Builder::Native::Remote < Kamal::Commands::Builder::Nativ
     build_context
   end
 
+  def context_hosts
+    context_host(builder_name_with_arch)
+  end
+
+  def config_context_hosts
+    [ remote_host ]
+  end
+
 
   private
     def builder_name

--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -36,6 +36,9 @@ class CliTestCase < ActiveSupport::TestCase
         .with { |arg1, arg2| arg1 == :mkdir && arg2 == ".kamal/locks/app" }
       SSHKit::Backend::Abstract.any_instance.stubs(:execute)
         .with { |arg1, arg2| arg1 == :rm && arg2 == ".kamal/locks/app/details" }
+      SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+        .with { |*args| args[0..2] == [ :docker, :buildx, :inspect ] }
+        .returns("")
     end
 
     def assert_hook_ran(hook, output, version:, service_version:, hosts:, command:, subcommand: nil, runtime: false)

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -116,6 +116,10 @@ class CliMainTest < CliTestCase
       .with(:git, "-C", anything, :status, "--porcelain")
       .returns("")
 
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+      .with(:docker, :buildx, :inspect, "kamal-app-multiarch", "> /dev/null")
+      .returns("")
+
     assert_raises(Kamal::Cli::LockError) do
       run_command("deploy")
     end
@@ -143,6 +147,10 @@ class CliMainTest < CliTestCase
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:git, "-C", anything, :status, "--porcelain")
+      .returns("")
+
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+      .with(:docker, :buildx, :inspect, "kamal-app-multiarch", "> /dev/null")
       .returns("")
 
     assert_raises(SSHKit::Runner::ExecuteError) do


### PR DESCRIPTION
Load the hosts from the contexts before trying to build.

If there is no context, we'll create one. If there is one but the hosts don't match we'll re-create.

Where we just have a local context, there won't be any hosts but we still inspect the builder to check that it exists.

Fixes #90 