### PR TITLE
Allow registry commands to skip local and remote

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -25,7 +25,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
       invoke_options = deploy_options
 
       say "Log into image registry...", :magenta
-      invoke "kamal:cli:registry:login", [], invoke_options
+      invoke "kamal:cli:registry:login", [], invoke_options.merge(skip_local: options[:skip_push])
 
       if options[:skip_push]
         say "Pull app image...", :magenta
@@ -197,7 +197,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
         invoke "kamal:cli:traefik:remove", [], options.without(:confirmed)
         invoke "kamal:cli:app:remove", [], options.without(:confirmed)
         invoke "kamal:cli:accessory:remove", [ "all" ], options
-        invoke "kamal:cli:registry:logout", [], options.without(:confirmed)
+        invoke "kamal:cli:registry:logout", [], options.without(:confirmed).merge(skip_local: true)
       end
     end
   end

--- a/lib/kamal/cli/registry.rb
+++ b/lib/kamal/cli/registry.rb
@@ -1,18 +1,17 @@
 class Kamal::Cli::Registry < Kamal::Cli::Base
   desc "login", "Log in to registry locally and remotely"
+  option :skip_local, aliases: "-L", type: :boolean, default: false, desc: "Skip local login"
+  option :skip_remote, aliases: "-R", type: :boolean, default: false, desc: "Skip remote login"
   def login
-    run_locally    { execute *KAMAL.registry.login }
-    on(KAMAL.hosts) { execute *KAMAL.registry.login }
-  # FIXME: This rescue needed?
-  rescue ArgumentError => e
-    puts e.message
+    run_locally    { execute *KAMAL.registry.login } unless options[:skip_local]
+    on(KAMAL.hosts) { execute *KAMAL.registry.login } unless options[:skip_remote]
   end
 
-  desc "logout", "Log out of registry remotely"
+  desc "logout", "Log out of registry locally and remotely"
+  option :skip_local, aliases: "-L", type: :boolean, default: false, desc: "Skip local login"
+  option :skip_remote, aliases: "-R", type: :boolean, default: false, desc: "Skip remote login"
   def logout
-    on(KAMAL.hosts) { execute *KAMAL.registry.logout }
-  # FIXME: This rescue needed?
-  rescue ArgumentError => e
-    puts e.message
+    run_locally    { execute *KAMAL.registry.logout } unless options[:skip_local]
+    on(KAMAL.hosts) { execute *KAMAL.registry.logout } unless options[:skip_remote]
   end
 end

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -22,7 +22,7 @@ class CliMainTest < CliTestCase
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:main:envify", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
     # deploy
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options.merge(skip_local: true))
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:pull", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:traefik:boot", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
@@ -46,7 +46,7 @@ class CliMainTest < CliTestCase
   test "deploy" do
     invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false, "verbose" => true }
 
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options.merge(skip_local: false))
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:traefik:boot", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
@@ -71,7 +71,7 @@ class CliMainTest < CliTestCase
   test "deploy with skip_push" do
     invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
 
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options.merge(skip_local: true))
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:pull", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:traefik:boot", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
@@ -151,10 +151,10 @@ class CliMainTest < CliTestCase
   end
 
   test "deploy errors during outside section leave remove lock" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
+    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false, :skip_local => false }
 
     Kamal::Cli::Main.any_instance.expects(:invoke)
-      .with("kamal:cli:registry:login", [], invoke_options)
+      .with("kamal:cli:registry:login", [], invoke_options.merge(skip_local: false))
       .raises(RuntimeError)
 
     assert_not KAMAL.holding_lock?
@@ -167,7 +167,7 @@ class CliMainTest < CliTestCase
   test "deploy with skipped hooks" do
     invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => true }
 
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options.merge(skip_local: false))
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:traefik:boot", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
@@ -184,7 +184,7 @@ class CliMainTest < CliTestCase
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:healthcheck:perform", [], invoke_options).never
 
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options.merge(skip_local: false))
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:traefik:boot", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
@@ -197,7 +197,7 @@ class CliMainTest < CliTestCase
   test "deploy with missing secrets" do
     invoke_options = { "config_file" => "test/fixtures/deploy_with_secrets.yml", "version" => "999", "skip_hooks" => false }
 
-    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:registry:login", [], invoke_options.merge(skip_local: false))
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:traefik:boot", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))

--- a/test/cli/registry_test.rb
+++ b/test/cli/registry_test.rb
@@ -8,9 +8,38 @@ class CliRegistryTest < CliTestCase
     end
   end
 
+  test "login skip local" do
+    run_command("login", "-L").tap do |output|
+      assert_no_match /docker login -u \[REDACTED\] -p \[REDACTED\] as .*@localhost/, output
+      assert_match /docker login -u \[REDACTED\] -p \[REDACTED\] on 1.1.1.\d/, output
+    end
+  end
+
+  test "login skip remote" do
+    run_command("login", "-R").tap do |output|
+      assert_match /docker login -u \[REDACTED\] -p \[REDACTED\] as .*@localhost/, output
+      assert_no_match /docker login -u \[REDACTED\] -p \[REDACTED\] on 1.1.1.\d/, output
+    end
+  end
+
   test "logout" do
     run_command("logout").tap do |output|
+      assert_match /docker logout as .*@localhost/, output
       assert_match /docker logout on 1.1.1.\d/, output
+    end
+  end
+
+  test "logout skip local" do
+    run_command("logout", "-L").tap do |output|
+      assert_no_match /docker logout as .*@localhost/, output
+      assert_match /docker logout on 1.1.1.\d/, output
+    end
+  end
+
+  test "logout skip remote" do
+    run_command("logout", "-R").tap do |output|
+      assert_match /docker logout as .*@localhost/, output
+      assert_no_match /docker logout on 1.1.1.\d/, output
     end
   end
 


### PR DESCRIPTION
- Add local logout to `kamal registry logout`
- Add `skip_local` and `skip_remote` options to `kamal registry` commands
- Skip local login in `kamal deploy` when `--skip-push` is used

Fixes https://github.com/basecamp/kamal/issues/814