### PR TITLE
Add x25519 gem, support Curve25519

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,7 @@ PATH
       net-ssh (~> 7.0)
       sshkit (>= 1.22.2, < 2.0)
       thor (~> 1.2)
+      x25519 (~> 1.0, >= 1.0.10)
       zeitwerk (~> 2.5)
 
 GEM
@@ -165,6 +166,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
+    x25519 (1.0.10)
     zeitwerk (2.6.12)
 
 PLATFORMS

--- a/kamal.gemspec
+++ b/kamal.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dotenv", "~> 2.8"
   spec.add_dependency "zeitwerk", "~> 2.5"
   spec.add_dependency "ed25519", "~> 1.2"
+  spec.add_dependency "x25519", "~> 1.0", ">= 1.0.10"
   spec.add_dependency "bcrypt_pbkdf", "~> 1.0"
   spec.add_dependency "concurrent-ruby", "~> 1.2"
   spec.add_dependency "base64", "~> 0.2"


### PR DESCRIPTION
Fixes:

```
  ERROR (Net::SSH::Exception): Exception while executing on host example.com: could not settle on kex algorithm
Server kex preferences: curve25519-sha256@libssh.org,ext-info-s,kex-strict-s-v00@openssh.com
Client kex preferences: ecdh-sha2-nistp521,ecdh-sha2-nistp384,ecdh-sha2-nistp256,diffie-hellman-group-exchange-sha256,diffie-hellman-group14-sha256,diffie-hellman-group14-sha1
```