### PR TITLE
Display container logs when failing to start new version when using single role

### DIFF
--- a/lib/kamal/cli/app/boot.rb
+++ b/lib/kamal/cli/app/boot.rb
@@ -19,6 +19,8 @@ class Kamal::Cli::App::Boot
     begin
       start_new_version
     rescue => e
+      error capture_with_info(*app.logs(version: version))
+      error capture_with_info(*app.container_health_log(version: version))
       close_barrier if gatekeeper?
       stop_new_version
       raise
@@ -88,8 +90,6 @@ class Kamal::Cli::App::Boot
     def close_barrier
       if barrier.close
         info "First #{KAMAL.primary_role} container is unhealthy on #{host}, not booting other roles"
-        error capture_with_info(*app.logs(version: version))
-        error capture_with_info(*app.container_health_log(version: version))
       end
     end
 


### PR DESCRIPTION
When Kamal is configured with a single role (ie: web), the container logs are not displayed after the container failed to become healthy.

I did not add a test as it seemed a bit overkill, but I can add a test case to `test/integration/broken_deploy_test.rb` if needed.

Fixes https://github.com/basecamp/kamal/issues/842