### PR TITLE
Revert "Envify already env pushes"

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -11,6 +11,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
 
         say "Evaluate and push env files...", :magenta
         invoke "kamal:cli:main:envify", [], invoke_options
+        invoke "kamal:cli:env:push", [], invoke_options
 
         invoke "kamal:cli:accessory:boot", [ "all" ], invoke_options
         deploy

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -6,6 +6,7 @@ class CliMainTest < CliTestCase
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:main:envify", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:deploy)
 
@@ -19,6 +20,7 @@ class CliMainTest < CliTestCase
     invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:env:push", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:main:envify", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
     # deploy


### PR DESCRIPTION
Reverts basecamp/kamal#815

`kamal envify` only calls `kamal env push` if there in a template file.