### PR TITLE
Log on boot errors with one role

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -14,7 +14,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
         end
 
         # Primary hosts and roles are returned first, so they can open the barrier
-        barrier = Kamal::Cli::Healthcheck::Barrier.new if KAMAL.roles.many?
+        barrier = Kamal::Cli::Healthcheck::Barrier.new
 
         on(KAMAL.hosts, **KAMAL.boot_strategy) do |host|
           KAMAL.roles_on(host).each do |role|

--- a/lib/kamal/cli/app/boot.rb
+++ b/lib/kamal/cli/app/boot.rb
@@ -72,7 +72,7 @@ class Kamal::Cli::App::Boot
 
     def release_barrier
       if barrier.open
-        info "First #{KAMAL.primary_role} container is healthy on #{host}, booting other roles"
+        info "First #{KAMAL.primary_role} container is healthy on #{host}, booting any other roles"
       end
     end
 
@@ -87,7 +87,7 @@ class Kamal::Cli::App::Boot
 
     def close_barrier
       if barrier.close
-        info "First #{KAMAL.primary_role} container is unhealthy on #{host}, not booting other roles"
+        info "First #{KAMAL.primary_role} container is unhealthy on #{host}, not booting any other roles"
         error capture_with_info(*app.logs(version: version))
         error capture_with_info(*app.container_health_log(version: version))
       end

--- a/test/integration/broken_deploy_test.rb
+++ b/test/integration/broken_deploy_test.rb
@@ -26,7 +26,7 @@ class BrokenDeployTest < IntegrationTest
   private
     def assert_failed_deploy(output)
       assert_match "Waiting for the first healthy web container before booting workers on vm3...", output
-      assert_match /First web container is unhealthy on vm[12], not booting other roles/, output
+      assert_match /First web container is unhealthy on vm[12], not booting any other roles/, output
       assert_match "First web container is unhealthy, not booting workers on vm3", output
       assert_match "nginx: [emerg] unexpected end of file, expecting \";\" or \"}\" in /etc/nginx/conf.d/default.conf:2", output
       assert_match 'ERROR {"Status":"unhealthy","FailingStreak":0,"Log":[]}', output


### PR DESCRIPTION
We didn't log boot errors if there was one role because there was no barrier and the logging is done by the first host to close the barrier.

Let's always create the barrier to fix this. Fixes #843 