### PR TITLE
Remove Ruby 2.7 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,25 +24,12 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-          - "2.7"
           - "3.1"
           - "3.2"
           - "3.3"
         gemfile:
           - Gemfile
-          - gemfiles/ruby_2.7.gemfile
           - gemfiles/rails_edge.gemfile
-        exclude:
-          - ruby-version: "2.7"
-            gemfile: Gemfile
-          - ruby-version: "2.7"
-            gemfile: gemfiles/rails_edge.gemfile
-          - ruby-version: "3.1"
-            gemfile: gemfiles/ruby_2.7.gemfile
-          - ruby-version: "3.2"
-            gemfile: gemfiles/ruby_2.7.gemfile
-          - ruby-version: "3.3"
-            gemfile: gemfiles/ruby_2.7.gemfile
     name: ${{ format('Tests (Ruby {0})', matrix.ruby-version) }}
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/gemfiles/ruby_2.7.gemfile
+++ b/gemfiles/ruby_2.7.gemfile
@@ -1,6 +1,0 @@
-source 'https://rubygems.org'
-git_source(:github) { |repo| "https://github.com/#{repo}.git" }
-
-gemspec path: "../"
-
-gem "nokogiri", "~> 1.15.0"


### PR DESCRIPTION
It's EOL since March 2023.