### PR TITLE
Match a "does not exist" error message

### DIFF
--- a/lib/kamal/cli/build.rb
+++ b/lib/kamal/cli/build.rb
@@ -43,8 +43,8 @@ class Kamal::Cli::Build < Kamal::Cli::Base
           cli.create
         end
       rescue SSHKit::Command::Failed => e
-        warn "Missing compatible builder, so creating a new one first"
-        if e.message =~ /(context not found|no builder)/
+        if e.message =~ /(context not found|no builder|does not exist)/
+          warn "Missing compatible builder, so creating a new one first"
           cli.create
         else
           raise


### PR DESCRIPTION
Only show the warning for building when we are actually going to do that and match `does not exist` in the error message.

Fixes: https://github.com/basecamp/kamal/issues/851