### PR TITLE
fix: Ensure SSH connections are closed after each command execution

### DIFF
--- a/lib/kamal/sshkit_with_ext.rb
+++ b/lib/kamal/sshkit_with_ext.rb
@@ -118,6 +118,8 @@ class SSHKit::Runner::Parallel
         rescue ::StandardError => e
           e2 = SSHKit::Runner::ExecuteError.new e
           raise e2, "Exception while executing #{host.user ? "as #{host.user}@" : "on host "}#{host}: #{e.message}"
+        ensure
+          SSHKit::Backend::Netssh.pool.close_connections
         end
       end
 


### PR DESCRIPTION
This commit addresses an issue where SSH connections were not being properly closed after each command execution, leading to timeout errors during the `kamal deploy` process.

### Problem
When executing commands using the `execute` method in `SSHKit::Runner::Parallel`, SSH connections were left open, causing subsequent commands to fail with timeout errors. This issue was particularly evident when running `kamal build deliver` after `kamal registry login` during the normal `kamal deploy process`

### Solution
The `execute` method in the `SSHKit::Runner::Parallel::CompleteAll` module has been modified to ensure that all SSH connections are closed after each command execution. This is achieved by adding an `ensure` block to the thread creation logic, which calls `SSHKit::Backend::Netssh.pool.close_connections` after each command, regardless of whether an exception occurs.

### Changes
- Added an `ensure` block to the `execute` method in `SSHKit::Runner::Parallel::CompleteAll` to close SSH connections after each command execution.

### Impact
This change ensures that SSH connections are properly closed, preventing timeout errors and improving the reliability of the `kamal deploy` process.

### Testing
Tested the changes by running `kamal deploy` commands. Verified that the timeout errors no longer occur and the deployment process completes successfully.

Closes #857