### PR TITLE
Expand on docker-setup.sample hook

### DIFF
--- a/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
+++ b/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
@@ -1,7 +1,13 @@
-#!/bin/sh
+#!/usr/bin/env ruby
 
 # A sample docker-setup hook
 #
-# Sets up a Docker network which can then be used by the application’s containers
+# Sets up a Docker network on defined hosts which can then be used by the application’s containers
 
-ssh user@example.com docker network create kamal
+hosts = ENV["KAMAL_HOSTS"].split(",")
+
+hosts.each do |ip|
+  destination = "root@#{ip}"
+  puts "Creating a Docker network \"kamal\" on #{destination}"
+  `ssh #{destination} docker network create kamal`
+end


### PR DESCRIPTION
The `docker-setup` sample hook seemed a bit lackluster compared to other hook examples. Here is my idea how it can be improved. 
 
It's using root user since this is what "default rails Docker" is using. 
It's idempotent, when network already exists (or not could not be created for some reason) it just prints error to stdout that is only visible with --verbose flag.