### PR TITLE
Bump sshkit to support unbracketed IPv6 addresses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,7 +9,7 @@ PATH
       dotenv (~> 2.8)
       ed25519 (~> 1.2)
       net-ssh (~> 7.0)
-      sshkit (>= 1.22.2, < 2.0)
+      sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.2)
       x25519 (~> 1.0, >= 1.0.10)
       zeitwerk (~> 2.5)
@@ -154,9 +154,8 @@ GEM
       rubocop-rails
     ruby-progressbar (1.13.0)
     ruby2_keywords (0.0.5)
-    sshkit (1.22.2)
+    sshkit (1.23.0)
       base64
-      mutex_m
       net-scp (>= 1.1.2)
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)

--- a/kamal.gemspec
+++ b/kamal.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.executables = %w[ kamal ]
 
   spec.add_dependency "activesupport", ">= 7.0"
-  spec.add_dependency "sshkit", ">= 1.22.2", "< 2.0"
+  spec.add_dependency "sshkit", ">= 1.23.0", "< 2.0"
   spec.add_dependency "net-ssh", "~> 7.0"
   spec.add_dependency "thor", "~> 1.2"
   spec.add_dependency "dotenv", "~> 2.8"


### PR DESCRIPTION
Set sshkit minimum version to 1.23.0, which includes an enhancement to support unbracketed IPv6 addresses.

See https://github.com/capistrano/sshkit/pull/538
Closes https://github.com/basecamp/kamal/issues/588