### PR TITLE
Allow arrays in args

### DIFF
--- a/lib/kamal/configuration/validator.rb
+++ b/lib/kamal/configuration/validator.rb
@@ -31,9 +31,9 @@ class Kamal::Configuration::Validator
             validate_array_of! value, example_value.first.class
           elsif example_value.is_a?(Hash)
             case key.to_s
-            when "options"
+            when "options", "args"
               validate_type! value, Hash
-            when "args", "labels"
+            when "labels"
               validate_hash_of! value, example_value.first[1].class
             else
               validate_against_example! value, example_value

--- a/test/commands/traefik_test.rb
+++ b/test/commands/traefik_test.rb
@@ -111,6 +111,11 @@ class CommandsTraefikTest < ActiveSupport::TestCase
       new_command.run.join(" ")
   end
 
+  test "run with args array" do
+    @config[:traefik]["args"] = { "entrypoints.web.forwardedheaders.trustedips" => %w[ 127.0.0.1 127.0.0.2 ] }
+    assert_equal "docker run --name traefik --detach --restart unless-stopped --publish 80:80 --volume /var/run/docker.sock:/var/run/docker.sock --env-file .kamal/env/traefik/traefik.env --log-opt max-size=\"10m\" --label traefik.http.routers.catchall.entryPoints=\"http\" --label traefik.http.routers.catchall.rule=\"PathPrefix(\\`/\\`)\" --label traefik.http.routers.catchall.service=\"unavailable\" --label traefik.http.routers.catchall.priority=\"1\" --label traefik.http.services.unavailable.loadbalancer.server.port=\"0\" traefik:test --providers.docker --log.level=\"DEBUG\" --entrypoints.web.forwardedheaders.trustedips=\"127.0.0.1\" --entrypoints.web.forwardedheaders.trustedips=\"127.0.0.2\"", new_command.run.join(" ")
+  end
+
   test "traefik start" do
     assert_equal \
       "docker container start traefik",

--- a/test/configuration/validation_test.rb
+++ b/test/configuration/validation_test.rb
@@ -94,7 +94,7 @@ class ConfigurationValidationTest < ActiveSupport::TestCase
     assert_error "builder/remote: unknown key: foo", builder: { "remote" => { "foo" => "bar" } }
     assert_error "builder/local: unknown key: foo", builder: { "local" => { "foo" => "bar" } }
     assert_error "builder/remote/arch: should be a string", builder: { "remote" => { "arch" => [] } }
-    assert_error "builder/args/foo: should be a string", builder: { "args" => { "foo" => [] } }
+    assert_error "builder/args: should be a hash", builder: { "args" => [ "foo" ] }
     assert_error "builder/cache/options: should be a string", builder: { "cache" => { "options" => [] } }
   end
 


### PR DESCRIPTION
Just check that args is a Hash without checking the value types.

Fixes: https://github.com/basecamp/kamal/issues/863