### PR TITLE
Ensure envify templates aren't polluted by existing env

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -191,10 +191,12 @@ class Kamal::Cli::Main < Kamal::Cli::Base
     end
 
     if Pathname.new(File.expand_path(env_template_path)).exist?
-      File.write(env_path, ERB.new(File.read(env_template_path), trim_mode: "-").result, perm: 0600)
+      # Ensure existing env doesn't pollute template evaluation
+      content = with_original_env { ERB.new(File.read(env_template_path), trim_mode: "-").result }
+      File.write(env_path, content, perm: 0600)
 
       unless options[:skip_push]
-        reload_envs
+        reload_env
         invoke "kamal:cli:env:push", options
       end
     else


### PR DESCRIPTION
Setting `GITHUB_TOKEN` as in the docs results in reusing the existing `GITHUB_TOKEN` since `gh` returns that env var if it's set:
```bash
GITHUB_TOKEN=junk gh config get -h github.com oauth_token
junk
```

Using the original env ensures that the templates will be evaluated the same way regardless of whether envify had been previously invoked.