### PR TITLE
Configurable SSH Identity

### DIFF
--- a/lib/kamal/configuration/docs/ssh.yml
+++ b/lib/kamal/configuration/docs/ssh.yml
@@ -44,3 +44,23 @@ ssh:
   # Defaults to `fatal`. Set this to debug if you are having
   # SSH connection issues.
   log_level: debug
+
+  # Keys Only
+  #
+  # Set to true to use only private keys from keys and key_data parameters, 
+  # even if ssh-agent offers more identities. This option is intended for 
+  # situations where ssh-agent offers many different identites or you have 
+  # a need to overwrite all identites and force a single one.
+  keys_only: false
+
+  # Keys
+  #
+  # An array of file names of private keys to use for publickey
+  # and hostbased authentication
+  keys: [ "~/.ssh/id.pem" ]
+
+  # Key Data
+  #
+  # An array of strings, with each element of the array being
+  # a raw private key in PEM format.
+  key_data: [ "-----BEGIN OPENSSH PRIVATE KEY-----" ]

--- a/lib/kamal/configuration/ssh.rb
+++ b/lib/kamal/configuration/ssh.rb
@@ -26,8 +26,20 @@ class Kamal::Configuration::Ssh
     end
   end
 
+  def keys_only
+    ssh_config["keys_only"]
+  end
+
+  def keys
+    ssh_config["keys"]
+  end
+
+  def key_data
+    ssh_config["key_data"]
+  end
+
   def options
-    { user: user, port: port, proxy: proxy, logger: logger, keepalive: true, keepalive_interval: 30 }.compact
+    { user: user, port: port, proxy: proxy, logger: logger, keepalive: true, keepalive_interval: 30, keys_only: keys_only, keys: keys, key_data: key_data }.compact
   end
 
   def to_h


### PR DESCRIPTION
This PR introduces SSH options keys_only, keys, and key_data, which gives us the ability to define the SSH key used.

```
  # Keys Only
  #
  # Set to true to use only private keys from keys and key_data parameters, 
  # even if ssh-agent offers more identities. This option is intended for 
  # situations where ssh-agent offers many different identites or you have 
  # a need to overwrite all identites and force a single one.
  keys_only: false

  # Keys
  #
  # An array of file names of private keys to use for publickey
  # and hostbased authentication
  keys: [ "~/.ssh/id.pem" ]

  # Key Data
  #
  # An array of strings, with each element of the array being
  # a raw private key in PEM format.
  key_data: [ "-----BEGIN OPENSSH PRIVATE KEY-----" ]
  ```