### PR TITLE
Add ENV['KAMAL_SERVICE'] to hooks

### DIFF
--- a/lib/kamal/commands/auditor.rb
+++ b/lib/kamal/commands/auditor.rb
@@ -9,7 +9,7 @@ class Kamal::Commands::Auditor < Kamal::Commands::Base
   # Runs remotely
   def record(line, **details)
     append \
-      [ :echo, audit_tags(**details).except(:version, :service_version).to_s, line ],
+      [ :echo, audit_tags(**details).except(:version, :service_version, :service).to_s, line ],
       audit_log_file
   end
 

--- a/lib/kamal/tags.rb
+++ b/lib/kamal/tags.rb
@@ -13,7 +13,8 @@ class Kamal::Tags
         performer: `whoami`.chomp,
         destination: config.destination,
         version: config.version,
-        service_version: service_version(config) }
+        service_version: service_version(config),
+        service: config.service }
     end
 
     def service_version(config)

--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -43,6 +43,7 @@ class CliTestCase < ActiveSupport::TestCase
 
     def assert_hook_ran(hook, output, version:, service_version:, hosts:, command:, subcommand: nil, runtime: false)
       performer = `whoami`.strip
+      service = service_version.split("@").first
 
       assert_match "Running the #{hook} hook...\n", output
 
@@ -52,6 +53,7 @@ class CliTestCase < ActiveSupport::TestCase
         KAMAL_PERFORMER=\"#{performer}\"\s
         KAMAL_VERSION=\"#{version}\"\s
         KAMAL_SERVICE_VERSION=\"#{service_version}\"\s
+        KAMAL_SERVICE=\"#{service}\"\s
         KAMAL_HOSTS=\"#{hosts}\"\s
         KAMAL_COMMAND=\"#{command}\"\s
         #{"KAMAL_SUBCOMMAND=\\\"#{subcommand}\\\"\\s" if subcommand}

--- a/test/commands/hook_test.rb
+++ b/test/commands/hook_test.rb
@@ -22,7 +22,8 @@ class CommandsHookTest < ActiveSupport::TestCase
         "KAMAL_RECORDED_AT" => @recorded_at,
         "KAMAL_PERFORMER" => @performer,
         "KAMAL_VERSION" => "123",
-        "KAMAL_SERVICE_VERSION" => "app@123" } }
+        "KAMAL_SERVICE_VERSION" => "app@123",
+        "KAMAL_SERVICE" => "app" } }
     ], new_command.run("foo")
   end
 
@@ -33,7 +34,8 @@ class CommandsHookTest < ActiveSupport::TestCase
         "KAMAL_RECORDED_AT" => @recorded_at,
         "KAMAL_PERFORMER" => @performer,
         "KAMAL_VERSION" => "123",
-        "KAMAL_SERVICE_VERSION" => "app@123" } }
+        "KAMAL_SERVICE_VERSION" => "app@123",
+        "KAMAL_SERVICE" => "app" } }
     ], new_command(hooks_path: "custom/hooks/path").run("foo")
   end
 


### PR DESCRIPTION
This adds `ENV['KAMAL_SERVICE']` to the hooks so that there isn't any additional processing that needs to be done within your hooks to reference the service, similar to the existing `ENV['KAMAL_VERSION']`. An example use for this would be the [docker-setup hook](https://github.com/basecamp/kamal/pull/861) so that you can easily define your Docker network to be attached to your service `docker network create #{ENV['KAMAL_SERVICE']}-#{ENV['KAMAL_DESTINATION']}"` or just `docker network create #{ENV['KAMAL_SERVICE']}`. 