### PR TITLE
Remove the deprecated docker compose version

### DIFF
--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 name: "kamal-test"
 
 volumes:


### PR DESCRIPTION
The top-level docker compose `version` property is no longer needed, this PR removes it.

Ref: https://github.com/compose-spec/compose-spec/blob/master/spec.md#version-and-name-top-level-elements

Running tests is currently outputting a bunch of these `WARN` lines:

```
WARN[0000] /Users/n/src/github/kamal/test/integration/docker-compose.yml: `version` is obsolete
```