### PR TITLE
feat: Use git email as performer when available

### DIFF
--- a/lib/kamal/git.rb
+++ b/lib/kamal/git.rb
@@ -9,6 +9,10 @@ module Kamal::Git
     `git config user.name`.strip
   end
 
+  def email
+    `git config user.email`.strip
+  end
+
   def revision
     `git rev-parse HEAD`.strip
   end

--- a/lib/kamal/tags.rb
+++ b/lib/kamal/tags.rb
@@ -10,7 +10,7 @@ class Kamal::Tags
 
     def default_tags(config)
       { recorded_at: Time.now.utc.iso8601,
-        performer: `whoami`.chomp,
+        performer: Kamal::Git.email.presence || `whoami`.chomp,
         destination: config.destination,
         version: config.version,
         service_version: service_version(config),

--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -42,7 +42,7 @@ class CliTestCase < ActiveSupport::TestCase
     end
 
     def assert_hook_ran(hook, output, version:, service_version:, hosts:, command:, subcommand: nil, runtime: false)
-      performer = `whoami`.strip
+      performer = Kamal::Git.email.presence || `whoami`.chomp
       service = service_version.split("@").first
 
       assert_match "Running the #{hook} hook...\n", output

--- a/test/commands/auditor_test.rb
+++ b/test/commands/auditor_test.rb
@@ -12,7 +12,7 @@ class CommandsAuditorTest < ActiveSupport::TestCase
     }
 
     @auditor = new_command
-    @performer = `whoami`.strip
+    @performer = Kamal::Git.email.presence || `whoami`.chomp
     @recorded_at = Time.now.utc.iso8601
   end
 

--- a/test/commands/hook_test.rb
+++ b/test/commands/hook_test.rb
@@ -11,7 +11,7 @@ class CommandsHookTest < ActiveSupport::TestCase
       traefik: { "args" => { "accesslog.format" => "json", "metrics.prometheus.buckets" => "0.1,0.3,1.2,5.0" } }
     }
 
-    @performer = `whoami`.strip
+    @performer = Kamal::Git.email.presence || `whoami`.chomp
     @recorded_at = Time.now.utc.iso8601
   end
 


### PR DESCRIPTION
Getting performer identifier from git configuration when it's available makes sense to me for a couple reasons :

- Value should be more unique and create less conflicts
- Git config can be overriden on a per-repo basis, which means a user could appear in the audit logs with their preferred git identity.

I think I made it so we'll still fall back to the sane default whoami that ensures a value is set.