### PR TITLE
Seed docker mirrors by pulling once per mirror first

### DIFF
--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -2,7 +2,7 @@ require "active_support/core_ext/string/filters"
 
 class Kamal::Commands::Builder < Kamal::Commands::Base
   delegate :create, :remove, :push, :clean, :pull, :info, :context_hosts, :config_context_hosts, :validate_image,
-    to: :target
+           :first_mirror, to: :target
 
   include Clone
 

--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -40,6 +40,10 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
     []
   end
 
+  def first_mirror
+    docker(:info, "--format '{{index .RegistryConfig.Mirrors 0}}'")
+  end
+
   private
     def build_tags
       [ "-t", config.absolute_image, "-t", config.latest_image ]

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -122,6 +122,11 @@ class CliMainTest < CliTestCase
       .with(:docker, :buildx, :inspect, "kamal-app-multiarch", "> /dev/null")
       .returns("")
 
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+      .with(:docker, :info, "--format '{{index .RegistryConfig.Mirrors 0}}'")
+      .returns("")
+      .at_least_once
+
     assert_raises(Kamal::Cli::LockError) do
       run_command("deploy")
     end
@@ -154,6 +159,11 @@ class CliMainTest < CliTestCase
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :buildx, :inspect, "kamal-app-multiarch", "> /dev/null")
       .returns("")
+
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+      .with(:docker, :info, "--format '{{index .RegistryConfig.Mirrors 0}}'")
+      .returns("")
+      .at_least_once
 
     assert_raises(SSHKit::Runner::ExecuteError) do
       run_command("deploy")

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -200,6 +200,11 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     assert_equal [ "unix:///var/run/docker.sock", "ssh://host" ], command.config_context_hosts
   end
 
+  test "mirror count" do
+    command = new_builder_command
+    assert_equal "docker info --format '{{index .RegistryConfig.Mirrors 0}}'", command.first_mirror.join(" ")
+  end
+
   private
     def new_builder_command(additional_config = {})
       Kamal::Commands::Builder.new(Kamal::Configuration.new(@config.merge(additional_config), version: "123"))


### PR DESCRIPTION
Find the first registry mirror on each host. If we find any, pull the images on one host per mirror, then do the remainder concurrently.

The initial pulls will seed the mirrors ensuring that we pull the image from Docker Hub only once per mirror.

This works best if there is only one mirror per host.