### PR TITLE
Update submodules after clone

### DIFF
--- a/lib/kamal/cli/build/clone.rb
+++ b/lib/kamal/cli/build/clone.rb
@@ -34,6 +34,7 @@ class Kamal::Cli::Build::Clone
 
       FileUtils.mkdir_p KAMAL.config.builder.clone_directory
       execute *KAMAL.builder.clone
+      execute *KAMAL.builder.update_submodules_after_clone
     end
 
     def reset

--- a/lib/kamal/commands/builder/clone.rb
+++ b/lib/kamal/commands/builder/clone.rb
@@ -9,6 +9,10 @@ module Kamal::Commands::Builder::Clone
     git :clone, Kamal::Git.root, path: clone_directory
   end
 
+  def update_submodules_after_clone
+    git :submodule, :update, "--init", "--recursive", "--depth", "1", path: build_directory
+  end
+
   def clone_reset_steps
     [
       git(:remote, "set-url", :origin, Kamal::Git.root, path: build_directory),


### PR DESCRIPTION
When git added some submodules, docker build will failed due to submodules' code is missing.
