### PR TITLE
Revert "Add x25519 gem, support Curve25519"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,6 @@ PATH
       net-ssh (~> 7.0)
       sshkit (>= 1.22.2, < 2.0)
       thor (~> 1.2)
-      x25519 (~> 1.0, >= 1.0.10)
       zeitwerk (~> 2.5)
 
 GEM
@@ -166,7 +165,6 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     webrick (1.8.1)
-    x25519 (1.0.10)
     zeitwerk (2.6.12)
 
 PLATFORMS

--- a/kamal.gemspec
+++ b/kamal.gemspec
@@ -18,7 +18,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dotenv", "~> 2.8"
   spec.add_dependency "zeitwerk", "~> 2.5"
   spec.add_dependency "ed25519", "~> 1.2"
-  spec.add_dependency "x25519", "~> 1.0", ">= 1.0.10"
   spec.add_dependency "bcrypt_pbkdf", "~> 1.0"
   spec.add_dependency "concurrent-ruby", "~> 1.2"
   spec.add_dependency "base64", "~> 0.2"


### PR DESCRIPTION
Reverts basecamp/kamal#840 as the x25519 gem doesn't build on amd64 docker images using Ruby:3.3.4-slim
