### PR TITLE
Dont build image if it has already been pushed

### DIFF
--- a/lib/kamal/cli/build.rb
+++ b/lib/kamal/cli/build.rb
@@ -5,7 +5,7 @@ class Kamal::Cli::Build < Kamal::Cli::Base
 
   desc "deliver", "Build app and push app image to registry then pull image on servers"
   def deliver
-    push
+    push unless already_built?
     pull
   end
 
@@ -157,5 +157,11 @@ class Kamal::Cli::Build < Kamal::Cli::Base
         execute *KAMAL.builder.pull
         execute *KAMAL.builder.validate_image
       end
+    end
+
+    def already_built?
+      run_locally { execute *KAMAL.docker.manifest(KAMAL.builder.absolute_image) }
+    rescue SSHKit::Command::Failed
+      false
     end
 end

--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -3,6 +3,7 @@ require "active_support/core_ext/string/filters"
 class Kamal::Commands::Builder < Kamal::Commands::Base
   delegate :create, :remove, :push, :clean, :pull, :info, :context_hosts, :config_context_hosts, :validate_image,
            :first_mirror, to: :target
+  delegate :absolute_image, to: :config
 
   include Clone
 

--- a/lib/kamal/commands/docker.rb
+++ b/lib/kamal/commands/docker.rb
@@ -14,6 +14,10 @@ class Kamal::Commands::Docker < Kamal::Commands::Base
     docker :version
   end
 
+  def manifest(tag)
+    docker :manifest, :inspect, tag
+  end
+
   # Do we have superuser access to install Docker and start system services?
   def superuser?
     [ '[ "${EUID:-$(id -u)}" -eq 0 ] || command -v sudo >/dev/null || command -v su >/dev/null' ]


### PR DESCRIPTION
This is useful when you push a branch to different environments at separate times from CI. It's also useful if you have CI setup to deploy main but have a concurrency key setup. If you push quickly youll end up deploying the same commit twice and the second time the image doesnt need to be built since it already exists. 