### PR TITLE
Remove `--update` flag from `apk add` command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Use the official Ruby 3.2.0 Alpine image as the base image
 FROM ruby:3.2.0-alpine
 
-# Install  docker/buildx-bin
+# Install docker/buildx-bin
 COPY --from=docker/buildx-bin /buildx /usr/libexec/docker/cli-plugins/docker-buildx
 
 # Set the working directory to /kamal
@@ -14,7 +14,7 @@ COPY Gemfile Gemfile.lock kamal.gemspec ./
 COPY lib/kamal/version.rb /kamal/lib/kamal/version.rb
 
 # Install system dependencies
-RUN apk add --no-cache --update build-base git docker openrc openssh-client-default \
+RUN apk add --no-cache build-base git docker openrc openssh-client-default \
     && rc-update add docker boot \
     && gem install bundler --version=2.4.3 \
     && bundle install


### PR DESCRIPTION
The `--update` flag is an abbreviation for `--update-cache`. Since the `--no-cache` flag already allows users to install packages using an updated index on-the-fly without caching it locally, specifying `--update` is redundant. 