### PR TITLE
Fix the tests when you have a git config email set

### DIFF
--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -42,12 +42,13 @@ class CliTestCase < ActiveSupport::TestCase
     end
 
     def assert_hook_ran(hook, output, version:, service_version:, hosts:, command:, subcommand: nil, runtime: false)
-      performer = Kamal::Git.email.presence || `whoami`.chomp
+      whoami = `whoami`.chomp
+      performer = Kamal::Git.email.presence || whoami
       service = service_version.split("@").first
 
       assert_match "Running the #{hook} hook...\n", output
 
-      expected = %r{Running\s/usr/bin/env\s\.kamal/hooks/#{hook}\sas\s#{performer}@localhost\n\s
+      expected = %r{Running\s/usr/bin/env\s\.kamal/hooks/#{hook}\sas\s#{whoami}@localhost\n\s
         DEBUG\s\[[0-9a-f]*\]\sCommand:\s\(\sexport\s
         KAMAL_RECORDED_AT=\"\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ\"\s
         KAMAL_PERFORMER=\"#{performer}\"\s


### PR DESCRIPTION
The ran ok on CI where we fall back to `whoami`, but failed locally where there was a git email set.