### PR TITLE
Integration test insecure registry

### DIFF
--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -29,8 +29,6 @@ services:
       context: docker/registry
     environment:
       - REGISTRY_HTTP_ADDR=0.0.0.0:4443
-      - REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt
-      - REGISTRY_HTTP_TLS_KEY=/certs/domain.key
     volumes:
       - shared:/shared
       - registry:/var/lib/registry/

--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -22,7 +22,6 @@ COPY app_with_roles/ app_with_roles/
 
 RUN rm -rf /root/.ssh
 RUN ln -s /shared/ssh /root/.ssh
-RUN mkdir -p /etc/docker/certs.d/registry:4443 && ln -s /shared/certs/domain.crt /etc/docker/certs.d/registry:4443/ca.crt
 
 RUN git config --global user.email "deployer@example.com"
 RUN git config --global user.name "Deployer"

--- a/test/integration/docker/deployer/boot.sh
+++ b/test/integration/docker/deployer/boot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-dockerd --max-concurrent-downloads 1 &
+dockerd --max-concurrent-downloads 1 --insecure-registry registry:4443 &
 
 exec sleep infinity

--- a/test/integration/docker/registry/boot.sh
+++ b/test/integration/docker/registry/boot.sh
@@ -1,5 +1,3 @@
 #!/bin/sh
 
-while [ ! -f /certs/domain.crt ]; do sleep 1; done
-
 exec /entrypoint.sh /etc/docker/registry/config.yml

--- a/test/integration/docker/shared/Dockerfile
+++ b/test/integration/docker/shared/Dockerfile
@@ -10,8 +10,6 @@ RUN mkdir ssh && \
 COPY registry-dns.conf .
 COPY boot.sh .
 
-RUN mkdir certs && openssl req -newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key   -x509 -days 365 -out certs/domain.crt   -subj '/CN=registry' -extensions EXT -config registry-dns.conf
-
 HEALTHCHECK --interval=1s CMD pgrep sleep
 
 CMD ["./boot.sh"]

--- a/test/integration/docker/vm/Dockerfile
+++ b/test/integration/docker/vm/Dockerfile
@@ -5,7 +5,6 @@ WORKDIR /work
 RUN apt-get update --fix-missing && apt-get -y install openssh-client openssh-server docker.io
 
 RUN mkdir /root/.ssh && ln -s /shared/ssh/id_rsa.pub /root/.ssh/authorized_keys
-RUN mkdir -p /etc/docker/certs.d/registry:4443 && ln -s /shared/certs/domain.crt /etc/docker/certs.d/registry:4443/ca.crt
 
 RUN echo "HOST_TOKEN=abcd" >> /etc/environment
 

--- a/test/integration/docker/vm/boot.sh
+++ b/test/integration/docker/vm/boot.sh
@@ -4,6 +4,6 @@ while [ ! -f /root/.ssh/authorized_keys ]; do echo "Waiting for ssh keys"; sleep
 
 service ssh restart
 
-dockerd --max-concurrent-downloads 1 &
+dockerd --max-concurrent-downloads 1 --insecure-registry registry:4443 &
 
 exec sleep infinity


### PR DESCRIPTION
The integrations tests use their own registry so avoid hitting docker hub rate limits.

This was using a self signed certificate but instead use `--insecure-registry` to let the docker daemon use HTTP.