### PR TITLE
Allow running detached app commands

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -75,8 +75,10 @@ class Kamal::Cli::App < Kamal::Cli::Base
   option :interactive, aliases: "-i", type: :boolean, default: false, desc: "Execute command over ssh for an interactive shell (use for console/bash)"
   option :reuse, type: :boolean, default: false, desc: "Reuse currently running container instead of starting a new one"
   option :env, aliases: "-e", type: :hash, desc: "Set environment variables for the command"
+  option :detach, type: :boolean, default: false, desc: "Execute command in a detached container"
   def exec(cmd)
     env = options[:env]
+    detach = options[:detach]
     case
     when options[:interactive] && options[:reuse]
       say "Get current version of running container...", :magenta unless options[:version]
@@ -118,7 +120,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
           roles.each do |role|
             execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on app version #{version}"), verbosity: :debug
-            puts_by_host host, capture_with_info(*KAMAL.app(role: role, host: host).execute_in_new_container(cmd, env: env))
+            puts_by_host host, capture_with_info(*KAMAL.app(role: role, host: host).execute_in_new_container(cmd, env: env, detach: detach))
           end
         end
       end

--- a/lib/kamal/commands/app/execution.rb
+++ b/lib/kamal/commands/app/execution.rb
@@ -7,9 +7,10 @@ module Kamal::Commands::App::Execution
       *command
   end
 
-  def execute_in_new_container(*command, interactive: false, env:)
+  def execute_in_new_container(*command, interactive: false, detach: false, env:)
     docker :run,
       ("-it" if interactive),
+      ("--detach" if detach),
       "--rm",
       *role&.env_args(host),
       *argumentize("--env", env),

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -247,6 +247,12 @@ class CliAppTest < CliTestCase
     end
   end
 
+  test "exec detach" do
+    run_command("exec", "--detach", "ruby -v").tap do |output|
+      assert_match "docker run --detach --rm --env-file .kamal/env/roles/app-web.env dhh/app:latest ruby -v", output
+    end
+  end
+
   test "exec with reuse" do
     run_command("exec", "--reuse", "ruby -v").tap do |output|
       assert_match "sh -c 'docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=role=web --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=role=web --filter status=running --filter status=restarting' | head -1 | while read line; do echo ${line#app-web-}; done", output # Get current version

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -214,6 +214,12 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command.execute_in_new_container("bin/rails", "db:setup", env: { "foo" => "bar" }).join(" ")
   end
 
+  test "execute in new detached container" do
+    assert_equal \
+      "docker run --detach --rm --env-file .kamal/env/roles/app-web.env --detach dhh/app:999 bin/rails db:setup",
+      new_command.execute_in_new_container("bin/rails", "db:setup", detach: true, env: {}).join(" ")
+  end
+
   test "execute in new container with tags" do
     @config[:servers] = [ { "1.1.1.1" => "tag1" } ]
     @config[:env]["tags"] = { "tag1" => { "ENV1" => "value1" } }


### PR DESCRIPTION
This is useful for long running rake tasks or [scripts](https://github.com/rails/rails/pull/52335) that can be run without having to keep an open connection to servers.

Example:
```sh
kamal app exec 'bin/rails db:seed' --detach
```