### PR TITLE
SSH: allow setting `config: false` to ignore local user `~/.ssh/config`

### DIFF
--- a/lib/kamal/configuration/docs/ssh.yml
+++ b/lib/kamal/configuration/docs/ssh.yml
@@ -64,3 +64,10 @@ ssh:
   # An array of strings, with each element of the array being
   # a raw private key in PEM format.
   key_data: [ "-----BEGIN OPENSSH PRIVATE KEY-----" ]
+
+  # Config
+  #
+  # Set to true to load the default OpenSSH config files (~/.ssh/config,
+  # /etc/ssh_config), to false ignore config files, or to a file path
+  # (or array of paths) to load specific configuration. Defaults to true.
+  config: true


### PR DESCRIPTION
Documents the existing `config` option so it can be set via Kamal config. Allows setting `config: false` to ignore users' `~/.ssh/config`.