### PR TITLE
Suppress health check progress bar

### DIFF
--- a/lib/kamal/configuration/healthcheck.rb
+++ b/lib/kamal/configuration/healthcheck.rb
@@ -58,6 +58,6 @@ class Kamal::Configuration::Healthcheck
 
   private
     def http_health_check
-      "curl -f #{URI.join("http://localhost:#{port}", path)} || exit 1" if path.present? || port.present?
+      "curl -fs #{URI.join("http://localhost:#{port}", path)} || exit 1" if path.present? || port.present?
     end
 end


### PR DESCRIPTION
Use `curl -s` option to suppress the curl progress bar in health check logs.

Log before change:

```json
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2024-08-21T11:52:00.657679683+02:00",
      "End": "2024-08-21T11:52:00.742591535+02:00",
      "ExitCode": 0,
      "Output": "  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current\n                                 Dload  Upload   Total   Spent    Left  Speed\n\r  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0\r100     7    0     7    0     0    306      0 --:--:-- --:--:-- --:--:--   318\nsuccess"
    }
  ]
}
```

After change:

```json
{
  "Status": "healthy",
  "FailingStreak": 0,
  "Log": [
    {
      "Start": "2024-08-21T12:15:44.48549569+02:00",
      "End": "2024-08-21T12:15:44.552755263+02:00",
      "ExitCode": 0,
      "Output": "success"
    }
  ]
}
```

Log obtained by running:

```sh
docker inspect --format='{{json .State.Health}}' <container-id> | jq .
```
