### PR TITLE
Add aliases to Kamal

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ PATH
       ed25519 (~> 1.2)
       net-ssh (~> 7.0)
       sshkit (>= 1.23.0, < 2.0)
-      thor (~> 1.2)
+      thor (~> 1.3)
       zeitwerk (~> 2.5)
 
 GEM

--- a/bin/docs
+++ b/bin/docs
@@ -17,6 +17,7 @@ end
 
 DOCS = {
   "accessory" => "Accessories",
+  "alias" => "Aliases",
   "boot" => "Booting",
   "builder" => "Builders",
   "configuration" => "Configuration overview",
@@ -67,26 +68,27 @@ class DocWriter
             output.puts
             place = :new_section
           elsif line =~ /^ *#/
-            generate_line(line, place: place)
+            generate_line(line, heading: place == :new_section)
             place = :in_section
           else
             output.puts "```yaml"
-            output.print line
+            output.puts line
             place = :in_yaml
           end
-        when :in_yaml
+        when :in_yaml, :in_empty_line_yaml
           if line =~ /^ *#/
             output.puts "```"
-            generate_line(line, place: :new_section)
+            generate_line(line, heading: place == :in_empty_line_yaml)
             place = :in_section
+          elsif line.empty?
+            place = :in_empty_line_yaml
           else
-            output.puts
-            output.print line
+            output.puts line
           end
         end
       end
 
-      output.puts "\n```" if place == :in_yaml
+      output.puts "```" if place == :in_yaml
     end
 
     def generate_header
@@ -98,7 +100,7 @@ class DocWriter
       output.puts
     end
 
-    def generate_line(line, place: :in_section)
+    def generate_line(line, heading: false)
       line = line.gsub(/^ *#\s?/, "")
 
       if line =~ /(.*)kamal docs ([a-z]*)(.*)/
@@ -109,7 +111,7 @@ class DocWriter
         line = "#{$1}[#{titlify($2.split("/").last)}](#{$2})#{$3}"
       end
 
-      if place == :new_section
+      if heading
         output.puts "## [#{line}](##{linkify(line)})"
       else
         output.puts line

--- a/kamal.gemspec
+++ b/kamal.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "activesupport", ">= 7.0"
   spec.add_dependency "sshkit", ">= 1.23.0", "< 2.0"
   spec.add_dependency "net-ssh", "~> 7.0"
-  spec.add_dependency "thor", "~> 1.2"
+  spec.add_dependency "thor", "~> 1.3"
   spec.add_dependency "dotenv", "~> 2.8"
   spec.add_dependency "zeitwerk", "~> 2.5"
   spec.add_dependency "ed25519", "~> 1.2"

--- a/lib/kamal/cli/alias/command.rb
+++ b/lib/kamal/cli/alias/command.rb
@@ -1,0 +1,9 @@
+class Kamal::Cli::Alias::Command < Thor::DynamicCommand
+  def run(instance, args = [])
+    if (_alias = KAMAL.config.aliases[name])
+      Kamal::Cli::Main.start(Shellwords.split(_alias.command) + ARGV[1..-1])
+    else
+      super
+    end
+  end
+end

--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -71,11 +71,12 @@ class Kamal::Cli::App < Kamal::Cli::Base
     end
   end
 
-  desc "exec [CMD]", "Execute a custom command on servers within the app container (use --help to show options)"
+  desc "exec [CMD...]", "Execute a custom command on servers within the app container (use --help to show options)"
   option :interactive, aliases: "-i", type: :boolean, default: false, desc: "Execute command over ssh for an interactive shell (use for console/bash)"
   option :reuse, type: :boolean, default: false, desc: "Reuse currently running container instead of starting a new one"
   option :env, aliases: "-e", type: :hash, desc: "Set environment variables for the command"
-  def exec(cmd)
+  def exec(*cmd)
+    cmd = Kamal::Utils.join_commands(cmd)
     env = options[:env]
     case
     when options[:interactive] && options[:reuse]

--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -1,7 +1,8 @@
 class Kamal::Cli::Server < Kamal::Cli::Base
   desc "exec", "Run a custom command on the server (use --help to show options)"
   option :interactive, type: :boolean, aliases: "-i", default: false, desc: "Run the command interactively (use for console/bash)"
-  def exec(cmd)
+  def exec(*cmd)
+    cmd = Kamal::Utils.join_commands(cmd)
     hosts = KAMAL.hosts | KAMAL.accessory_hosts
 
     case

--- a/lib/kamal/commander.rb
+++ b/lib/kamal/commander.rb
@@ -27,7 +27,11 @@ class Kamal::Commander
 
   def specific_primary!
     @specifics = nil
-    self.specific_hosts = [ config.primary_host ]
+    if specific_roles.present?
+      self.specific_hosts = [ specific_roles.first.primary_host ]
+    else
+      self.specific_hosts = [ config.primary_host ]
+    end
   end
 
   def specific_roles=(role_names)
@@ -111,6 +115,10 @@ class Kamal::Commander
 
   def traefik
     @traefik ||= Kamal::Commands::Traefik.new(config)
+  end
+
+  def alias(name)
+    config.aliases[name]
   end
 
 

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -11,7 +11,7 @@ class Kamal::Configuration
   delegate :argumentize, :optionize, to: Kamal::Utils
 
   attr_reader :destination, :raw_config
-  attr_reader :accessories, :boot, :builder, :env, :healthcheck, :logging, :traefik, :servers, :ssh, :sshkit, :registry
+  attr_reader :accessories, :aliases, :boot, :builder, :env, :healthcheck, :logging, :traefik, :servers, :ssh, :sshkit, :registry
 
   include Validation
 
@@ -54,6 +54,7 @@ class Kamal::Configuration
     @registry = Registry.new(config: self)
 
     @accessories = @raw_config.accessories&.keys&.collect { |name| Accessory.new(name, config: self) } || []
+    @aliases = @raw_config.aliases&.keys&.to_h { |name| [ name, Alias.new(name, config: self) ] } || {}
     @boot = Boot.new(config: self)
     @builder = Builder.new(config: self)
     @env = Env.new(config: @raw_config.env || {})

--- a/lib/kamal/configuration/alias.rb
+++ b/lib/kamal/configuration/alias.rb
@@ -1,0 +1,15 @@
+class Kamal::Configuration::Alias
+  include Kamal::Configuration::Validation
+
+  attr_reader :name, :command
+
+  def initialize(name, config:)
+    @name, @command = name.inquiry, config.raw_config["aliases"][name]
+
+    validate! \
+      command,
+      example: validation_yml["aliases"]["uname"],
+      context: "aliases/#{name}",
+      with: Kamal::Configuration::Validator::Alias
+  end
+end

--- a/lib/kamal/configuration/docs/alias.yml
+++ b/lib/kamal/configuration/docs/alias.yml
@@ -1,0 +1,26 @@
+# Aliases
+#
+# Aliases are shortcuts for Kamal commands.
+#
+# For example, for a Rails app, you might open a console with:
+#
+# ```shell
+# kamal app exec -i -r console "rails console"
+# ```
+#
+# By defining an alias, like this:
+aliases:
+  console: app exec -r console -i "rails console"
+# You can now open the console with:
+# ```shell
+# kamal console
+# ```
+
+# Configuring aliases
+#
+# Aliases are defined in the root config under the alias key
+#
+# Each alias is named and can only contain lowercase letters, numbers, dashes and underscores.
+
+aliases:
+  uname: app exec -p -q -r web "uname -a"

--- a/lib/kamal/configuration/docs/configuration.yml
+++ b/lib/kamal/configuration/docs/configuration.yml
@@ -166,3 +166,9 @@ healthcheck:
 # Docker logging configuration, see kamal docs logging
 logging:
   ...
+
+# Aliases
+#
+# Alias configuration, see kamal docs alias
+aliases:
+  ...

--- a/lib/kamal/configuration/validator.rb
+++ b/lib/kamal/configuration/validator.rb
@@ -13,32 +13,34 @@ class Kamal::Configuration::Validator
 
   private
     def validate_against_example!(validation_config, example)
-      validate_type! validation_config, Hash
+      validate_type! validation_config, example.class
 
-      check_unknown_keys! validation_config, example
+      if example.class == Hash
+        check_unknown_keys! validation_config, example
 
-      validation_config.each do |key, value|
-        next if extension?(key)
-        with_context(key) do
-          example_value = example[key]
+        validation_config.each do |key, value|
+          next if extension?(key)
+          with_context(key) do
+            example_value = example[key]
 
-          if example_value == "..."
-            validate_type! value, *(Array if key == :servers), Hash
-          elsif key == "hosts"
-            validate_servers! value
-          elsif example_value.is_a?(Array)
-            validate_array_of! value, example_value.first.class
-          elsif example_value.is_a?(Hash)
-            case key.to_s
-            when "options", "args"
-              validate_type! value, Hash
-            when "labels"
-              validate_hash_of! value, example_value.first[1].class
+            if example_value == "..."
+              validate_type! value, *(Array if key == :servers), Hash
+            elsif key == "hosts"
+              validate_servers! value
+            elsif example_value.is_a?(Array)
+              validate_array_of! value, example_value.first.class
+            elsif example_value.is_a?(Hash)
+              case key.to_s
+              when "options", "args"
+                validate_type! value, Hash
+              when "labels"
+                validate_hash_of! value, example_value.first[1].class
+              else
+                validate_against_example! value, example_value
+              end
             else
-              validate_against_example! value, example_value
+              validate_type! value, example_value.class
             end
-          else
-            validate_type! value, example_value.class
           end
         end
       end

--- a/lib/kamal/configuration/validator/alias.rb
+++ b/lib/kamal/configuration/validator/alias.rb
@@ -1,0 +1,15 @@
+class Kamal::Configuration::Validator::Alias < Kamal::Configuration::Validator
+  def validate!
+    super
+
+    name = context.delete_prefix("aliases/")
+
+    if name !~ /\A[a-z0-9_-]+\z/
+      error "Invalid alias name: '#{name}'. Must only contain lowercase letters, alphanumeric, hyphens and underscores."
+    end
+
+    if Kamal::Cli::Main.commands.include?(name)
+      error "Alias '#{name}' conflicts with a built-in command."
+    end
+  end
+end

--- a/lib/kamal/utils.rb
+++ b/lib/kamal/utils.rb
@@ -77,4 +77,8 @@ module Kamal::Utils
   def stable_sort!(elements, &block)
     elements.sort_by!.with_index { |element, index| [ block.call(element), index ] }
   end
+
+  def join_commands(commands)
+    commands.map(&:strip).join(" ")
+  end
 end

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -247,6 +247,12 @@ class CliAppTest < CliTestCase
     end
   end
 
+  test "exec separate arguments" do
+    run_command("exec", "ruby", " -v").tap do |output|
+      assert_match "docker run --rm --env-file .kamal/env/roles/app-web.env dhh/app:latest ruby -v", output
+    end
+  end
+
   test "exec with reuse" do
     run_command("exec", "--reuse", "ruby -v").tap do |output|
       assert_match "sh -c 'docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=role=web --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=role=web --filter status=running --filter status=restarting' | head -1 | while read line; do echo ${line#app-web-}; done", output # Get current version

--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -63,4 +63,12 @@ class CliTestCase < ActiveSupport::TestCase
 
       assert_match expected, output
     end
+
+    def with_argv(*argv)
+      old_argv = ARGV
+      ARGV.replace(*argv)
+      yield
+    ensure
+      ARGV.replace(old_argv)
+    end
 end

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -566,6 +566,13 @@ class CliMainTest < CliTestCase
     end
   end
 
+  test "append to command with an alias" do
+    run_command("rails", "db:migrate:status", config_file: "deploy_with_aliases").tap do |output|
+      assert_match "docker exec app-console-999 rails db:migrate:status on 1.1.1.5", output
+      assert_match "App Host: 1.1.1.5", output
+    end
+  end
+
   private
     def run_command(*command, config_file: "deploy_simple")
       with_argv([ *command, "-c", "test/fixtures/#{config_file}.yml" ]) do

--- a/test/cli/server_test.rb
+++ b/test/cli/server_test.rb
@@ -3,13 +3,27 @@ require_relative "cli_test_case"
 class CliServerTest < CliTestCase
   test "running a command with exec" do
     SSHKit::Backend::Abstract.any_instance.stubs(:capture)
-    .with("date", verbosity: 1)
-    .returns("Today")
+      .with("date", verbosity: 1)
+      .returns("Today")
 
     hosts = "1.1.1.1".."1.1.1.4"
     run_command("exec", "date").tap do |output|
       hosts.map do |host|
         assert_match "Running 'date' on #{hosts.to_a.join(', ')}...", output
+        assert_match "App Host: #{host}\nToday", output
+      end
+    end
+  end
+
+  test "running a command with exec multiple arguments" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture)
+      .with("date -j", verbosity: 1)
+      .returns("Today")
+
+    hosts = "1.1.1.1".."1.1.1.4"
+    run_command("exec", "date", "-j").tap do |output|
+      hosts.map do |host|
+        assert_match "Running 'date -j' on #{hosts.to_a.join(', ')}...", output
         assert_match "App Host: #{host}\nToday", output
       end
     end

--- a/test/fixtures/deploy_with_aliases.yml
+++ b/test/fixtures/deploy_with_aliases.yml
@@ -18,3 +18,4 @@ aliases:
   info: details
   console: app exec --reuse -p -r console "bin/console"
   exec: app exec --reuse -p -r console
+  rails: app exec --reuse -p -r console rails

--- a/test/fixtures/deploy_with_aliases.yml
+++ b/test/fixtures/deploy_with_aliases.yml
@@ -1,0 +1,20 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - 1.1.1.1
+    - 1.1.1.2
+  workers:
+    hosts:
+      - 1.1.1.3
+      - 1.1.1.4
+  console:
+    hosts:
+      - 1.1.1.5
+registry:
+  username: user
+  password: pw
+aliases:
+  info: details
+  console: app exec --reuse -p -r console "bin/console"
+  exec: app exec --reuse -p -r console

--- a/test/integration/docker/deployer/app/.kamal/hooks/pre-connect
+++ b/test/integration/docker/deployer/app/.kamal/hooks/pre-connect
@@ -1,8 +1,4 @@
 #!/bin/sh
 
 echo "About to lock..."
-if [ "$KAMAL_HOSTS" != "vm1,vm2" ]; then
-  echo "Expected hosts to be 'vm1,vm2', got $KAMAL_HOSTS"
-  exit 1
-fi
 mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/pre-connect

--- a/test/integration/docker/deployer/app_with_roles/.kamal/hooks/pre-connect
+++ b/test/integration/docker/deployer/app_with_roles/.kamal/hooks/pre-connect
@@ -1,8 +1,4 @@
 #!/bin/sh
 
 echo "About to lock..."
-if [ "$KAMAL_HOSTS" != "vm1,vm2,vm3" ]; then
-  echo "Expected hosts to be 'vm1,vm2,vm3', got $KAMAL_HOSTS"
-  exit 1
-fi
 mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/pre-connect

--- a/test/integration/docker/deployer/app_with_roles/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_roles/config/deploy.yml
@@ -37,3 +37,6 @@ accessories:
       - web
 stop_wait_time: 1
 readiness_delay: 0
+aliases:
+  whome: version
+  worker_hostname: app exec -r workers -q --reuse hostname

--- a/test/integration/docker/deployer/app_with_roles/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_roles/config/deploy.yml
@@ -40,3 +40,4 @@ readiness_delay: 0
 aliases:
   whome: version
   worker_hostname: app exec -r workers -q --reuse hostname
+  uname: server exec -q -p uname

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -93,6 +93,9 @@ class MainTest < IntegrationTest
 
     output = kamal :worker_hostname, capture: true
     assert_match /App Host: vm3\nvm3-[0-9a-f]{12}$/, output
+
+    output = kamal :uname, "-o", capture: true
+    assert_match "App Host: vm1\nGNU/Linux", output
   end
 
   test "setup and remove" do

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -82,6 +82,19 @@ class MainTest < IntegrationTest
     assert_equal({ "cmd"=>"wget -qO- http://localhost > /dev/null || exit 1", "interval"=>"1s", "max_attempts"=>3, "port"=>3000, "path"=>"/up", "cord"=>"/tmp/kamal-cord", "log_lines"=>50 }, config[:healthcheck])
   end
 
+  test "aliases" do
+    @app = "app_with_roles"
+
+    kamal :envify
+    kamal :deploy
+
+    output = kamal :whome, capture: true
+    assert_equal Kamal::VERSION, output
+
+    output = kamal :worker_hostname, capture: true
+    assert_match /App Host: vm3\nvm3-[0-9a-f]{12}$/, output
+  end
+
   test "setup and remove" do
     # Check remove completes when nothing has been setup yet
     kamal :remove, "-y"


### PR DESCRIPTION
Aliases are defined in the configuration file under the `aliases` key.

The configuration is a map of alias name to command. When we run the command the we just do a literal replacement of the alias with the string.

So if we have:

```yaml
aliases:
  console: app exec -r console -i --reuse "rails console"
```

Then running `kamal console -r workers` will run the command

```sh
$ kamal app exec -r console -i --reuse "rails console" -r workers
```

Because of the order Thor parses the arguments, this allows us to override the role from the alias command.

There might be cases where we need to munge the command a bit more but that would involve getting into Thor command parsing internals, which are complicated and possibly subject to change.

There's a chance that your aliases could conflict with future built-in commands, but there's not likely to be many of those and if it happens you'll get a validation error when you upgrade.

Thanks to @dhnaranjo for the idea!