### PR TITLE
Fix typos in "Environment variables" docs.

### DIFF
--- a/lib/kamal/configuration/docs/env.yml
+++ b/lib/kamal/configuration/docs/env.yml
@@ -1,7 +1,7 @@
 # Environment variables
 #
-# Environment variables can be set directory in the Kamal configuration or
-# for loaded from a .env file, for secrets that should not be checked into Git.
+# Environment variables can be set directly in the Kamal configuration or
+# loaded from a .env file, for secrets that should not be checked into Git.
 
 # Reading environment variables from the configuration
 #

--- a/lib/kamal/configuration/docs/healthcheck.yml
+++ b/lib/kamal/configuration/docs/healthcheck.yml
@@ -3,7 +3,7 @@
 # On roles that are running Traefik, Kamal will supply a default healthcheck to `docker run`.
 # For other roles, by default no healthcheck is supplied.
 #
-# If no healthcheck is supplied and the image does not define one, they we wait for the container
+# If no healthcheck is supplied and the image does not define one, then we wait for the container
 # to reach a running state and then pause for the readiness delay.
 #
 # The default healthcheck is `curl -f http://localhost:<port>/<path>`, so it assumes that `curl`


### PR DESCRIPTION
I found a couple of incorrect words in the "Environment variables" documentation. This PR fixes those.