### PR TITLE
Build and clean remote builders correctly

### DIFF
--- a/lib/kamal/cli/build.rb
+++ b/lib/kamal/cli/build.rb
@@ -32,10 +32,15 @@ class Kamal::Cli::Build < Kamal::Cli::Base
 
     run_locally do
       begin
-        execute *KAMAL.builder.buildx_inspect
+        execute *KAMAL.builder.inspect_builder
       rescue SSHKit::Command::Failed => e
-        if e.message =~ /(context not found|no builder|does not exist)/
+        if e.message =~ /(context not found|no builder|no compatible builder|does not exist)/
           warn "Missing compatible builder, so creating a new one first"
+          begin
+            cli.remove
+          rescue SSHKit::Command::Failed
+            raise unless e.message =~ /(context not found|no builder|does not exist)/
+          end
           cli.create
         else
           raise

--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -81,6 +81,10 @@ module Kamal::Commands
         [ :git, *([ "-C", path ] if path), *args.compact ]
       end
 
+      def grep(*args)
+        args.compact.unshift :grep
+      end
+
       def tags(**details)
         Kamal::Tags.from_config(config, **details)
       end

--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -1,7 +1,7 @@
 require "active_support/core_ext/string/filters"
 
 class Kamal::Commands::Builder < Kamal::Commands::Base
-  delegate :create, :remove, :push, :clean, :pull, :info, :buildx_inspect, :validate_image, :first_mirror, to: :target
+  delegate :create, :remove, :push, :clean, :pull, :info, :inspect_builder, :validate_image, :first_mirror, to: :target
   delegate :local?, :remote?, to: "config.builder"
 
   include Clone

--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -32,7 +32,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
       docker(:buildx, :ls)
   end
 
-  def buildx_inspect
+  def inspect_builder
     docker :buildx, :inspect, builder_name unless docker_driver?
   end
 
@@ -99,10 +99,6 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
 
     def builder_config
       config.builder
-    end
-
-    def context_host(builder_name)
-      docker :context, :inspect, builder_name, "--format", ENDPOINT_DOCKER_HOST_INSPECT
     end
 
     def platform_options(arches)

--- a/lib/kamal/commands/builder/hybrid.rb
+++ b/lib/kamal/commands/builder/hybrid.rb
@@ -16,6 +16,6 @@ class Kamal::Commands::Builder::Hybrid < Kamal::Commands::Builder::Remote
     end
 
     def append_remote_buildx
-      docker :buildx, :create, *platform_options(remote_arches), "--append", "--name", builder_name, builder_name
+      docker :buildx, :create, *platform_options(remote_arches), "--append", "--name", builder_name, remote_context_name
     end
 end

--- a/lib/kamal/commands/builder/remote.rb
+++ b/lib/kamal/commands/builder/remote.rb
@@ -17,21 +17,44 @@ class Kamal::Commands::Builder::Remote < Kamal::Commands::Builder::Base
       docker(:buildx, :ls)
   end
 
+  def inspect_builder
+    combine \
+      combine inspect_buildx, inspect_remote_context,
+      [ "(echo no compatible builder && exit 1)" ],
+      by: "||"
+  end
+
   private
     def builder_name
-      "kamal-remote-#{driver}-#{remote.gsub(/[^a-z0-9_-]/, "-")}"
+      "kamal-remote-#{remote.gsub(/[^a-z0-9_-]/, "-")}"
+    end
+
+    def remote_context_name
+      "#{builder_name}-context"
+    end
+
+    def inspect_buildx
+      pipe \
+        docker(:buildx, :inspect, builder_name),
+        grep("-q", "Endpoint:.*#{remote_context_name}")
+    end
+
+    def inspect_remote_context
+      pipe \
+        docker(:context, :inspect, remote_context_name, "--format", ENDPOINT_DOCKER_HOST_INSPECT),
+        grep("-xq", remote)
     end
 
     def create_remote_context
-      docker :context, :create, builder_name, "--description", "'#{builder_name} host'", "--docker", "'host=#{remote}'"
+      docker :context, :create, remote_context_name, "--description", "'#{builder_name} host'", "--docker", "'host=#{remote}'"
     end
 
     def remove_remote_context
-      docker :context, :rm, builder_name
+      docker :context, :rm, remote_context_name
     end
 
     def create_buildx
-      docker :buildx, :create, "--name", builder_name, builder_name
+      docker :buildx, :create, "--name", builder_name, remote_context_name
     end
 
     def remove_buildx

--- a/lib/kamal/commands/prune.rb
+++ b/lib/kamal/commands/prune.rb
@@ -9,7 +9,7 @@ class Kamal::Commands::Prune < Kamal::Commands::Base
   def tagged_images
     pipe \
       docker(:image, :ls, *service_filter, "--format", "'{{.ID}} {{.Repository}}:{{.Tag}}'"),
-      "grep -v -w \"#{active_image_list}\"",
+      grep("-v -w \"#{active_image_list}\""),
       "while read image tag; do docker rmi $tag; done"
   end
 

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -41,7 +41,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "arch" => [ "#{remote_arch}" ], "remote" => "ssh://app@host", "cache" => { "type" => "gha" } })
     assert_equal "remote", builder.name
     assert_equal \
-      "docker buildx build --push --platform linux/#{remote_arch} --builder kamal-remote-docker-container-ssh---app-host -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile .",
+      "docker buildx build --push --platform linux/#{remote_arch} --builder kamal-remote-ssh---app-host -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile .",
       builder.push.join(" ")
   end
 

--- a/test/fixtures/deploy_with_hybrid_builder.yml
+++ b/test/fixtures/deploy_with_hybrid_builder.yml
@@ -35,10 +35,8 @@ accessories:
 
 readiness_delay: 0
 
-ssh:
-  user: root
-  port: 22
-
 builder:
-  arch: <%= Kamal::Utils.docker_arch == "arm64" ? "amd64" : "arm64" %>
-  remote: ssh://app@1.1.1.5:2122
+  arch:
+    - arm64
+    - amd64
+  remote: ssh://app@1.1.1.5

--- a/test/fixtures/deploy_with_remote_builder.yml
+++ b/test/fixtures/deploy_with_remote_builder.yml
@@ -32,8 +32,6 @@ accessories:
     port: 6379
     directories:
       - data:/data
-builder:
-  arch: amd64
 
 readiness_delay: 0
 


### PR DESCRIPTION
Check that the builder and context match what we expect, and if not remove and re-create them.