### PR TITLE
Build both arches with remote multarch builder

### DIFF
--- a/lib/kamal/commands/builder/multiarch/remote.rb
+++ b/lib/kamal/commands/builder/multiarch/remote.rb
@@ -58,4 +58,8 @@ class Kamal::Commands::Builder::Multiarch::Remote < Kamal::Commands::Builder::Mu
     def remove_context(arch)
       docker :context, :rm, builder_name_with_arch(arch)
     end
+
+    def platform_names
+      "linux/#{local_arch},linux/#{remote_arch}"
+    end
 end

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -30,10 +30,10 @@ class CommandsBuilderTest < ActiveSupport::TestCase
   end
 
   test "target multiarch remote when local and remote is set" do
-    builder = new_builder_command(builder: { "local" => {}, "remote" => {}, "cache" => { "type" => "gha" } })
+    builder = new_builder_command(builder: { "local" => { "arch" => "arm64" }, "remote" => { "arch" => "amd64" }, "cache" => { "type" => "gha" } })
     assert_equal "multiarch/remote", builder.name
     assert_equal \
-      "docker buildx build --push --platform linux/amd64,linux/arm64 --builder kamal-app-multiarch-remote -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile .",
+      "docker buildx build --push --platform linux/arm64,linux/amd64 --builder kamal-app-multiarch-remote -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile .",
       builder.push.join(" ")
   end
 


### PR DESCRIPTION
When using the remote build arch builder, build with both arches.