### PR TITLE
Revert "Integration test insecure registry"

### DIFF
--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -29,6 +29,8 @@ services:
       context: docker/registry
     environment:
       - REGISTRY_HTTP_ADDR=0.0.0.0:4443
+      - REGISTRY_HTTP_TLS_CERTIFICATE=/certs/domain.crt
+      - REGISTRY_HTTP_TLS_KEY=/certs/domain.key
     volumes:
       - shared:/shared
       - registry:/var/lib/registry/

--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -22,6 +22,7 @@ COPY app_with_roles/ app_with_roles/
 
 RUN rm -rf /root/.ssh
 RUN ln -s /shared/ssh /root/.ssh
+RUN mkdir -p /etc/docker/certs.d/registry:4443 && ln -s /shared/certs/domain.crt /etc/docker/certs.d/registry:4443/ca.crt
 
 RUN git config --global user.email "deployer@example.com"
 RUN git config --global user.name "Deployer"

--- a/test/integration/docker/deployer/boot.sh
+++ b/test/integration/docker/deployer/boot.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-dockerd --max-concurrent-downloads 1 --insecure-registry registry:4443 &
+dockerd --max-concurrent-downloads 1 &
 
 exec sleep infinity

--- a/test/integration/docker/registry/boot.sh
+++ b/test/integration/docker/registry/boot.sh
@@ -1,3 +1,5 @@
 #!/bin/sh
 
+while [ ! -f /certs/domain.crt ]; do sleep 1; done
+
 exec /entrypoint.sh /etc/docker/registry/config.yml

--- a/test/integration/docker/shared/Dockerfile
+++ b/test/integration/docker/shared/Dockerfile
@@ -10,6 +10,8 @@ RUN mkdir ssh && \
 COPY registry-dns.conf .
 COPY boot.sh .
 
+RUN mkdir certs && openssl req -newkey rsa:4096 -nodes -sha256 -keyout certs/domain.key   -x509 -days 365 -out certs/domain.crt   -subj '/CN=registry' -extensions EXT -config registry-dns.conf
+
 HEALTHCHECK --interval=1s CMD pgrep sleep
 
 CMD ["./boot.sh"]

--- a/test/integration/docker/vm/Dockerfile
+++ b/test/integration/docker/vm/Dockerfile
@@ -5,6 +5,7 @@ WORKDIR /work
 RUN apt-get update --fix-missing && apt-get -y install openssh-client openssh-server docker.io
 
 RUN mkdir /root/.ssh && ln -s /shared/ssh/id_rsa.pub /root/.ssh/authorized_keys
+RUN mkdir -p /etc/docker/certs.d/registry:4443 && ln -s /shared/certs/domain.crt /etc/docker/certs.d/registry:4443/ca.crt
 
 RUN echo "HOST_TOKEN=abcd" >> /etc/environment
 

--- a/test/integration/docker/vm/boot.sh
+++ b/test/integration/docker/vm/boot.sh
@@ -4,6 +4,6 @@ while [ ! -f /root/.ssh/authorized_keys ]; do echo "Waiting for ssh keys"; sleep
 
 service ssh restart
 
-dockerd --max-concurrent-downloads 1 --insecure-registry registry:4443 &
+dockerd --max-concurrent-downloads 1 &
 
 exec sleep infinity


### PR DESCRIPTION
Reverts basecamp/kamal#903

Integrations tests seem to be a bit flaky without this, so let's just add it back.

```
  INFO [fc80c47a] Running docker login registry:4443 -u [REDACTED] -p [REDACTED] on vm2
  INFO [c2f2671f] Running docker login registry:4443 -u [REDACTED] -p [REDACTED] on vm1
  Finished all in 0.8 seconds
  ERROR (SSHKit::Command::Failed): Exceptions on 2 hosts:
Exception while executing on host vm1: docker exit status: 1
docker stdout: Nothing written
docker stderr: WARNING! Using --password via the CLI is insecure. Use --password-stdin.
time="2024-09-10T09:00:49Z" level=info msg="Error logging in to endpoint, trying next endpoint" error="Get \"https://registry:4443/v2/\": http: server gave HTTP response to HTTPS client"
Get "https://registry:4443/v2/": http: server gave HTTP response to HTTPS client

Exception while executing on host vm2: docker exit status: 1
docker stdout: Nothing written
docker stderr: WARNING! Using --password via the CLI is insecure. Use --password-stdin.
time="2024-09-10T09:00:49Z" level=info msg="Error logging in to endpoint, trying next endpoint" error="Get \"https://registry:4443/v2/\": http: server gave HTTP response to HTTPS client"
Get "https://registry:4443/v2/": http: server gave HTTP response to HTTPS client
```