### PR TITLE
Hide the 1password login error

### DIFF
--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -11,7 +11,7 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
     end
 
     def loggedin?(account)
-      `op account get --account #{account.shellescape}`
+      `op account get --account #{account.shellescape} 2> /dev/null`
       $?.success?
     end
 

--- a/test/secrets/one_password_adapter_test.rb
+++ b/test/secrets/one_password_adapter_test.rb
@@ -2,7 +2,7 @@ require "test_helper"
 
 class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   test "fetch" do
-    stub_ticks.with("op account get --account myaccount")
+    stub_ticks.with("op account get --account myaccount 2> /dev/null")
 
     stub_ticks
       .with("op item get myitem --vault \"myvault\" --fields \"label=section.SECRET1,label=section.SECRET2,label=section2.SECRET3\" --format \"json\" --account \"myaccount\"")
@@ -56,7 +56,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with multiple items" do
-    stub_ticks.with("op account get --account myaccount")
+    stub_ticks.with("op account get --account myaccount 2> /dev/null")
 
     stub_ticks
       .with("op item get myitem --vault \"myvault\" --fields \"label=section.SECRET1,label=section.SECRET2\" --format \"json\" --account \"myaccount\"")
@@ -115,7 +115,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with signin, no session" do
-    stub_ticks_with("op account get --account myaccount", succeed: false)
+    stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
     stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("")
 
     stub_ticks
@@ -132,7 +132,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with signin and session" do
-    stub_ticks_with("op account get --account myaccount", succeed: false)
+    stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
     stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("1234567890")
 
     stub_ticks


### PR DESCRIPTION
Avoid outputting this login error message, it wasn't an error and you don't need to follow those instructions.

```
[ERROR] 2024/09/11 11:57:08 You are not currently signed in. Please run `op signin --help` for instructions
```