### PR TITLE
Don't git ignore .kamal/secrets

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -152,12 +152,6 @@ class Kamal::Cli::Main < Kamal::Cli::Base
       FileUtils.mkdir_p secrets_file.dirname
       FileUtils.cp_r Pathname.new(File.expand_path("templates/secrets", __dir__)), secrets_file
       puts "Created .kamal/secrets file"
-
-      gitignore = Pathname.new(File.expand_path(".gitignore"))
-      if gitignore.exist? && !gitignore.read.include?(".kamal/secrets")
-        gitignore.open("a") { |f| f.puts "\n.kamal/secrets*" }
-        puts "Added .kamal/secrets* to .gitignore"
-      end
     end
 
     unless (hooks_dir = Pathname.new(File.expand_path(".kamal/hooks"))).exist?

--- a/lib/kamal/cli/templates/secrets
+++ b/lib/kamal/cli/templates/secrets
@@ -1,6 +1,16 @@
-# SECRETS=$(kamal secrets --adapter 1password --from Vault/Item Section1/KAMAL_REGISTRY_PASSWORD Section2/RAILS_MASTER_KEY)
-# KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
-# RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
+# WARNING: Avoid adding secrets directly to this file
+# If you must, then add `.kamal/secrets*` to your .gitignore file
 
-KAMAL_REGISTRY_PASSWORD=change-this
-RAILS_MASTER_KEY=another-env
+# Option 1: Read secrets from the environment
+KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
+
+# Option 2: Read secrets via a command
+# RAILS_MASTER_KEY=$(cat config/master.key)
+
+# Option 3: Read secrets via kamal secrets helpers
+# These will handle logging in and fetching the secrets in as few calls as possible
+# There are adapters for 1Password, LastPass + Bitwarden
+#
+# SECRETS=$(kamal secrets fetch --adapter 1password --account my-account --from MyVault/MyItem KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY)
+# KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD $SECRETS)
+# RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY $SECRETS)

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -388,12 +388,10 @@ class CliMainTest < CliTestCase
       run_command("init").tap do |output|
         assert_match "Created configuration file in config/deploy.yml", output
         assert_match "Created .kamal/secrets file", output
-        assert_match "Added .kamal/secrets* to .gitignore", output
       end
 
       assert_file "config/deploy.yml", "service: my-app"
-      assert_file ".kamal/secrets", "KAMAL_REGISTRY_PASSWORD=change-this"
-      assert_file ".gitignore", %r{\n.kamal/secrets\*\n}
+      assert_file ".kamal/secrets", "KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD"
     end
   end
 
@@ -528,7 +526,6 @@ class CliMainTest < CliTestCase
       Dir.mktmpdir do |tmpdir|
         Dir.chdir(tmpdir) do
           `git init`
-          `echo '/.bundle\n/log/*\n/tmp/*' > .gitignore`
           yield
         end
       end

--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -26,8 +26,8 @@ RUN mkdir -p /etc/docker/certs.d/registry:4443 && ln -s /shared/certs/domain.crt
 
 RUN git config --global user.email "deployer@example.com"
 RUN git config --global user.name "Deployer"
-RUN cd app && git init && echo ".env" >> .gitignore && git add . && git commit -am "Initial version"
-RUN cd app_with_roles && git init && echo ".env" >> .gitignore && git add . && git commit -am "Initial version"
+RUN cd app && git init && git add . && git commit -am "Initial version"
+RUN cd app_with_roles && git init && git add . && git commit -am "Initial version"
 
 HEALTHCHECK --interval=1s CMD pgrep sleep
 


### PR DESCRIPTION
Secrets should be interpolated at runtime so we do want the file in git.

But add a warning at the top to avoid adding secrets or git ignore the file if you do.

Also provide examples of the three options for interpolating secrets.