### PR TITLE
builder/cache/options: fix order of build args when using registry

### DIFF
--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -166,7 +166,7 @@ class Kamal::Configuration::Builder
     end
 
     def cache_to_config_for_registry
-      [ "type=registry", builder_config["cache"]&.fetch("options", nil), "ref=#{cache_image_ref}" ].compact.join(",")
+      [ "type=registry", "ref=#{cache_image_ref}", builder_config["cache"]&.fetch("options", nil) ].compact.join(",")
     end
 
     def repo_basename

--- a/test/configuration/builder_test.rb
+++ b/test/configuration/builder_test.rb
@@ -64,7 +64,7 @@ class ConfigurationBuilderTest < ActiveSupport::TestCase
     @deploy[:builder] = { "arch" => "amd64", "cache" => { "type" => "registry", "options" => "mode=max,image-manifest=true,oci-mediatypes=true" } }
 
     assert_equal "type=registry,ref=dhh/app-build-cache", config.builder.cache_from
-    assert_equal "type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=dhh/app-build-cache", config.builder.cache_to
+    assert_equal "type=registry,ref=dhh/app-build-cache,mode=max,image-manifest=true,oci-mediatypes=true", config.builder.cache_to
   end
 
   test "setting registry cache when using a custom registry" do
@@ -72,14 +72,14 @@ class ConfigurationBuilderTest < ActiveSupport::TestCase
     @deploy[:builder] = { "arch" => "amd64", "cache" => { "type" => "registry", "options" => "mode=max,image-manifest=true,oci-mediatypes=true" } }
 
     assert_equal "type=registry,ref=registry.example.com/dhh/app-build-cache", config.builder.cache_from
-    assert_equal "type=registry,mode=max,image-manifest=true,oci-mediatypes=true,ref=registry.example.com/dhh/app-build-cache", config.builder.cache_to
+    assert_equal "type=registry,ref=registry.example.com/dhh/app-build-cache,mode=max,image-manifest=true,oci-mediatypes=true", config.builder.cache_to
   end
 
   test "setting registry cache with image" do
     @deploy[:builder] = { "arch" => "amd64", "cache" => { "type" => "registry", "image" => "kamal", "options" => "mode=max" } }
 
     assert_equal "type=registry,ref=kamal", config.builder.cache_from
-    assert_equal "type=registry,mode=max,ref=kamal", config.builder.cache_to
+    assert_equal "type=registry,ref=kamal,mode=max", config.builder.cache_to
   end
 
   test "args" do


### PR DESCRIPTION
# Background

When using the build cache with the `registry` cache type the order of options given to `docker build --cache-to` appears to be significant and the `ref` option *MUST* come first, directly after the `type=registry` option.

The error looks like the following with the existing implementation that appends the `ref` option at the end of the `builder/cache/options`:

```sh
DEBUG [f3e45b60] Command: docker buildx build --push -t $ACCOUNT.dkr.ecr.us-east-2.amazonaws.com/$REPO:$SHA -t $ACCOUNT.dkr.ecr.us-east-2.amazonaws.com/$REPO:latest --cache-to type=registry,mode=max,compression=zstd,oci-mediatypes=true,image-manifest=true
,ref=$ACCOUNT.dkr.ecr.us-east-2.amazonaws.com/$REPO-build-cache --cache-from type=registry,ref=$ACCOUNT.dkr.ecr.us-east-2.amazonaws.com/$REPO-build-cache --label service="$APP" --file Dockerfile .
 DEBUG [f3e45b60] 	ERROR: "docker buildx build" requires exactly 1 argument.
 DEBUG [f3e45b60] 	See 'docker buildx build --help'.
 DEBUG [f3e45b60] 	
 DEBUG [f3e45b60] 	Usage:  docker buildx build [OPTIONS] PATH | URL | -
 DEBUG [f3e45b60] 	
 DEBUG [f3e45b60] 	Start a build
 DEBUG [f3e45b60] 	sh: 2: ,ref=$ACCOUNT.dkr.ecr.us-east-2.amazonaws.com/$REPO-build-cache: not found
  Finished all in 9.3 seconds
```

I can't just remove the other options because the `oci-mediatypes=true,image-manifest=true` options are required to use the build cache with ECR.