### PR TITLE
Fix /home/kamal-proxy/.config/kamal-proxy ownership

### DIFF
--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -167,7 +167,6 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
         stop
         remove_container
         remove_image
-        remove_host_directory
       end
     end
   end
@@ -188,16 +187,6 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
       on(KAMAL.proxy_hosts) do
         execute *KAMAL.auditor.record("Removed proxy image"), verbosity: :debug
         execute *KAMAL.proxy.remove_image
-      end
-    end
-  end
-
-  desc "remove_host_directory", "Remove proxy directory from servers", hide: true
-  def remove_host_directory
-    with_lock do
-      on(KAMAL.proxy_hosts) do
-        execute *KAMAL.auditor.record("Removed #{KAMAL.config.proxy_directory}"), verbosity: :debug
-        execute *KAMAL.proxy.remove_host_directory, raise_on_non_zero_exit: false
       end
     end
   end

--- a/lib/kamal/commands/proxy.rb
+++ b/lib/kamal/commands/proxy.rb
@@ -8,8 +8,7 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
       "--detach",
       "--restart", "unless-stopped",
       *config.proxy_publish_args,
-      "--volume", "/var/run/docker.sock:/var/run/docker.sock",
-      *config.proxy_config_volume.docker_args,
+      "--volume", "kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy",
       *config.logging_args,
       config.proxy_image
   end
@@ -55,10 +54,6 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
 
   def remove_image
     docker :image, :prune, "--all", "--force", "--filter", "label=org.opencontainers.image.title=kamal-proxy"
-  end
-
-  def remove_host_directory
-    remove_directory config.proxy_directory
   end
 
   def cleanup_traefik

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -14,7 +14,7 @@ class Kamal::Configuration
 
   include Validation
 
-  PROXY_MINIMUM_VERSION = "v0.3.0"
+  PROXY_MINIMUM_VERSION = "v0.4.0"
   PROXY_HTTP_PORT = 80
   PROXY_HTTPS_PORT = 443
 
@@ -216,10 +216,6 @@ class Kamal::Configuration
     File.join apps_directory, [ service, destination ].compact.join("-")
   end
 
-  def proxy_directory
-    File.join run_directory, "proxy"
-  end
-
   def env_directory
     File.join app_directory, "env"
   end
@@ -260,12 +256,6 @@ class Kamal::Configuration
 
   def proxy_container_name
     "kamal-proxy"
-  end
-
-  def proxy_config_volume
-    Kamal::Configuration::Volume.new \
-      host_path: File.join(proxy_directory, "config"),
-      container_path: "/home/kamal-proxy/.config/kamal-proxy"
   end
 
 

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -4,7 +4,7 @@ class CliProxyTest < CliTestCase
   test "boot" do
     run_command("boot").tap do |output|
       assert_match "docker login", output
-      assert_match "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume /var/run/docker.sock:/var/run/docker.sock --volume $(pwd)/.kamal/proxy/config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image}", output
+      assert_match "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image}", output
     end
   end
 
@@ -18,7 +18,7 @@ class CliProxyTest < CliTestCase
     exception = assert_raises do
       run_command("boot").tap do |output|
         assert_match "docker login", output
-        assert_match "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume /var/run/docker.sock:/var/run/docker.sock --volume $(pwd)/.kamal/proxy/config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image}", output
+        assert_match "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image}", output
       end
     end
 
@@ -36,7 +36,7 @@ class CliProxyTest < CliTestCase
 
     run_command("boot").tap do |output|
       assert_match "docker login", output
-      assert_match "docker container start kamal-proxy || docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume /var/run/docker.sock:/var/run/docker.sock --volume $(pwd)/.kamal/proxy/config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image}", output
+      assert_match "docker container start kamal-proxy || docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image}", output
     end
   ensure
     Thread.report_on_exception = false
@@ -57,13 +57,13 @@ class CliProxyTest < CliTestCase
       assert_match "docker container stop kamal-proxy on 1.1.1.1", output
       assert_match "Running docker container stop traefik ; docker container prune --force --filter label=org.opencontainers.image.title=Traefik && docker image prune --all --force --filter label=org.opencontainers.image.title=Traefik on 1.1.1.1", output
       assert_match "docker container prune --force --filter label=org.opencontainers.image.title=kamal-proxy on 1.1.1.1", output
-      assert_match "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume /var/run/docker.sock:/var/run/docker.sock --volume $(pwd)/.kamal/proxy/config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image} on 1.1.1.1", output
+      assert_match "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image} on 1.1.1.1", output
       assert_match "docker exec kamal-proxy kamal-proxy deploy app-web --target \"abcdefabcdef:80\" --deploy-timeout \"6s\" --drain-timeout \"30s\" --buffer-requests --buffer-responses --log-request-header \"Cache-Control\" --log-request-header \"Last-Modified\" --log-request-header \"User-Agent\" on 1.1.1.1", output
 
       assert_match "docker container stop kamal-proxy on 1.1.1.2", output
       assert_match "Running docker container stop traefik ; docker container prune --force --filter label=org.opencontainers.image.title=Traefik && docker image prune --all --force --filter label=org.opencontainers.image.title=Traefik on 1.1.1.2", output
       assert_match "docker container prune --force --filter label=org.opencontainers.image.title=kamal-proxy on 1.1.1.2", output
-      assert_match "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume /var/run/docker.sock:/var/run/docker.sock --volume $(pwd)/.kamal/proxy/config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image} on 1.1.1.2", output
+      assert_match "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image} on 1.1.1.2", output
       assert_match "docker exec kamal-proxy kamal-proxy deploy app-web --target \"abcdefabcdef:80\" --deploy-timeout \"6s\" --drain-timeout \"30s\" --buffer-requests --buffer-responses --log-request-header \"Cache-Control\" --log-request-header \"Last-Modified\" --log-request-header \"User-Agent\" on 1.1.1.2", output
     end
   end
@@ -136,7 +136,6 @@ class CliProxyTest < CliTestCase
       assert_match "/usr/bin/env ls .kamal/apps | wc -l", output
       assert_match "docker container prune --force --filter label=org.opencontainers.image.title=kamal-proxy", output
       assert_match "docker image prune --all --force --filter label=org.opencontainers.image.title=kamal-proxy", output
-      assert_match "/usr/bin/env rm -r .kamal/proxy", output
     end
   end
 
@@ -176,12 +175,6 @@ class CliProxyTest < CliTestCase
     end
   end
 
-  test "remove_host_directory" do
-    run_command("remove_host_directory").tap do |output|
-      assert_match "/usr/bin/env rm -r .kamal/proxy", output
-    end
-  end
-
   test "upgrade" do
     Object.any_instance.stubs(:sleep)
 
@@ -205,7 +198,7 @@ class CliProxyTest < CliTestCase
       assert_match "/usr/bin/env mkdir -p .kamal", output
       assert_match "docker network create kamal", output
       assert_match "docker login -u [REDACTED] -p [REDACTED]", output
-      assert_match "docker container start kamal-proxy || docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume /var/run/docker.sock:/var/run/docker.sock --volume $(pwd)/.kamal/proxy/config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" basecamp/kamal-proxy:#{Kamal::Configuration::PROXY_MINIMUM_VERSION}", output
+      assert_match "docker container start kamal-proxy || docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" basecamp/kamal-proxy:#{Kamal::Configuration::PROXY_MINIMUM_VERSION}", output
       assert_match "/usr/bin/env mkdir -p .kamal", output
       assert_match %r{docker rename app-web-latest app-web-latest_replaced_.*}, output
       assert_match "/usr/bin/env mkdir -p .kamal/apps/app/env/roles", output

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -15,13 +15,13 @@ class CommandsProxyTest < ActiveSupport::TestCase
 
   test "run" do
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume /var/run/docker.sock:/var/run/docker.sock --volume $(pwd)/.kamal/proxy/config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image}",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" basecamp/kamal-proxy:#{Kamal::Configuration::PROXY_MINIMUM_VERSION}",
       new_command.run.join(" ")
   end
 
   test "run with ports configured" do
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume /var/run/docker.sock:/var/run/docker.sock --volume $(pwd)/.kamal/proxy/config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image}",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" basecamp/kamal-proxy:#{Kamal::Configuration::PROXY_MINIMUM_VERSION}",
       new_command.run.join(" ")
   end
 
@@ -29,7 +29,7 @@ class CommandsProxyTest < ActiveSupport::TestCase
     @config.delete(:proxy)
 
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume /var/run/docker.sock:/var/run/docker.sock --volume $(pwd)/.kamal/proxy/config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" #{KAMAL.config.proxy_image}",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --log-opt max-size=\"10m\" basecamp/kamal-proxy:#{Kamal::Configuration::PROXY_MINIMUM_VERSION}",
       new_command.run.join(" ")
   end
 
@@ -37,7 +37,7 @@ class CommandsProxyTest < ActiveSupport::TestCase
     @config[:logging] = { "driver" => "local", "options" => { "max-size" => "100m", "max-file" => "3" } }
 
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume /var/run/docker.sock:/var/run/docker.sock --volume $(pwd)/.kamal/proxy/config:/home/kamal-proxy/.config/kamal-proxy --log-driver \"local\" --log-opt max-size=\"100m\" --log-opt max-file=\"3\" #{KAMAL.config.proxy_image}",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --publish 80:80 --publish 443:443 --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --log-driver \"local\" --log-opt max-size=\"100m\" --log-opt max-file=\"3\" basecamp/kamal-proxy:#{Kamal::Configuration::PROXY_MINIMUM_VERSION}",
       new_command.run.join(" ")
   end
 

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -153,10 +153,6 @@ class IntegrationTest < ActiveSupport::TestCase
       assert_directory_removed("./kamal/apps/#{@app}")
     end
 
-    def assert_proxy_directory_removed
-      assert_directory_removed("./kamal/proxy")
-    end
-
     def assert_directory_removed(directory)
       assert docker_compose("exec vm1 ls #{directory} | wc -l", capture: true).strip == "0"
     end

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -98,7 +98,6 @@ class MainTest < IntegrationTest
     kamal :remove, "-y"
     assert_no_images_or_containers
     assert_app_directory_removed
-    assert_proxy_directory_removed
   end
 
   private

--- a/test/integration/proxy_test.rb
+++ b/test/integration/proxy_test.rb
@@ -48,7 +48,6 @@ class ProxyTest < IntegrationTest
 
     kamal :proxy, :remove
     assert_proxy_not_running
-    assert_proxy_directory_removed
   end
 
   private


### PR DESCRIPTION
1. Update to kamal-proxy 0.4.0 which creates and chowns /home/kamal-proxy/.config/kamal-proxy to kamal-proxy
2. Use a docker volume rather than mapping in a directory, so docker keeps it owned by the correct user