### PR TITLE
Response timeout should be a number

### DIFF
--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -47,7 +47,7 @@ proxy:
   # Response timeout
   #
   # How long to wait for requests to complete before timing out, defaults to 30 seconds
-  response_timeout: 10s
+  response_timeout: 10
 
   # Healthcheck
   #


### PR DESCRIPTION
Kamal will append the `s` for the duration when talking to kamal-proxy so no need to have it in the config.