### PR TITLE
Added app_port example to the proxy section

### DIFF
--- a/lib/kamal/cli/templates/deploy.yml
+++ b/lib/kamal/cli/templates/deploy.yml
@@ -18,7 +18,7 @@ servers:
 proxy:
   ssl: true
   host: app.example.com
-  # Change the default application port from 80 to 3000. Useful for non-Thruster apps.
+  # kamal-proxy connects to your container over port 80, use `app_port` to specify a different port.
   # app_port: 3000
 
 # Credentials for your image host.

--- a/lib/kamal/cli/templates/deploy.yml
+++ b/lib/kamal/cli/templates/deploy.yml
@@ -18,6 +18,8 @@ servers:
 proxy:
   ssl: true
   host: app.example.com
+  # Change the default application port from 80 to 3000. Useful for non-Thruster apps.
+  # app_port: 3000
 
 # Credentials for your image host.
 registry:
@@ -32,7 +34,6 @@ registry:
 # Configure builder setup.
 builder:
   arch: amd64
-
 # Inject ENV variables into containers (secrets come from .kamal/secrets).
 #
 # env:

--- a/lib/kamal/cli/templates/deploy.yml
+++ b/lib/kamal/cli/templates/deploy.yml
@@ -34,6 +34,7 @@ registry:
 # Configure builder setup.
 builder:
   arch: amd64
+
 # Inject ENV variables into containers (secrets come from .kamal/secrets).
 #
 # env:


### PR DESCRIPTION
By default, all requests are forwarded to port 80 which is fine for Thruster-enabled applications, however Rails default is port 3000. I think it would be useful to have an example of how to change the port in the deploy.yml template.