### PR TITLE
Add provenance option

### DIFF
--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -6,7 +6,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   delegate :argumentize, to: Kamal::Utils
   delegate \
     :args, :secrets, :dockerfile, :target, :arches, :local_arches, :remote_arches, :remote,
-    :cache_from, :cache_to, :ssh, :driver, :docker_driver?,
+    :cache_from, :cache_to, :ssh, :provenance, :driver, :docker_driver?,
     to: :builder_config
 
   def clean
@@ -37,7 +37,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   end
 
   def build_options
-    [ *build_tags, *build_cache, *build_labels, *build_args, *build_secrets, *build_dockerfile, *build_target, *build_ssh ]
+    [ *build_tags, *build_cache, *build_labels, *build_args, *build_secrets, *build_dockerfile, *build_target, *build_ssh, *builder_provenance ]
   end
 
   def build_context
@@ -95,6 +95,10 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
 
     def build_ssh
       argumentize "--ssh", ssh if ssh.present?
+    end
+
+    def builder_provenance
+      argumentize "--provenance", provenance unless provenance.nil?
     end
 
     def builder_config

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -111,6 +111,10 @@ class Kamal::Configuration::Builder
     builder_config["ssh"]
   end
 
+  def provenance
+    builder_config["provenance"]
+  end
+
   def git_clone?
     Kamal::Git.used? && builder_config["context"].nil?
   end

--- a/lib/kamal/configuration/docs/builder.yml
+++ b/lib/kamal/configuration/docs/builder.yml
@@ -104,3 +104,9 @@ builder:
   #
   # The build driver to use, defaults to `docker-container`
   driver: docker
+
+  # Provenance
+  #
+  # It is used to configure provenance attestations for the build result.
+  # The value can also be a boolean to enable or disable provenance attestations.
+  provenance: mode=max

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -151,6 +151,13 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "push with provenance false" do
+    builder = new_builder_command(builder: { "provenance" => false })
+    assert_equal \
+      "docker buildx build --push --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --provenance false .",
+      builder.push.join(" ")
+  end
+
   test "mirror count" do
     command = new_builder_command
     assert_equal "docker info --format '{{index .RegistryConfig.Mirrors 0}}'", command.first_mirror.join(" ")

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -144,6 +144,13 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "push with provenance" do
+    builder = new_builder_command(builder: { "provenance" => "mode=max" })
+    assert_equal \
+      "docker buildx build --push --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --provenance mode=max .",
+      builder.push.join(" ")
+  end
+
   test "mirror count" do
     command = new_builder_command
     assert_equal "docker info --format '{{index .RegistryConfig.Mirrors 0}}'", command.first_mirror.join(" ")

--- a/test/configuration/builder_test.rb
+++ b/test/configuration/builder_test.rb
@@ -134,6 +134,16 @@ class ConfigurationBuilderTest < ActiveSupport::TestCase
     assert_equal "default=$SSH_AUTH_SOCK", config.builder.ssh
   end
 
+  test "provenance" do
+    assert_nil config.builder.provenance
+  end
+
+  test "setting provenance" do
+    @deploy[:builder]["provenance"] = "mode=max"
+
+    assert_equal "mode=max", config.builder.provenance
+  end
+
   test "local disabled but no remote set" do
     @deploy[:builder]["local"] = false
 


### PR DESCRIPTION
## Summary

This PR adds a `provenance` option in the `builder` config. You can use `provenance: false` to prevent the showing of `unknown/unknown` architecture on the container registry.

## Description

I am using Kamal with GitHub Container Registry, and it works very well. However, when I push images to the container registry, I noticed an `unknown/unknown` architecture listed on the registry. See the screenshot below.

![CleanShot 2024-09-25 at 19 04 38@2x](https://github.com/user-attachments/assets/e5ff8aba-2883-40ae-b012-6b87e808af74)

I believe this is an issue with the UI of the registry service, such as GitHub Container Registry. You can use `provenance: false` as a workaround to avoid the issue.

Once the PR is merged, you can use the following config to prevent pushing the `unknown/unknown` architecture.

```yaml
builder:
  arch: amd64
  provenance: false
```

## Related information

- https://github.com/orgs/community/discussions/45969
- https://github.com/docker/buildx/issues/1507
