### PR TITLE
Use `secrets-destination` instead of `secrets.destination`

### DIFF
--- a/lib/kamal/secrets.rb
+++ b/lib/kamal/secrets.rb
@@ -7,7 +7,7 @@ class Kamal::Secrets
 
   def initialize(destination: nil)
     @secrets_files = \
-      [ ".kamal/secrets-common", ".kamal/secrets#{(".#{destination}" if destination)}" ].select { |f| File.exist?(f) }
+      [ ".kamal/secrets-common", ".kamal/secrets#{("-#{destination}" if destination)}" ].select { |f| File.exist?(f) }
     @mutex = Mutex.new
   end
 

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -21,7 +21,7 @@ class SecretsTest < ActiveSupport::TestCase
   end
 
   test "destinations" do
-    with_test_secrets("secrets.dest" => "SECRET=DEF", "secrets" => "SECRET=ABC", "secrets-common" => "SECRET=GHI\nSECRET2=JKL") do
+    with_test_secrets("secrets-dest" => "SECRET=DEF", "secrets" => "SECRET=ABC", "secrets-common" => "SECRET=GHI\nSECRET2=JKL") do
       assert_equal "ABC", Kamal::Secrets.new["SECRET"]
       assert_equal "DEF", Kamal::Secrets.new(destination: "dest")["SECRET"]
       assert_equal "GHI", Kamal::Secrets.new(destination: "nodest")["SECRET"]


### PR DESCRIPTION
Fixes https://github.com/basecamp/kamal/issues/984.
Alternative fix: https://github.com/basecamp/kamal-site/pull/108.

### Details

Use `.kamal/secrets-destination` instead of `.kamal/secrets.destination`, as documented in the kamal-site docs:

- https://kamal-deploy.org/docs/configuration/environment-variables/#secrets
- https://kamal-deploy.org/docs/upgrading/secrets-changes