### PR TITLE
Rails 8 doesn't support Ruby 3.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
         gemfile:
           - Gemfile
           - gemfiles/rails_edge.gemfile
+        exclude:
+          - ruby-version: "3.1"
+            gemfile: gemfiles/rails_edge.gemfile
     name: ${{ format('Tests (Ruby {0})', matrix.ruby-version) }}
     runs-on: ubuntu-latest
     continue-on-error: true


### PR DESCRIPTION
Remove it from the build matrix as it's no longer a supported combination.