### PR TITLE
Fixed kamal-proxy remove command

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -68,7 +68,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
             version = capture_with_info(*app.current_running_version, raise_on_non_zero_exit: false).strip
             endpoint = capture_with_info(*app.container_id_for_version(version)).strip
             if endpoint.present?
-              execute *app.remove(target: endpoint), raise_on_non_zero_exit: false
+              execute *app.remove, raise_on_non_zero_exit: false
             end
           end
 

--- a/lib/kamal/commands/app/proxy.rb
+++ b/lib/kamal/commands/app/proxy.rb
@@ -5,8 +5,8 @@ module Kamal::Commands::App::Proxy
     proxy_exec :deploy, role.container_prefix, *role.proxy.deploy_command_args(target: target)
   end
 
-  def remove(target:)
-    proxy_exec :remove, role.container_prefix, *role.proxy.remove_command_args(target: target)
+  def remove
+    proxy_exec :remove, role.container_prefix
   end
 
   private

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -51,10 +51,6 @@ class Kamal::Configuration::Proxy
     optionize ({ target: "#{target}:#{app_port}" }).merge(deploy_options)
   end
 
-  def remove_command_args(target:)
-    optionize({ target: "#{target}:#{app_port}" })
-  end
-
   def merge(other)
     self.class.new config: config, proxy_config: proxy_config.deep_merge(other.proxy_config)
   end

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -121,8 +121,8 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "remove" do
     assert_equal \
-      "docker exec kamal-proxy kamal-proxy remove app-web --target \"172.1.0.2:80\"",
-      new_command.remove(target: "172.1.0.2").join(" ")
+      "docker exec kamal-proxy kamal-proxy remove app-web",
+      new_command.remove.join(" ")
   end
 
 

--- a/test/integration/app_test.rb
+++ b/test/integration/app_test.rb
@@ -48,7 +48,7 @@ class AppTest < IntegrationTest
 
     kamal :app, :remove
 
-    assert_app_is_down
+    assert_app_not_found
     assert_app_directory_removed
   end
 end

--- a/test/integration/app_test.rb
+++ b/test/integration/app_test.rb
@@ -8,7 +8,7 @@ class AppTest < IntegrationTest
 
     kamal :app, :stop
 
-    assert_app_is_down
+    assert_app_not_found
 
     kamal :app, :start
 

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -50,6 +50,12 @@ class IntegrationTest < ActiveSupport::TestCase
       assert_equal "502", response.code
     end
 
+    def assert_app_not_found
+      response = app_response
+      debug_response_code(response, "404")
+      assert_equal "404", response.code
+    end
+
     def assert_app_is_up(version: nil, app: @app)
       response = app_response(app: app)
       debug_response_code(response, "200")


### PR DESCRIPTION
`kamal-proxy remove` does not accept `--target` argument.

This caused the `1` exit status for `docker exec kamal-proxy kamal-proxy remove onetribe-web-production --target "4bff5dfb662d:80"` call (see screenshot).  

<img width="994" alt="Screenshot 2024-09-27 at 17 47 51" src="https://github.com/user-attachments/assets/0848b015-454c-4a60-9a87-5337466325f8">

Also, this PR fixes integration test that for some reason asserted the response to be HTTP 502 when the application is down and has been removed from kamal-proxy. 
