### PR TITLE
[bitwarden] ability to fetch all fields from an item

### DIFF
--- a/test/secrets/bitwarden_adapter_test.rb
+++ b/test/secrets/bitwarden_adapter_test.rb
@@ -44,6 +44,23 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     assert_equal expected_json, json
   end
 
+  test "fetch all with from" do
+    stub_ticks.with("bw --version 2> /dev/null")
+
+    stub_unlocked
+    stub_ticks.with("bw sync").returns("")
+    stub_noteitem_with_fields
+
+    json = JSON.parse(shellunescape(run_command("fetch", "mynotefields")))
+
+    expected_json = {
+      "mynotefields/field1"=>"secret1", "mynotefields/field2"=>"blam", "mynotefields/field3"=>"fewgrwjgk",
+      "mynotefields/field4"=>"auto"
+    }
+
+    assert_equal expected_json, json
+  end
+
   test "fetch with multiple items" do
     stub_ticks.with("bw --version 2> /dev/null")
 
@@ -237,7 +254,37 @@ class BitwardenAdapterTest < SecretAdapterTestCase
             "collectionIds":[]
           }
         JSON
-  end
+      end
+
+      def stub_noteitem_with_fields(session: nil)
+      stub_ticks
+        .with("#{"BW_SESSION=#{session} " if session}bw get item mynotefields")
+        .returns(<<~JSON)
+            {
+              "passwordHistory":null,
+              "revisionDate":"2024-09-28T09:07:27.461Z",
+              "creationDate":"2024-09-28T09:07:00.740Z",
+              "deletedDate":null,
+              "object":"item",
+              "id":"aaaaaaaa-cccc-eeee-0000-222222222222",
+              "organizationId":null,
+              "folderId":null,
+              "type":2,
+              "reprompt":0,
+              "name":"noteitem",
+              "notes":"NOTES",
+              "favorite":false,
+              "fields":[
+                {"name":"field1","value":"secret1","type":1,"linkedId":null},
+                {"name":"field2","value":"blam","type":1,"linkedId":null},
+                {"name":"field3","value":"fewgrwjgk","type":1,"linkedId":null},
+                {"name":"field4","value":"auto","type":1,"linkedId":null}
+              ],
+              "secureNote":{"type":0},
+              "collectionIds":[]
+            }
+          JSON
+      end
 
     def stub_myitem
       stub_ticks
@@ -260,7 +307,8 @@ class BitwardenAdapterTest < SecretAdapterTestCase
             "fields":[
               {"name":"field1","value":"secret1","type":1,"linkedId":null},
               {"name":"field2","value":"blam","type":1,"linkedId":null},
-              {"name":"field3","value":"fewgrwjgk","type":1,"linkedId":null}
+              {"name":"field3","value":"fewgrwjgk","type":1,"linkedId":null},
+              {"name":"field4","value":"auto","type":1,"linkedId":null}
             ],
             "login":{"fido2Credentials":[],"uris":[],"username":null,"password":null,"totp":null,"passwordRevisionDate":null},"collectionIds":[]
           }


### PR DESCRIPTION
Sometimes a projects has a lot of secrets (more than 10). And its cumbersome to write $(kama secrets fetch ...) with a lot of field names.

I want to be able to just fetch all the fields from a given item and then just use these with $(kamal extract NAME)

The result is that you can:
- create on item in bitwaren of type Secre note
- add custom fields to that item
- fetch all the custom fields into your .kamal/secrets like so:
```
SECRETS=$(kamal secrets fetch --adapter bitwarden SECRETS_ITEM)
SECRET_VAR=$(kamal secrets extract FIELD_NAME $SECRETS)
```