### PR TITLE
Backporting changes to the documentation committed directly to kamal-site

### DIFF
--- a/bin/docs
+++ b/bin/docs
@@ -70,6 +70,7 @@ class DocWriter
             generate_line(line, heading: place == :new_section)
             place = :in_section
           else
+            output.puts
             output.puts "```yaml"
             output.puts line
             place = :in_yaml
@@ -77,6 +78,7 @@ class DocWriter
         when :in_yaml, :in_empty_line_yaml
           if line =~ /^ *#/
             output.puts "```"
+            output.puts
             generate_line(line, heading: place == :in_empty_line_yaml)
             place = :in_section
           elsif line.empty?

--- a/bin/docs
+++ b/bin/docs
@@ -98,7 +98,6 @@ class DocWriter
       output.puts "---"
       output.puts
       output.puts heading
-      output.puts
     end
 
     def generate_line(line, heading: false)

--- a/bin/docs
+++ b/bin/docs
@@ -30,6 +30,7 @@ DOCS = {
   "ssh" => "SSH",
   "sshkit" => "SSHKit"
 }
+DOCS_PATH = "lib/kamal/configuration/docs"
 
 class DocWriter
   attr_reader :from_file, :to_file, :key, :heading, :body, :output, :in_yaml
@@ -94,6 +95,8 @@ class DocWriter
 
     def generate_header
       output.puts "---"
+      output.puts "# This file has been generated from the Kamal source, do not edit directly."
+      output.puts "# Find the source of this file at #{DOCS_PATH}/#{key}.yml in the Kamal repository."
       output.puts "title: #{heading[2..-1]}"
       output.puts "---"
       output.puts
@@ -131,7 +134,7 @@ class DocWriter
     end
 end
 
-from_dir = File.join(File.dirname(__FILE__), "../lib/kamal/configuration/docs")
+from_dir = File.join(File.dirname(__FILE__), "../#{DOCS_PATH}")
 to_dir = File.join(kamal_site_repo, "docs/configuration")
 Dir.glob("#{from_dir}/*") do |from_file|
   DocWriter.new(from_file, to_dir).write

--- a/bin/docs
+++ b/bin/docs
@@ -118,7 +118,11 @@ class DocWriter
     end
 
     def linkify(text)
-      text.downcase.gsub(" ", "-")
+      if text == "Configuration overview"
+        "overview"
+      else
+        text.downcase.gsub(" ", "-")
+      end
     end
 
     def titlify(text)

--- a/bin/docs
+++ b/bin/docs
@@ -129,7 +129,5 @@ end
 from_dir = File.join(File.dirname(__FILE__), "../lib/kamal/configuration/docs")
 to_dir = File.join(kamal_site_repo, "docs/configuration")
 Dir.glob("#{from_dir}/*") do |from_file|
-  key = File.basename(from_file, ".yml")
-
   DocWriter.new(from_file, to_dir).write
 end

--- a/lib/kamal/configuration/docs/accessory.yml
+++ b/lib/kamal/configuration/docs/accessory.yml
@@ -3,32 +3,32 @@
 # Accessories can be booted on a single host, a list of hosts, or on specific roles.
 # The hosts do not need to be defined in the Kamal servers configuration.
 #
-# Accessories are managed separately from the main service - they are not updated
-# when you deploy and they do not have zero-downtime deployments.
+# Accessories are managed separately from the main service — they are not updated
+# when you deploy, and they do not have zero-downtime deployments.
 #
 # Run `kamal accessory boot <accessory>` to boot an accessory.
 # See `kamal accessory --help` for more information.
 
 # Configuring accessories
 #
-# First define the accessory in the `accessories`
+# First, define the accessory in the `accessories`:
 accessories:
   mysql:
 
     # Service name
     #
-    # This is used in the service label and defaults to `<service>-<accessory>`
-    # where `<service>` is the main service name from the root configuration
+    # This is used in the service label and defaults to `<service>-<accessory>`,
+    # where `<service>` is the main service name from the root configuration:
     service: mysql
 
     # Image
     #
-    # The Docker image to use, prefix with a registry if not using Docker hub
+    # The Docker image to use, prefix it with a registry if not using Docker Hub:
     image: mysql:8.0
 
     # Accessory hosts
     #
-    # Specify one  of `host`, `hosts` or `roles`
+    # Specify one of `host`, `hosts`, or `roles`:
     host: mysql-db1
     hosts:
       - mysql-db1
@@ -38,12 +38,12 @@ accessories:
 
     # Custom command
     #
-    # You can set a custom command to run in the container, if you do not want to use the default
+    # You can set a custom command to run in the container if you do not want to use the default:
     cmd: "bin/mysqld"
 
     # Port mappings
     #
-    # See https://docs.docker.com/network/, especially note the warning about the security
+    # See https://docs.docker.com/network/, and especially note the warning about the security
     # implications of exposing ports publicly.
     port: "127.0.0.1:3306:3306"
 
@@ -52,20 +52,22 @@ accessories:
       app: myapp
 
     # Options
-    # These are passed to the Docker run command in the form `--<name> <value>`
+    #
+    # These are passed to the Docker run command in the form `--<name> <value>`:
     options:
       restart: always
       cpus: 2
 
     # Environment variables
-    # See kamal docs env for more information
+    #
+    # See kamal docs env for more information:
     env:
       ...
 
     # Copying files
     #
     # You can specify files to mount into the container.
-    # The format is `local:remote` where `local` is the path to the file on the local machine
+    # The format is `local:remote`, where `local` is the path to the file on the local machine
     # and `remote` is the path to the file in the container.
     #
     # They will be uploaded from the local repo to the host and then mounted.
@@ -78,13 +80,13 @@ accessories:
     # Directories
     #
     # You can specify directories to mount into the container. They will be created on the host
-    # before being mounted
+    # before being mounted:
     directories:
       - mysql-logs:/var/log/mysql
 
     # Volumes
     #
     # Any other volumes to mount, in addition to the files and directories.
-    # They are not created or copied before mounting
+    # They are not created or copied before mounting:
     volumes:
       - /path/to/mysql-logs:/var/log/mysql

--- a/lib/kamal/configuration/docs/alias.yml
+++ b/lib/kamal/configuration/docs/alias.yml
@@ -12,15 +12,15 @@
 aliases:
   console: app exec -r console -i "rails console"
 # You can now open the console with:
+#
 # ```shell
 # kamal console
 # ```
 
 # Configuring aliases
 #
-# Aliases are defined in the root config under the alias key
+# Aliases are defined in the root config under the alias key.
 #
-# Each alias is named and can only contain lowercase letters, numbers, dashes and underscores.
-
+# Each alias is named and can only contain lowercase letters, numbers, dashes, and underscores:
 aliases:
   uname: app exec -p -q -r web "uname -a"

--- a/lib/kamal/configuration/docs/boot.yml
+++ b/lib/kamal/configuration/docs/boot.yml
@@ -2,18 +2,18 @@
 #
 # When deploying to large numbers of hosts, you might prefer not to restart your services on every host at the same time.
 #
-# Kamal’s default is to boot new containers on all hosts in parallel. But you can control this with the boot configuration.
+# Kamal’s default is to boot new containers on all hosts in parallel. However, you can control this with the boot configuration.
 
 # Fixed group sizes
 #
-# Here we boot 2 hosts at a time with a 10 second gap between each group.
+# Here, we boot 2 hosts at a time with a 10-second gap between each group:
 boot:
   limit: 2
   wait: 10
 
 # Percentage of hosts
 #
-# Here we boot 25% of the hosts at a time with a 2 second gap between each group.
+# Here, we boot 25% of the hosts at a time with a 2-second gap between each group:
 boot:
   limit: 25%
   wait: 2

--- a/lib/kamal/configuration/docs/builder.yml
+++ b/lib/kamal/configuration/docs/builder.yml
@@ -1,8 +1,8 @@
 # Builder
 #
-# The builder configuration controls how the application is built with `docker build`
+# The builder configuration controls how the application is built with `docker build`.
 #
-# See https://kamal-deploy.org/docs/configuration/builder-examples/ for more information
+# See https://kamal-deploy.org/docs/configuration/builder-examples/ for more information.
 
 # Builder options
 #
@@ -11,15 +11,15 @@ builder:
 
   # Arch
   #
-  # The architectures to build for - you can set an array or just a single value.
+  # The architectures to build for — you can set an array or just a single value.
   #
-  # Allowed values are `amd64` and `arm64`
+  # Allowed values are `amd64` and `arm64`:
   arch:
     - amd64
 
   # Remote
   #
-  # The connection string for a remote builder. If supplied Kamal will use this
+  # The connection string for a remote builder. If supplied, Kamal will use this
   # for builds that do not match the local architecture of the deployment host.
   remote: ssh://docker@docker-builder
 
@@ -28,14 +28,14 @@ builder:
   # If set to false, Kamal will always use the remote builder even when building
   # the local architecture.
   #
-  # Defaults to true
+  # Defaults to true:
   local: true
 
   # Builder cache
   #
-  # The type must be either 'gha' or 'registry'
+  # The type must be either 'gha' or 'registry'.
   #
-  # The image is only used for registry cache. Not compatible with the docker driver
+  # The image is only used for registry cache and is not compatible with the Docker driver:
   cache:
     type: registry
     options: mode=max
@@ -43,25 +43,25 @@ builder:
 
   # Build context
   #
-  # If this is not set, then a local git clone of the repo is used.
+  # If this is not set, then a local Git clone of the repo is used.
   # This ensures a clean build with no uncommitted changes.
   #
-  # To use the local checkout instead you can set the context to `.`, or a path to another directory.
+  # To use the local checkout instead, you can set the context to `.`, or a path to another directory.
   context: .
 
   # Dockerfile
   #
-  # The Dockerfile to use for building, defaults to `Dockerfile`
+  # The Dockerfile to use for building, defaults to `Dockerfile`:
   dockerfile: Dockerfile.production
 
   # Build target
   #
-  # If not set, then the default target is used
+  # If not set, then the default target is used:
   target: production
 
-  # Build Arguments
+  # Build arguments
   #
-  # Any additional build arguments, passed to `docker build` with `--build-arg <key>=<value>`
+  # Any additional build arguments, passed to `docker build` with `--build-arg <key>=<value>`:
   args:
     ENVIRONMENT: production
 
@@ -74,33 +74,31 @@ builder:
 
   # Build secrets
   #
-  # Values are read from .kamal/secrets.
-  #
+  # Values are read from `.kamal/secrets`:
   secrets:
     - SECRET1
     - SECRET2
 
-  # Referencing Build Secrets
+  # Referencing build secrets
   #
   # ```shell
   # # Copy Gemfiles
   # COPY Gemfile Gemfile.lock ./
   #
   # # Install dependencies, including private repositories via access token
-  # # Then remove bundle cache with exposed GITHUB_TOKEN)
+  # # Then remove bundle cache with exposed GITHUB_TOKEN
   # RUN --mount=type=secret,id=GITHUB_TOKEN \
   #   BUNDLE_GITHUB__COM=x-access-token:$(cat /run/secrets/GITHUB_TOKEN) \
   #   bundle install && \
   #   rm -rf /usr/local/bundle/cache
   # ```
 
-
   # SSH
   #
-  # SSH agent socket or keys to expose to the build
+  # SSH agent socket or keys to expose to the build:
   ssh: default=$SSH_AUTH_SOCK
 
   # Driver
   #
-  # The build driver to use, defaults to `docker-container`
+  # The build driver to use, defaults to `docker-container`:
   driver: docker

--- a/lib/kamal/configuration/docs/configuration.yml
+++ b/lib/kamal/configuration/docs/configuration.yml
@@ -1,14 +1,13 @@
 # Kamal Configuration
 #
-# Configuration is read from the `config/deploy.yml`
-#
+# Configuration is read from the `config/deploy.yml`.
 
 # Destinations
 #
 # When running commands, you can specify a destination with the `-d` flag,
-# e.g. `kamal deploy -d staging`
+# e.g., `kamal deploy -d staging`.
 #
-# In this case the configuration will also be read from `config/deploy.staging.yml`
+# In this case, the configuration will also be read from `config/deploy.staging.yml`
 # and merged with the base configuration.
 
 # Extensions
@@ -18,10 +17,11 @@
 # However, you might want to declare a configuration block using YAML anchors
 # and aliases to avoid repetition.
 #
-# You can use prefix a configuration section with `x-` to indicate that it is an
+# You can prefix a configuration section with `x-` to indicate that it is an
 # extension. Kamal will ignore the extension and not raise an error.
 
 # The service name
+#
 # This is a required value. It is used as the container name prefix.
 service: myapp
 
@@ -32,147 +32,147 @@ image: my-image
 
 # Labels
 #
-# Additional labels to add to the container
+# Additional labels to add to the container:
 labels:
   my-label: my-value
 
 # Volumes
 #
-# Additional volumes to mount into the container
+# Additional volumes to mount into the container:
 volumes:
   - /path/on/host:/path/in/container:ro
 
 # Registry
 #
-# The Docker registry configuration, see kamal docs registry
+# The Docker registry configuration, see kamal docs registry:
 registry:
   ...
 
 # Servers
 #
-# The servers to deploy to, optionally with custom roles, see kamal docs servers
+# The servers to deploy to, optionally with custom roles, see kamal docs servers:
 servers:
   ...
 
 # Environment variables
 #
-# See kamal docs env
+# See kamal docs env:
 env:
   ...
 
-# Asset Path
+# Asset path
 #
-# Used for asset bridging across deployments, default to `nil`
+# Used for asset bridging across deployments, default to `nil`.
 #
 # If there are changes to CSS or JS files, we may get requests
-# for the old versions on the new container and vice-versa.
+# for the old versions on the new container, and vice versa.
 #
-# To avoid 404s we can specify an asset path.
+# To avoid 404s, we can specify an asset path.
 # Kamal will replace that path in the container with a mapped
 # volume containing both sets of files.
 # This requires that file names change when the contents change
-# (e.g. by including a hash of the contents in the name).
+# (e.g., by including a hash of the contents in the name).
 #
 # To configure this, set the path to the assets:
 asset_path: /path/to/assets
 
 # Hooks path
 #
-# Path to hooks, defaults to `.kamal/hooks`
-# See https://kamal-deploy.org/docs/hooks for more information
+# Path to hooks, defaults to `.kamal/hooks`.
+# See https://kamal-deploy.org/docs/hooks for more information:
 hooks_path: /user_home/kamal/hooks
 
 # Require destinations
 #
-# Whether deployments require a destination to be specified, defaults to `false`
+# Whether deployments require a destination to be specified, defaults to `false`:
 require_destination: true
 
 # Primary role
 #
-# This defaults to `web`, but if you have no web role, you can change this
+# This defaults to `web`, but if you have no web role, you can change this:
 primary_role: workers
 
 # Allowing empty roles
 #
-# Whether roles with no servers are allowed. Defaults to `false`.
+# Whether roles with no servers are allowed. Defaults to `false`:
 allow_empty_roles: false
 
 # Retain containers
 #
-# How many old containers and images we retain, defaults to 5
+# How many old containers and images we retain, defaults to 5:
 retain_containers: 3
 
 # Minimum version
 #
-# The minimum version of Kamal required to deploy this configuration, defaults to nil
+# The minimum version of Kamal required to deploy this configuration, defaults to `nil`:
 minimum_version: 1.3.0
 
 # Readiness delay
 #
-# Seconds to wait for a container to boot after is running, default 7
+# Seconds to wait for a container to boot after it is running, default 7.
 #
-# This only applies to containers that do not run a proxy or specify a healthcheck
+# This only applies to containers that do not run a proxy or specify a healthcheck:
 readiness_delay: 4
 
 # Deploy timeout
 #
-# How long to wait for a container to become ready, default 30
+# How long to wait for a container to become ready, default 30:
 deploy_timeout: 10
 
 # Drain timeout
 #
-# How long to wait for a containers to drain, default 30
+# How long to wait for a container to drain, default 30:
 drain_timeout: 10
 
 # Run directory
 #
-# Directory to store kamal runtime files in on the host, default `.kamal`
+# Directory to store kamal runtime files in on the host, default `.kamal`:
 run_directory: /etc/kamal
 
 # SSH options
 #
-# See kamal docs ssh
+# See kamal docs ssh:
 ssh:
   ...
 
 # Builder options
 #
-# See kamal docs builder
+# See kamal docs builder:
 builder:
   ...
 
 # Accessories
 #
-# Additionals services to run in Docker, see kamal docs accessory
+# Additional services to run in Docker, see kamal docs accessory:
 accessories:
   ...
 
 # Proxy
 #
-# Configuration for kamal-proxy, see kamal docs proxy
+# Configuration for kamal-proxy, see kamal docs proxy:
 proxy:
   ...
 
 # SSHKit
 #
-# See kamal docs sshkit
+# See kamal docs sshkit:
 sshkit:
   ...
 
 # Boot options
 #
-# See kamal docs boot
+# See kamal docs boot:
 boot:
   ...
 
 # Logging
 #
-# Docker logging configuration, see kamal docs logging
+# Docker logging configuration, see kamal docs logging:
 logging:
   ...
 
 # Aliases
 #
-# Alias configuration, see kamal docs alias
+# Alias configuration, see kamal docs alias:
 aliases:
   ...

--- a/lib/kamal/configuration/docs/env.yml
+++ b/lib/kamal/configuration/docs/env.yml
@@ -1,13 +1,13 @@
 # Environment variables
 #
 # Environment variables can be set directly in the Kamal configuration or
-# read from .kamal/secrets.
+# read from `.kamal/secrets`.
 
 # Reading environment variables from the configuration
 #
 # Environment variables can be set directly in the configuration file.
 #
-# These are passed to the docker run command when deploying.
+# These are passed to the `docker run` command when deploying.
 env:
   DATABASE_HOST: mysql-db1
   DATABASE_PORT: 3306
@@ -16,7 +16,7 @@ env:
 #
 # Kamal uses dotenv to automatically load environment variables set in the `.kamal/secrets` file.
 #
-# If you are using destinations, secrets will instead be read from `.kamal/secrets-<DESTINATION>` if
+# If you are using destinations, secrets will instead be read from `.kamal/secrets.<DESTINATION>` if
 # it exists.
 #
 # Common secrets across all destinations can be set in `.kamal/secrets-common`.
@@ -24,26 +24,27 @@ env:
 # This file can be used to set variables like `KAMAL_REGISTRY_PASSWORD` or database passwords.
 # You can use variable or command substitution in the secrets file.
 #
-# ```
+# ```shell
 # KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
 # RAILS_MASTER_KEY=$(cat config/master.key)
 # ```
 #
-# You can also use [secret helpers](../commands/secrets) for some common password managers.
-# ```
+# You can also use [secret helpers](../../commands/secrets) for some common password managers.
+#
+# ```shell
 # SECRETS=$(kamal secrets fetch ...)
 #
 # REGISTRY_PASSWORD=$(kamal secrets extract REGISTRY_PASSWORD $SECRETS)
 # DB_PASSWORD=$(kamal secrets extract DB_PASSWORD $SECRETS)
 # ```
 #
-# If you store secrets directly in .kamal/secrets, ensure that it is not checked into version control.
+# If you store secrets directly in `.kamal/secrets`, ensure that it is not checked into version control.
 #
-# To pass the secrets you should list them under the `secret` key. When you do this the
+# To pass the secrets, you should list them under the `secret` key. When you do this, the
 # other variables need to be moved under the `clear` key.
 #
-# Unlike clear values, secrets are not passed directly to the container,
-# but are stored in an env file on the host
+# Unlike clear values, secrets are not passed directly to the container
+# but are stored in an env file on the host:
 env:
   clear:
     DB_USER: app
@@ -55,7 +56,7 @@ env:
 # Tags are used to add extra env variables to specific hosts.
 # See kamal docs servers for how to tag hosts.
 #
-# Tags are only allowed in the top level env configuration (i.e not under a role specific env).
+# Tags are only allowed in the top-level env configuration (i.e., not under a role-specific env).
 #
 # The env variables can be specified with secret and clear values as explained above.
 env:

--- a/lib/kamal/configuration/docs/logging.yml
+++ b/lib/kamal/configuration/docs/logging.yml
@@ -6,16 +6,16 @@
 #
 # These go under the logging key in the configuration file.
 #
-# This can be specified in the root level or for a specific role.
+# This can be specified at the root level or for a specific role.
 logging:
 
   # Driver
   #
-  # The logging driver to use, passed to Docker via `--log-driver`
+  # The logging driver to use, passed to Docker via `--log-driver`:
   driver: json-file
 
   # Options
   #
-  # Any logging options to pass to the driver, passed to Docker via `--log-opt`
+  # Any logging options to pass to the driver, passed to Docker via `--log-opt`:
   options:
     max-size: 100m

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -5,16 +5,16 @@
 # application container.
 #
 # The proxy is configured in the root configuration under `proxy`. These are
-# options that are set when deploying the application, not when booting the proxy
+# options that are set when deploying the application, not when booting the proxy.
 #
-# They are application specific, so are not shared when multiple applications
+# They are application-specific, so they are not shared when multiple applications
 # run on the same proxy.
 #
-# The proxy is enabled by default on the primary role, but can be disabled by
+# The proxy is enabled by default on the primary role but can be disabled by
 # setting `proxy: false`.
 #
-# It is disabled by default on all other roles, but can be enabled by setting
-# `proxy: true`, or providing a proxy configuration.
+# It is disabled by default on all other roles but can be enabled by setting
+# `proxy: true` or providing a proxy configuration.
 proxy:
 
   # Host
@@ -25,34 +25,36 @@ proxy:
   # If no hosts are set, then all requests will be forwarded, except for matching
   # requests for other apps deployed on that server that do have a host set.
   host: foo.example.com
+  # If multiple hosts are needed, these can be specified by comma-separating the hosts.
+  host: foo.example.com,bar.example.com
 
   # App port
   #
-  # The port the application container is exposed on
+  # The port the application container is exposed on.
   #
-  # Defaults to 80
+  # Defaults to 80:
   app_port: 3000
 
   # SSL
   #
   # kamal-proxy can provide automatic HTTPS for your application via Let's Encrypt.
   #
-  # This requires that we are deploying to a one server and the host option is set.
-  # The host value must point to the server we are deploying to and port 443 must be
+  # This requires that we are deploying to one server and the host option is set.
+  # The host value must point to the server we are deploying to, and port 443 must be
   # open for the Let's Encrypt challenge to succeed.
   #
-  # Defaults to false
+  # Defaults to `false`:
   ssl: true
 
   # Response timeout
   #
-  # How long to wait for requests to complete before timing out, defaults to 30 seconds
+  # How long to wait for requests to complete before timing out, defaults to 30 seconds:
   response_timeout: 10
 
   # Healthcheck
   #
-  # When deploying, the proxy will by default hit /up once every second until we hit
-  # the deploy timeout, with a 5 second timeout for each request.
+  # When deploying, the proxy will by default hit `/up` once every second until we hit
+  # the deploy timeout, with a 5-second timeout for each request.
   #
   # Once the app is up, the proxy will stop hitting the healthcheck endpoint.
   healthcheck:
@@ -62,12 +64,12 @@ proxy:
 
   # Buffering
   #
-  # Whether to buffer request and response bodies in the proxy
+  # Whether to buffer request and response bodies in the proxy.
   #
-  # By default buffering is enabled with a max request body size of 1GB and no limit
+  # By default, buffering is enabled with a max request body size of 1GB and no limit
   # for response size.
   #
-  # You can also set the memory limit for buffering, which defaults to 1MB, anything
+  # You can also set the memory limit for buffering, which defaults to 1MB; anything
   # larger than that is written to disk.
   buffering:
     requests: true
@@ -78,9 +80,9 @@ proxy:
 
   # Logging
   #
-  # Configure request logging for the proxy
+  # Configure request logging for the proxy.
   # You can specify request and response headers to log.
-  # By default, Cache-Control, Last-Modified and User-Agent request headers are logged
+  # By default, `Cache-Control`, `Last-Modified`, and `User-Agent` request headers are logged:
   logging:
     request_headers:
       - Cache-Control
@@ -91,10 +93,10 @@ proxy:
 
   # Forward headers
   #
-  # Whether to forward the X-Forwarded-For and X-Forwarded-Proto headers.
+  # Whether to forward the `X-Forwarded-For` and `X-Forwarded-Proto` headers.
   #
-  # If you are behind a trusted proxy, you can set this to true to forward the headers.
+  # If you are behind a trusted proxy, you can set this to `true` to forward the headers.
   #
-  # By default kamal-proxy will not forward the headers the ssl option is set to true, and
-  # will forward them if it is set to false.
+  # By default, kamal-proxy will not forward the headers if the `ssl` option is set to `true`, and
+  # will forward them if it is set to `false`.
   forward_headers: true

--- a/lib/kamal/configuration/docs/registry.yml
+++ b/lib/kamal/configuration/docs/registry.yml
@@ -1,10 +1,9 @@
 # Registry
 #
-# The default registry is Docker Hub, but you can change it using registry/server:
+# The default registry is Docker Hub, but you can change it using `registry/server`.
 #
-# A reference to secret (in this case DOCKER_REGISTRY_TOKEN) will look up the secret
-# in the local environment.
-
+# A reference to a secret (in this case, `DOCKER_REGISTRY_TOKEN`) will look up the secret
+# in the local environment:
 registry:
   server: registry.digitalocean.com
   username:
@@ -13,30 +12,31 @@ registry:
     - DOCKER_REGISTRY_TOKEN
 
 # Using AWS ECR as the container registry
-# You will need to have the aws CLI installed locally for this to work.
-# AWS ECR’s access token is only valid for 12hrs. In order to not have to manually regenerate the token every time, you can use ERB in the deploy.yml file to shell out to the aws cli command, and obtain the token:
-
+#
+# You will need to have the AWS CLI installed locally for this to work.
+# AWS ECR’s access token is only valid for 12 hours. In order to avoid having to manually regenerate the token every time, you can use ERB in the `deploy.yml` file to shell out to the AWS CLI command and obtain the token:
 registry:
   server: <your aws account id>.dkr.ecr.<your aws region id>.amazonaws.com
   username: AWS
   password: <%= %x(aws ecr get-login-password) %>
 
 # Using GCP Artifact Registry as the container registry
-# To sign into Artifact Registry, you would need to
+#
+# To sign into Artifact Registry, you need to
 # [create a service account](https://cloud.google.com/iam/docs/service-accounts-create#creating)
 # and [set up roles and permissions](https://cloud.google.com/artifact-registry/docs/access-control#permissions).
-# Normally, assigning a roles/artifactregistry.writer role should be sufficient.
+# Normally, assigning the `roles/artifactregistry.writer` role should be sufficient.
 #
 # Once the service account is ready, you need to generate and download a JSON key and base64 encode it:
 #
 # ```shell
-# base64 -i /path/to/key.json | tr -d "\\n")
+# base64 -i /path/to/key.json | tr -d "\\n"
 # ```
-# You'll then need to set the KAMAL_REGISTRY_PASSWORD secret to that value.
 #
-# Use the env variable as password along with _json_key_base64 as username.
+# You'll then need to set the `KAMAL_REGISTRY_PASSWORD` secret to that value.
+#
+# Use the environment variable as the password along with `_json_key_base64` as the username.
 # Here’s the final configuration:
-
 registry:
   server: <your registry region>-docker.pkg.dev
   username: _json_key_base64
@@ -46,6 +46,7 @@ registry:
 # Validating the configuration
 #
 # You can validate the configuration by running:
+#
 # ```shell
 # kamal registry login
 # ```

--- a/lib/kamal/configuration/docs/role.yml
+++ b/lib/kamal/configuration/docs/role.yml
@@ -1,22 +1,21 @@
 # Roles
 #
 # Roles are used to configure different types of servers in the deployment.
-# The most common use for this is to run a web servers and job servers.
+# The most common use for this is to run web servers and job servers.
 #
 # Kamal expects there to be a `web` role, unless you set a different `primary_role`
 # in the root configuration.
 
 # Role configuration
 #
-# Roles are specified under the servers key
+# Roles are specified under the servers key:
 servers:
 
   # Simple role configuration
   #
+  # This can be a list of hosts if you don't need custom configuration for the role.
   #
-  # This can be a list of hosts, if you don't need custom configuration for the role.
-  #
-  # You can set tags on the hosts for custom env variables (see kamal docs env)
+  # You can set tags on the hosts for custom env variables (see kamal docs env):
   web:
     - 172.1.0.1
     - 172.1.0.2: experiment1
@@ -24,16 +23,16 @@ servers:
 
   # Custom role configuration
   #
-  # When there are other options to set, the list of hosts goes under the `hosts` key
+  # When there are other options to set, the list of hosts goes under the `hosts` key.
   #
-  # By default only the primary role uses a proxy.
+  # By default, only the primary role uses a proxy.
   #
-  # For other roles, you can set it to `proxy: true` enable it and inherit the root proxy
+  # For other roles, you can set it to `proxy: true` to enable it and inherit the root proxy
   # configuration or provide a map of options to override the root configuration.
   #
   # For the primary role, you can set `proxy: false` to disable the proxy.
   #
-  # You can also set a custom cmd to run in the container, and overwrite other settings
+  # You can also set a custom `cmd` to run in the container and overwrite other settings
   # from the root configuration.
   workers:
     hosts:

--- a/lib/kamal/configuration/docs/servers.yml
+++ b/lib/kamal/configuration/docs/servers.yml
@@ -2,7 +2,7 @@
 #
 # Servers are split into different roles, with each role having its own configuration.
 #
-# For simpler deployments though where all servers are identical, you can just specify a list of servers
+# For simpler deployments, though, where all servers are identical, you can just specify a list of servers.
 # They will be implicitly assigned to the `web` role.
 servers:
   - 172.0.0.1
@@ -19,7 +19,7 @@ servers:
 
 # Roles
 #
-# For more complex deployments (e.g. if you are running job hosts), you can specify roles, and configure each separately (see kamal docs role)
+# For more complex deployments (e.g., if you are running job hosts), you can specify roles and configure each separately (see kamal docs role):
 servers:
   web:
     ...

--- a/lib/kamal/configuration/docs/ssh.yml
+++ b/lib/kamal/configuration/docs/ssh.yml
@@ -1,9 +1,9 @@
 # SSH configuration
 #
-# Kamal uses SSH to connect run commands on your hosts.
-# By default it will attempt to connect to the root user on port 22
+# Kamal uses SSH to connect and run commands on your hosts.
+# By default, it will attempt to connect to the root user on port 22.
 #
-# If you are using non-root user, you may need to bootstrap your servers manually, before using them with Kamal. On Ubuntu, you’d do:
+# If you are using a non-root user, you may need to bootstrap your servers manually before using them with Kamal. On Ubuntu, you’d do:
 #
 # ```shell
 # sudo apt update
@@ -12,7 +12,6 @@
 # sudo usermod -a -G docker app
 # ```
 
-
 # SSH options
 #
 # The options are specified under the ssh key in the configuration file.
@@ -20,46 +19,44 @@ ssh:
 
   # The SSH user
   #
-  # Defaults to `root`
-  #
+  # Defaults to `root`:
   user: app
 
   # The SSH port
   #
-  # Defaults to 22
+  # Defaults to 22:
   port: "2222"
 
   # Proxy host
   #
-  # Specified in the form <host> or <user>@<host>
+  # Specified in the form <host> or <user>@<host>:
   proxy: root@proxy-host
 
   # Proxy command
   #
-  # A custom proxy command, required for older versions of SSH
+  # A custom proxy command, required for older versions of SSH:
   proxy_command: "ssh -W %h:%p user@proxy"
 
   # Log level
   #
-  # Defaults to `fatal`. Set this to debug if you are having
-  # SSH connection issues.
+  # Defaults to `fatal`. Set this to `debug` if you are having SSH connection issues.
   log_level: debug
 
-  # Keys Only
+  # Keys only
   #
-  # Set to true to use only private keys from keys and key_data parameters, 
-  # even if ssh-agent offers more identities. This option is intended for 
-  # situations where ssh-agent offers many different identites or you have 
-  # a need to overwrite all identites and force a single one.
+  # Set to `true` to use only private keys from the `keys` and `key_data` parameters,
+  # even if ssh-agent offers more identities. This option is intended for
+  # situations where ssh-agent offers many different identities or you
+  # need to overwrite all identities and force a single one.
   keys_only: false
 
   # Keys
   #
-  # An array of file names of private keys to use for publickey
-  # and hostbased authentication
+  # An array of file names of private keys to use for public key
+  # and host-based authentication:
   keys: [ "~/.ssh/id.pem" ]
 
-  # Key Data
+  # Key data
   #
   # An array of strings, with each element of the array being
   # a raw private key in PEM format.

--- a/lib/kamal/configuration/docs/sshkit.yml
+++ b/lib/kamal/configuration/docs/sshkit.yml
@@ -2,8 +2,8 @@
 #
 # [SSHKit](https://github.com/capistrano/sshkit) is the SSH toolkit used by Kamal.
 #
-# The default settings should be sufficient for most use cases, but
-# when connecting to a large number of hosts you may need to adjust
+# The default, settings should be sufficient for most use cases, but
+# when connecting to a large number of hosts, you may need to adjust.
 
 # SSHKit options
 #
@@ -13,11 +13,11 @@ sshkit:
   # Max concurrent starts
   #
   # Creating SSH connections concurrently can be an issue when deploying to many servers.
-  # By default Kamal will limit concurrent connection starts to 30 at a time.
+  # By default, Kamal will limit concurrent connection starts to 30 at a time.
   max_concurrent_starts: 10
 
   # Pool idle timeout
   #
   # Kamal sets a long idle timeout of 900 seconds on connections to try to avoid
-  # re-connection storms after an idle period, like building an image or waiting for CI.
+  # re-connection storms after an idle period, such as building an image or waiting for CI.
   pool_idle_timeout: 300


### PR DESCRIPTION
Several documentation updates to Kamal configuration were made directly in the kamal-site repository:

* Commits directly to `kamal-2` branch, like https://github.com/basecamp/kamal-site/commit/5fa8538fceb4b7bc075526773c851cc575c555b3
* https://github.com/basecamp/kamal-site/pull/102
* https://github.com/basecamp/kamal-site/pull/104
* https://github.com/basecamp/kamal-site/pull/115
(_see full history [here](https://github.com/basecamp/kamal-site/commits/main/docs/configuration)_)

This MR backports the changes, and also:

* Updates `bin/doc` to produce better spacing for code fences
* Introduces a header into generated files to (hopefully) prevent editing them directly
* Updates the filename for the configuration overview page

The front matter will look like this:

```yaml
# This file has been generated from the Kamal source, do not edit directly.
# Find the source of this file at lib/kamal/configuration/docs/accessory.yml in the Kamal repository.
title: Accessories
```

Closes #1003