### PR TITLE
Add `kamal secrets print` for secret debugging

### DIFF
--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -21,6 +21,13 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
     return_or_puts value, inline: options[:inline]
   end
 
+  desc "print", "Print the secrets (for debugging)"
+  def print
+    KAMAL.config.secrets.to_h.each do |key, value|
+      puts "#{key}=#{value}"
+    end
+  end
+
   private
     def adapter(adapter)
       Kamal::Secrets::Adapters.lookup(adapter)

--- a/test/cli/secrets_test.rb
+++ b/test/cli/secrets_test.rb
@@ -15,6 +15,12 @@ class CliSecretsTest < CliTestCase
     assert_equal "oof", run_command("extract", "foo", "{\"abc/foo\":\"oof\", \"bar\":\"rab\", \"baz\":\"zab\"}")
   end
 
+  test "print" do
+    with_test_secrets("secrets" => "SECRET1=ABC\nSECRET2=${SECRET1}DEF\n") do
+      assert_equal "SECRET1=ABC\nSECRET2=ABCDEF", run_command("print")
+    end
+  end
+
   private
     def run_command(*command)
       stdouted { Kamal::Cli::Secrets.start([ *command, "-c", "test/fixtures/deploy_with_accessories.yml" ]) }


### PR DESCRIPTION
Dotenv's variable substitution doesn't work the same way as commands run in the shell. It needs values to be escaped.

```sh
$ cat /tmp/env
SECRETS=$(cat /tmp/json)
SECRETS2=$(echo $SECRETS | jq)
$ cat /tmp/json
\{\ \"foo\"\ :\ \"bar\" \}
$ SECRETS=$(cat /tmp/json)
$ SECRETS2=$(echo $SECRETS | jq)
jq: parse error: Invalid numeric literal at line 1, column 2
$ ruby -e 'require "dotenv"; puts Dotenv.parse("/tmp/env")["SECRETS2"]'
{
  "foo": "bar"
}
```

Since you then can't use the shell to debug, `kamal secrets print` will allow you to see what the secrets will be set to.