### PR TITLE
Added support for ACME `http-01` challenges

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -14,7 +14,7 @@ class Kamal::Configuration
 
   include Validation
 
-  PROXY_MINIMUM_VERSION = "v0.6.0"
+  PROXY_MINIMUM_VERSION = "v0.7.0"
   PROXY_HTTP_PORT = 80
   PROXY_HTTPS_PORT = 443
 


### PR DESCRIPTION
Update to kamal-proxy 0.7.0 for ACME `http-01` challenge support.