### PR TITLE
Do not tag 1.9.x Docker images as latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,9 @@ jobs:
         gemfile:
           - Gemfile
           - gemfiles/rails_edge.gemfile
+        exclude:
+          - ruby-version: "3.1"
+            gemfile: gemfiles/rails_edge.gemfile
     name: ${{ format('Tests (Ruby {0})', matrix.ruby-version) }}
     runs-on: ubuntu-latest
     continue-on-error: true

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,7 +6,7 @@ on:
       tagInput:
         description: 'Tag'
         required: true
-    
+
   release:
     types: [created]
     tags:
@@ -51,5 +51,4 @@ jobs:
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ghcr.io/basecamp/kamal:latest
             ghcr.io/basecamp/kamal:${{ steps.version-tag.outputs.value }}


### PR DESCRIPTION
Only 2.x images should be set as latest.