### PR TITLE
Allow destination and config-file in aliases

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -30,7 +30,8 @@ module Kamal::Cli
       else
         super
       end
-      initialize_commander unless KAMAL.configured?
+
+      initialize_commander unless config[:invoked_via_subcommand]
     end
 
     private

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -382,8 +382,10 @@ class CliAppTest < CliTestCase
 
 
   test "version through main" do
-    stdouted { Kamal::Cli::Main.start([ "app", "version", "-c", "test/fixtures/deploy_with_accessories.yml", "--hosts", "1.1.1.1" ]) }.tap do |output|
-      assert_match "sh -c 'docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting' | head -1 | while read line; do echo ${line#app-web-}; done", output
+    with_argv([ "app", "version", "-c", "test/fixtures/deploy_with_accessories.yml", "--hosts", "1.1.1.1" ]) do
+      stdouted { Kamal::Cli::Main.start }.tap do |output|
+        assert_match "sh -c 'docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting' | head -1 | while read line; do echo ${line#app-web-}; done", output
+      end
     end
   end
 

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -274,17 +274,4 @@ class CliBuildTest < CliTestCase
       SSHKit::Backend::Abstract.any_instance.stubs(:execute)
         .with { |*args| args[0..1] == [ :docker, :buildx ] }
     end
-
-    def with_build_directory
-      build_directory = File.join Dir.tmpdir, "kamal-clones", "app-#{pwd_sha}", "kamal"
-      FileUtils.mkdir_p build_directory
-      FileUtils.touch File.join build_directory, "Dockerfile"
-      yield build_directory + "/"
-    ensure
-      FileUtils.rm_rf build_directory
-    end
-
-    def pwd_sha
-      Digest::SHA256.hexdigest(Dir.pwd)[0..12]
-    end
 end

--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -51,4 +51,17 @@ class CliTestCase < ActiveSupport::TestCase
     ensure
       ARGV.replace(old_argv)
     end
+
+    def with_build_directory
+      build_directory = File.join Dir.tmpdir, "kamal-clones", "app-#{pwd_sha}", "kamal"
+      FileUtils.mkdir_p build_directory
+      FileUtils.touch File.join build_directory, "Dockerfile"
+      yield build_directory + "/"
+    ensure
+      FileUtils.rm_rf build_directory
+    end
+
+    def pwd_sha
+      Digest::SHA256.hexdigest(Dir.pwd)[0..12]
+    end
 end

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -460,6 +460,7 @@ class CliMainTest < CliTestCase
 
   test "run an alias for a console" do
     run_command("console", config_file: "deploy_with_aliases").tap do |output|
+      assert_no_match "App Host: 1.1.1.4", output
       assert_match "docker exec app-console-999 bin/console on 1.1.1.5", output
       assert_match "App Host: 1.1.1.5", output
     end
@@ -483,6 +484,33 @@ class CliMainTest < CliTestCase
     run_command("rails", "db:migrate:status", config_file: "deploy_with_aliases").tap do |output|
       assert_match "docker exec app-console-999 rails db:migrate:status on 1.1.1.5", output
       assert_match "App Host: 1.1.1.5", output
+    end
+  end
+
+  test "switch config file with an alias" do
+    with_config_files do
+      with_argv([ "other_config" ]) do
+        stdouted { Kamal::Cli::Main.start }.tap do |output|
+          assert_match ":service_with_version: app2-999", output
+        end
+      end
+    end
+  end
+
+  test "switch destination with an alias" do
+    with_config_files do
+      with_argv([ "other_destination_config" ]) do
+        stdouted { Kamal::Cli::Main.start }.tap do |output|
+          assert_match ":service_with_version: app3-999", output
+        end
+      end
+    end
+  end
+
+  test "run on primary via alias" do
+    run_command("primary_details", config_file: "deploy_with_aliases").tap do |output|
+      assert_match "App Host: 1.1.1.1", output
+      assert_no_match "App Host: 1.1.1.2", output
     end
   end
 
@@ -525,6 +553,20 @@ class CliMainTest < CliTestCase
       Dir.mktmpdir do |tmpdir|
         Dir.chdir(tmpdir) do
           `git init`
+          yield
+        end
+      end
+    end
+
+    def with_config_files
+      Dir.mktmpdir do |tmpdir|
+        config_dir = File.join(tmpdir, "config")
+        FileUtils.mkdir_p(config_dir)
+        FileUtils.cp "test/fixtures/deploy.yml", config_dir
+        FileUtils.cp "test/fixtures/deploy2.yml", config_dir
+        FileUtils.cp "test/fixtures/deploy.elsewhere.yml", config_dir
+
+        Dir.chdir(tmpdir) do
           yield
         end
       end

--- a/test/fixtures/deploy.elsewhere.yml
+++ b/test/fixtures/deploy.elsewhere.yml
@@ -1,0 +1,12 @@
+service: app3
+image: dhh/app3
+servers:
+  - "1.1.1.3"
+  - "1.1.1.4"
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64
+aliases:
+  other_config: config -c config/deploy2.yml

--- a/test/fixtures/deploy.yml
+++ b/test/fixtures/deploy.yml
@@ -1,0 +1,13 @@
+service: app
+image: dhh/app
+servers:
+  - "1.1.1.1"
+  - "1.1.1.2"
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64
+aliases:
+  other_config: config -c config/deploy2.yml
+  other_destination_config: config -d elsewhere

--- a/test/fixtures/deploy2.yml
+++ b/test/fixtures/deploy2.yml
@@ -1,0 +1,12 @@
+service: app2
+image: dhh/app2
+servers:
+  - "1.1.1.1"
+  - "1.1.1.2"
+registry:
+  username: user2
+  password: pw2
+builder:
+  arch: amd64
+aliases:
+  other_config: config -c config/deploy2.yml

--- a/test/fixtures/deploy_with_aliases.yml
+++ b/test/fixtures/deploy_with_aliases.yml
@@ -21,3 +21,6 @@ aliases:
   console: app exec --reuse -p -r console "bin/console"
   exec: app exec --reuse -p -r console
   rails: app exec --reuse -p -r console rails
+  primary_details: details -p
+  deploy_secondary: deploy -d secondary
+


### PR DESCRIPTION
We only loaded the configuration once, which meant that aliases always used the initial configuration file and destination.

We don't want to load the configuration in subcommands as it is not passed all the options we need. But just checking if we are in a subcommand is enough - the alias reloads and the subcommand does not.

One thing to note is that anything passed on the command line overrides what is in the alias, so if an alias says
`other_config: config -c config/deploy2.yml` and you run `kamal other_config -c config/deploy.yml`, it won't switch.

Fixes: https://github.com/basecamp/kamal/issues/1027