### PR TITLE
Restore kamal setup to accessory hosts

### DIFF
--- a/lib/kamal/commander/specifics.rb
+++ b/lib/kamal/commander/specifics.rb
@@ -43,7 +43,12 @@ class Kamal::Commander::Specifics
     end
 
     def specified_hosts
-      (specific_hosts || config.all_hosts) \
-        .select { |host| (specific_roles || config.roles).flat_map(&:hosts).include?(host) }
+      specified_hosts = specific_hosts || config.all_hosts
+
+      if (specific_role_hosts = specific_roles&.flat_map(&:hosts)).present?
+        specified_hosts.select { |host| specific_role_hosts.include?(host) }
+      else
+        specified_hosts
+      end
     end
 end

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -154,7 +154,7 @@ class CommanderTest < ActiveSupport::TestCase
     configure_with(:deploy_with_single_accessory)
     assert_equal [ "1.1.1.5" ], @kamal.accessory_hosts
 
-    configure_with(:deploy_with_accessories)
+    configure_with(:deploy_with_accessories_on_independent_server)
     assert_equal [ "1.1.1.5", "1.1.1.1", "1.1.1.2" ], @kamal.accessory_hosts
   end
 
@@ -163,7 +163,7 @@ class CommanderTest < ActiveSupport::TestCase
     @kamal.specific_roles = [ "web" ]
     assert_equal [], @kamal.accessory_hosts
 
-    configure_with(:deploy_with_accessories)
+    configure_with(:deploy_with_accessories_on_independent_server)
     @kamal.specific_roles = [ "web" ]
     assert_equal [ "1.1.1.1", "1.1.1.2" ], @kamal.accessory_hosts
 

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -150,6 +150,27 @@ class CommanderTest < ActiveSupport::TestCase
     assert_equal [ "1.1.1.2" ], @kamal.proxy_hosts
   end
 
+  test "accessory hosts without filtering" do
+    configure_with(:deploy_with_single_accessory)
+    assert_equal [ "1.1.1.5" ], @kamal.accessory_hosts
+
+    configure_with(:deploy_with_accessories)
+    assert_equal [ "1.1.1.5", "1.1.1.1", "1.1.1.2" ], @kamal.accessory_hosts
+  end
+
+  test "accessory hosts with role filtering" do
+    configure_with(:deploy_with_single_accessory)
+    @kamal.specific_roles = [ "web" ]
+    assert_equal [ ], @kamal.accessory_hosts
+
+    configure_with(:deploy_with_accessories)
+    @kamal.specific_roles = [ "web" ]
+    assert_equal [ "1.1.1.1", "1.1.1.2" ], @kamal.accessory_hosts
+
+    @kamal.specific_roles = [ "workers" ]
+    assert_equal [ ], @kamal.accessory_hosts
+  end
+
   private
     def configure_with(variant)
       @kamal = Kamal::Commander.new.tap do |kamal|

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -161,14 +161,14 @@ class CommanderTest < ActiveSupport::TestCase
   test "accessory hosts with role filtering" do
     configure_with(:deploy_with_single_accessory)
     @kamal.specific_roles = [ "web" ]
-    assert_equal [ ], @kamal.accessory_hosts
+    assert_equal [], @kamal.accessory_hosts
 
     configure_with(:deploy_with_accessories)
     @kamal.specific_roles = [ "web" ]
     assert_equal [ "1.1.1.1", "1.1.1.2" ], @kamal.accessory_hosts
 
     @kamal.specific_roles = [ "workers" ]
-    assert_equal [ ], @kamal.accessory_hosts
+    assert_equal [], @kamal.accessory_hosts
   end
 
   private

--- a/test/fixtures/deploy_with_accessories_on_independent_server.yml
+++ b/test/fixtures/deploy_with_accessories_on_independent_server.yml
@@ -16,7 +16,7 @@ builder:
 accessories:
   mysql:
     image: mysql:5.7
-    host: 1.1.1.3
+    host: 1.1.1.5
     port: 3306
     env:
       clear:

--- a/test/fixtures/deploy_with_single_accessory.yml
+++ b/test/fixtures/deploy_with_single_accessory.yml
@@ -27,12 +27,3 @@ accessories:
       - test/fixtures/files/my.cnf:/etc/mysql/my.cnf
     directories:
       - data:/var/lib/mysql
-  redis:
-    image: redis:latest
-    roles:
-      - web
-    port: 6379
-    directories:
-      - data:/data
-
-readiness_delay: 0


### PR DESCRIPTION
`Specifics#accessory_hosts` was being filtered out by role host check even when a specific role was not being specified.