### PR TITLE
Kamal::Secrets did not load environment variables in .env on my Apple M1

### DIFF
--- a/lib/kamal/secrets.rb
+++ b/lib/kamal/secrets.rb
@@ -5,10 +5,13 @@ class Kamal::Secrets
 
   Kamal::Secrets::Dotenv::InlineCommandSubstitution.install!
 
+  attr_reader :secrets
   def initialize(destination: nil)
     @secrets_files = \
       [ ".kamal/secrets-common", ".kamal/secrets#{(".#{destination}" if destination)}" ].select { |f| File.exist?(f) }
     @mutex = Mutex.new
+    ::Dotenv.load
+    @secrets = set_secrets
   end
 
   def [](key)
@@ -29,7 +32,7 @@ class Kamal::Secrets
   end
 
   private
-    def secrets
+    def set_secrets
       @secrets ||= secrets_files.inject({}) do |secrets, secrets_file|
         secrets.merge!(::Dotenv.parse(secrets_file))
       end

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -31,4 +31,25 @@ class SecretsTest < ActiveSupport::TestCase
       assert_equal "JKL", Kamal::Secrets.new(destination: "nodest")["SECRET2"]
     end
   end
+
+  test "dotenv load" do
+    create_and_remove_secret_files do
+      secrets = Kamal::Secrets.new
+      assert_equal @value, secrets[@key]
+    end
+  end
+
+  private
+
+    def create_and_remove_secret_files
+      @key = "ABC"
+      @value = "SECRET"
+      File.write(".env", "#{ @key }=#{ @value }")
+      Dir.mkdir(".kamal") if !Dir.exist?(".kamal")
+      File.write(".kamal/secrets", "#{ @key }=$#{ @key }")
+      yield
+      File.delete(".env")
+      File.delete(".kamal/secrets")
+      Dir.delete(".kamal")
+    end
 end


### PR DESCRIPTION
I consistently got error messages trying to login to docker on my Apple M1. The issue was .env variables were not being passed correctly to kamal. 