### PR TITLE
Update Deploy Template: Switch to Latest Stable Redis Version (7.4)

### DIFF
--- a/lib/kamal/cli/templates/deploy.yml
+++ b/lib/kamal/cli/templates/deploy.yml
@@ -89,7 +89,7 @@ builder:
 #     directories:
 #       - data:/var/lib/mysql
 #   redis:
-#     image: redis:7.0
+#     image: redis:7.4
 #     host: 192.168.0.2
 #     port: 6379
 #     directories:


### PR DESCRIPTION
This pull request introduces update to the deploy template to use latest stable version of  Redis 7.4. This version was officially released on July 29, 2024, and can be found [here](https://redis.io/blog/announcing-redis-community-edition-and-redis-stack-74/) and available in DockerHub: `docker pull redis:7.4`