### PR TITLE
Allow false env var value

### DIFF
--- a/lib/kamal/utils.rb
+++ b/lib/kamal/utils.rb
@@ -12,6 +12,8 @@ module Kamal::Utils
         attr = "#{key}=#{escape_shell_value(value)}"
         attr = self.sensitive(attr, redaction: "#{key}=[REDACTED]") if sensitive
         [ argument, attr ]
+      elsif value == false
+        [ argument, "#{key}=false" ]
       else
         [ argument, key ]
       end

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class UtilsTest < ActiveSupport::TestCase
   test "argumentize" do
-    assert_equal [ "--label", "foo=\"\\`bar\\`\"", "--label", "baz=\"qux\"", "--label", :quux ], \
-      Kamal::Utils.argumentize("--label", { foo: "`bar`", baz: "qux", quux: nil })
+    assert_equal [ "--label", "foo=\"\\`bar\\`\"", "--label", "baz=\"qux\"", "--label", :quux, "--label", "quuz=false" ], \
+      Kamal::Utils.argumentize("--label", { foo: "`bar`", baz: "qux", quux: nil, quuz: false })
   end
 
   test "argumentize with redacted" do


### PR DESCRIPTION
I am booting an accessory that needs a clear env var value like `ENABLE_AUTO_LOGIN=false` so my config is just:

```
env:
  clear:
    ENABLE_AUTO_LOGIN: false
```

When Kamal passes such env vars to `docker run` it drops the `false` value since the `argumentize` utility checks that the value is `present?` and `false` values evaluate to false, leading to `docker run --env ENABLE_AUTO_LOGIN`

This PR updates `argumentize` to preserve false values, leading to `docker run --env ENABLE_AUTO_LOGIN=false`