### PR TITLE
Expose `pause` and `resume` methods of `kamal-proxy`

### DIFF
--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -152,6 +152,26 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
     end
   end
 
+  desc "pause_app", "Pause existing app on servers"
+  def pause_app
+    with_lock do
+      on(KAMAL.proxy_hosts) do |host|
+        execute *KAMAL.auditor.record("Paused app on proxy"), verbosity: :debug
+        execute *KAMAL.proxy.pause_app, raise_on_non_zero_exit: false
+      end
+    end
+  end
+
+  desc "resume_app", "Resume existing app on servers"
+  def resume_app
+    with_lock do
+      on(KAMAL.proxy_hosts) do |host|
+        execute *KAMAL.auditor.record("Resumed app on proxy"), verbosity: :debug
+        execute *KAMAL.proxy.resume_app, raise_on_non_zero_exit: false
+      end
+    end
+  end
+
   desc "restart", "Restart existing proxy container on servers"
   def restart
     with_lock do

--- a/lib/kamal/commands/proxy.rb
+++ b/lib/kamal/commands/proxy.rb
@@ -16,8 +16,16 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
     docker :container, :start, container_name
   end
 
-  def stop(name: container_name)
-    docker :container, :stop, name
+  def stop
+    docker :container, :stop, container_name
+  end
+
+  def pause_app
+    docker :exec, container_name, "kamal-proxy", "pause", "#{config.service}-web"
+  end
+
+  def resume_app
+    docker :exec, container_name, "kamal-proxy", "resume", "#{config.service}-web"
   end
 
   def start_or_run

--- a/lib/kamal/commands/proxy.rb
+++ b/lib/kamal/commands/proxy.rb
@@ -21,11 +21,11 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
   end
 
   def pause_app
-    docker :exec, container_name, "kamal-proxy", "pause", "#{config.service}-web"
+    docker :exec, container_name, "kamal-proxy", "pause", "#{config.service}-#{config.primary_role_name}"
   end
 
   def resume_app
-    docker :exec, container_name, "kamal-proxy", "resume", "#{config.service}-web"
+    docker :exec, container_name, "kamal-proxy", "resume", "#{config.service}-#{config.primary_role_name}"
   end
 
   def start_or_run

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -96,6 +96,18 @@ class CliProxyTest < CliTestCase
     end
   end
 
+  test "pause_app" do
+    run_command("pause_app").tap do |output|
+      assert_match "docker exec kamal-proxy kamal-proxy pause app-web", output
+    end
+  end
+
+  test "resume_app" do
+    run_command("resume_app").tap do |output|
+      assert_match "docker exec kamal-proxy kamal-proxy resume app-web", output
+    end
+  end
+
   test "restart" do
     Kamal::Cli::Proxy.any_instance.expects(:stop)
     Kamal::Cli::Proxy.any_instance.expects(:start)

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -39,6 +39,18 @@ class CommandsProxyTest < ActiveSupport::TestCase
       new_command.stop.join(" ")
   end
 
+  test "proxy pause_app" do
+    assert_equal \
+      "docker exec kamal-proxy kamal-proxy pause app-web",
+      new_command.pause_app.join(" ")
+  end
+
+  test "proxy resume_app" do
+    assert_equal \
+      "docker exec kamal-proxy kamal-proxy resume app-web",
+      new_command.resume_app.join(" ")
+  end
+
   test "proxy info" do
     assert_equal \
       "docker ps --filter name=^kamal-proxy$",

--- a/test/integration/app_proxy_test.rb
+++ b/test/integration/app_proxy_test.rb
@@ -1,0 +1,20 @@
+require_relative "integration_test"
+
+class AppProxyTest < IntegrationTest
+  setup do
+    @app = "app_with_roles"
+  end
+
+  test "boot, reboot, stop, start, pause_app, resume_app, restart, logs, remove" do
+    kamal :deploy
+
+    kamal :proxy, :boot
+    assert_proxy_running
+
+    kamal :proxy, :pause_app
+    assert_proxy_app_paused
+
+    kamal :proxy, :resume_app
+    assert_proxy_app_running
+  end
+end

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -167,6 +167,22 @@ class IntegrationTest < ActiveSupport::TestCase
       assert_container_running(host: "vm1", name: "kamal-proxy")
     end
 
+    def proxy_app_paused?(host:, name:)
+      docker_compose("exec #{host} docker exec #{name} kamal-proxy list | grep paused", capture: true).present?
+    end
+
+    def assert_proxy_app_paused
+      proxy_app_paused?(host: "vm1", name: "kamal-proxy")
+    end
+
+    def proxy_app_running?(host:, name:)
+      docker_compose("exec #{host} docker exec #{name} kamal-proxy list | grep running", capture: true).present?
+    end
+
+    def assert_proxy_app_running
+      proxy_app_running?(host: "vm1", name: "kamal-proxy")
+    end
+
     def assert_proxy_not_running
       assert_container_not_running(host: "vm1", name: "kamal-proxy")
     end

--- a/test/integration/proxy_test.rb
+++ b/test/integration/proxy_test.rb
@@ -5,7 +5,7 @@ class ProxyTest < IntegrationTest
     @app = "app_with_roles"
   end
 
-  test "boot, reboot, stop, start, restart, logs, remove" do
+  test "boot, reboot, stop, start, pause_app, resume_app, restart, logs, remove" do
     kamal :proxy, :boot
     assert_proxy_running
 


### PR DESCRIPTION
I created the issue to be addressed https://github.com/basecamp/kamal/issues/1046

The idea is to expose the `pause` and `resume` commands of the `kamal-proxy`

## Proxy Interface edits

This pr enables that via the some new commands in the `proxy` interface:
- `pause_app` will triggers the `pause` command in all kamal proxy containers
- `resume_app` will triggers the `resume` command in all kamal proxy containers

## Concerns

I feel like the presence in the `proxy` interface is not the best option, what do you think? i feel like this could go in the `app` interface, not really sure

## Tests
tests of all levels are there. i found some old ugly tests in the integration part, but managed to have something running ;)

this could be useful to address a `maintenance mode` as requested here https://github.com/basecamp/kamal/issues/162


## Docs
docs pr https://github.com/basecamp/kamal-site/pull/122