### PR TITLE
Update to kamal-proxy 0.8.0

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -14,7 +14,7 @@ class Kamal::Configuration
 
   include Validation
 
-  PROXY_MINIMUM_VERSION = "v0.7.0"
+  PROXY_MINIMUM_VERSION = "v0.8.0"
   PROXY_HTTP_PORT = 80
   PROXY_HTTPS_PORT = 443
 


### PR DESCRIPTION
Proxy changes:
- Add option to use custom TLS certificates (#17)
- Don't buffer SSE responses (#36)
- Allow routing to wildcard subdomains (#45)

Custom TLS certificates not supported in Kamal itself yet. Buffering SSE responses and wildcard subdomains will work without any Kamal changes.