### PR TITLE
Add `kamal app open` command to open app in a web browser

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -227,6 +227,24 @@ class Kamal::Cli::App < Kamal::Cli::Base
     end
   end
 
+  desc "open", "open app in a web browser"
+  def open
+    host = KAMAL.primary_role.proxy.hosts.first || KAMAL.primary_host
+    protocol = KAMAL.primary_role.ssl? ? "https" : "http"
+    cmd =
+      case RbConfig::CONFIG["host_os"]
+      when /mswin|mingw|cygwin/ then "start"
+      when /darwin/ then "open"
+      when /linux|bsd/ then "xdg-open"
+      end
+
+    if cmd
+      system(cmd, "#{protocol}://#{host}")
+    else
+      say "Could not detect OS browser"
+    end
+  end
+
   desc "remove", "Remove app containers and images from servers"
   def remove
     with_lock do

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -235,6 +235,20 @@ class CliAppTest < CliTestCase
     end
   end
 
+  test "open with proxy host domain" do
+    RbConfig::CONFIG.stubs(:[]).with("host_os").returns("linux")
+    Object.any_instance.expects(:system).with("xdg-open", "https://app.example.com")
+
+    run_command("open", config: :with_proxy_host)
+  end
+
+  test "open with primary host IP" do
+    RbConfig::CONFIG.stubs(:[]).with("host_os").returns("linux")
+    Object.any_instance.expects(:system).with("xdg-open", "http://1.1.1.1")
+
+    run_command("open")
+  end
+
   test "remove" do
     run_command("remove").tap do |output|
       assert_match /#{Regexp.escape("sh -c 'docker ps --latest --quiet --filter label=service=app --filter label=role=web --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --quiet --filter label=service=app --filter label=role=web --filter status=running --filter status=restarting' | head -1 | xargs docker stop")}/, output

--- a/test/fixtures/deploy_with_proxy_host.yml
+++ b/test/fixtures/deploy_with_proxy_host.yml
@@ -1,0 +1,13 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+proxy:
+  ssl: true
+  host: app.example.com
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64


### PR DESCRIPTION
## Problem

Kamal is a no-PaaS tool with PaaS-like ergonomics, where you can open a production Rails (or other) console, a shell session, tail logs, etc. One of the things that I've been missing is a command to open the app in a web browser. That is, a Kamal equivalent to Heroku's `heroku open` or Fly.io's `fly apps open`.

This would allow for quick access to a deployed web application, from the CLI, without having to manually copy/paste the URL from one of your browser tabs or your `config/deploy.yml`. Examples where this can be useful:

- right after deploying your app
- when switching between different Kamal-enabled repos
- in copy/paste-able Readme instructions
- any time you're in the command line and don't want to switch context

## Solution

Add a `kamal app open` command. It opens the primary role (usually `web`) first domain defined in `proxy` `host(s)`, or falls back to the primary role's first IP address.

The implementation is so short that adding a dependency for finding the right opening command (with a gem like launchy) felt like too much. But I can change the PR if needed.