### PR TITLE
Remove to_sentence method

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -254,7 +254,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
       error \
         "No accessory by the name of '#{name}'" +
-        (options ? " (options: #{options.to_sentence})" : "")
+        (options ? " (options: #{options.join(', ')})" : "")
     end
 
     def accessory_hosts(accessory)

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -94,7 +94,7 @@ class CliAccessoryTest < CliTestCase
   end
 
   test "details with non-existent accessory" do
-    assert_equal "No accessory by the name of 'hello' (options: mysql and redis)", stderred { run_command("details", "hello") }
+    assert_equal "No accessory by the name of 'hello' (options: mysql, redis)", stderred { run_command("details", "hello") }
   end
 
   test "details with all" do


### PR DESCRIPTION
Fixes #1061 

##### Problem
`to_sentence` method is part of activesupport and will fail in case kamal is running independently.

##### Solution
Use `join(',')`