### PR TITLE
Switch Redis to Valkey in deploy template and tests

### DIFF
--- a/lib/kamal/cli/templates/deploy.yml
+++ b/lib/kamal/cli/templates/deploy.yml
@@ -91,7 +91,7 @@ builder:
 #     directories:
 #       - data:/var/lib/mysql
 #   redis:
-#     image: redis:7.0
+#     image: valkey/valkey:8
 #     host: 192.168.0.2
 #     port: 6379
 #     directories:


### PR DESCRIPTION
 As mentioned by @dhh in https://github.com/basecamp/kamal/pull/1044#issuecomment-2394796495, this PR replaces Redis with [Valkey](https://github.com/valkey-io/valkey?tab=License-1-ov-file) (the FOSS fork of Redis) in deploy template and tests.

The deploy template now uses [`valkey/valkey:8`](https://hub.docker.com/r/valkey/valkey/tags) image for cache, which is the latest release with performance improvements over Valkey 7 / Redis 7, and still retains [full compatibility with Redis OSS 7.2](https://github.com/valkey-io/valkey/releases/tag/8.0.0), which means the current ruby adapter for [redis](https://github.com/redis/redis-rb/commit/63581a90772dbb8366180b9caf7bc1dd133e9dd2) remains compatible.