### PR TITLE
ERROR (ArgumentError): Unknown boot_config subcommand clear

### DIFF
--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -21,7 +21,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
     end
   end
 
-  desc "boot_config <set|get|clear>", "Mange kamal-proxy boot configuration"
+  desc "boot_config <set|get|reset>", "Mange kamal-proxy boot configuration"
   option :publish, type: :boolean, default: true, desc: "Publish the proxy ports on the host"
   option :http_port, type: :numeric, default: Kamal::Configuration::PROXY_HTTP_PORT, desc: "HTTP port to publish on the host"
   option :https_port, type: :numeric, default: Kamal::Configuration::PROXY_HTTPS_PORT, desc: "HTTPS port to publish on the host"


### PR DESCRIPTION
`kamal proxy boot_config clear`
 
 ERROR (ArgumentError): Unknown boot_config subcommand clear

<img width="741" alt="image" src="https://github.com/user-attachments/assets/1c43a21e-1a68-43c5-97c0-44e1612700b3">

`kamal proxy boot_config reset`
<img width="870" alt="image" src="https://github.com/user-attachments/assets/92fd7af5-e483-4319-93d1-9edce703595c">


https://github.com/basecamp/kamal/blob/7b48648bf2a380bfb44f89d357cf5ec975c7b18b/lib/kamal/cli/proxy.rb#L47-L50


