### PR TITLE
Add user to docker group if not superuser

### DIFF
--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -32,6 +32,7 @@ class Kamal::Cli::Server < Kamal::Cli::Base
           if execute(*KAMAL.docker.superuser?, raise_on_non_zero_exit: false)
             info "Missing Docker on #{host}. Installing…"
             execute *KAMAL.docker.install
+            execute *KAMAL.docker.add_group
           else
             missing << host
           end

--- a/lib/kamal/commands/docker.rb
+++ b/lib/kamal/commands/docker.rb
@@ -19,6 +19,11 @@ class Kamal::Commands::Docker < Kamal::Commands::Base
     [ '[ "${EUID:-$(id -u)}" -eq 0 ] || command -v sudo >/dev/null || command -v su >/dev/null' ]
   end
 
+  # Add the user to the docker group if we're not root
+  def add_group
+    [ '[ "${EUID:-$(id -u)}" -eq 0 ] || sudo usermod -aG docker "${USER:-$(id -un)}"' ]
+  end
+
   def create_network
     docker :network, :create, :kamal
   end

--- a/test/cli/server_test.rb
+++ b/test/cli/server_test.rb
@@ -52,6 +52,7 @@ class CliServerTest < CliTestCase
     stub_setup
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:docker, "-v", raise_on_non_zero_exit: false).returns(false).at_least_once
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with('[ "${EUID:-$(id -u)}" -eq 0 ] || command -v sudo >/dev/null || command -v su >/dev/null', raise_on_non_zero_exit: false).returns(true).at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with('[ "${EUID:-$(id -u)}" -eq 0 ] || sudo usermod -aG docker "${USER:-$(id -un)}"').at_least_once
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:sh, "-c", "'curl -fsSL https://get.docker.com || wget -O - https://get.docker.com || echo \"exit 1\"'", "|", :sh).at_least_once
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:mkdir, "-p", ".kamal").returns("").at_least_once
     Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).returns(true)

--- a/test/commands/docker_test.rb
+++ b/test/commands/docker_test.rb
@@ -23,4 +23,8 @@ class CommandsDockerTest < ActiveSupport::TestCase
   test "superuser?" do
     assert_equal '[ "${EUID:-$(id -u)}" -eq 0 ] || command -v sudo >/dev/null || command -v su >/dev/null', @docker.superuser?.join(" ")
   end
+
+  test "add_group" do
+    assert_equal '[ "${EUID:-$(id -u)}" -eq 0 ] || sudo usermod -aG docker "${USER:-$(id -un)}"', @docker.add_group.join(" ")
+  end
 end


### PR DESCRIPTION
This allows docker commands to function with a non-root ssh user

Fixes: #980