### PR TITLE
feat(secrets): add Doppler adapter

### DIFF
--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -1,11 +1,17 @@
 class Kamal::Cli::Secrets < Kamal::Cli::Base
   desc "fetch [SECRETS...]", "Fetch secrets from a vault"
   option :adapter, type: :string, aliases: "-a", required: true, desc: "Which vault adapter to use"
-  option :account, type: :string, required: true, desc: "The account identifier or username"
+  option :account, type: :string, required: false, desc: "The account identifier or username"
   option :from, type: :string, required: false, desc: "A vault or folder to fetch the secrets from"
   option :inline, type: :boolean, required: false, hidden: true
   def fetch(*secrets)
-    results = adapter(options[:adapter]).fetch(secrets, **options.slice(:account, :from).symbolize_keys)
+    adapter = initialize_adapter(options[:adapter])
+
+    if adapter.requires_account? && options[:account].blank?
+      return puts "No value provided for required options '--account'"
+    end
+
+    results = adapter.fetch(secrets, **options.slice(:account, :from).symbolize_keys)
 
     return_or_puts JSON.dump(results).shellescape, inline: options[:inline]
   end
@@ -29,7 +35,7 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
   end
 
   private
-    def adapter(adapter)
+    def initialize_adapter(adapter)
       Kamal::Secrets::Adapters.lookup(adapter)
     end
 

--- a/lib/kamal/secrets/adapters/base.rb
+++ b/lib/kamal/secrets/adapters/base.rb
@@ -1,11 +1,18 @@
 class Kamal::Secrets::Adapters::Base
   delegate :optionize, to: Kamal::Utils
 
-  def fetch(secrets, account:, from: nil)
+  def fetch(secrets, account: nil, from: nil)
+    raise RuntimeError, "Missing required option '--account'" if requires_account? && account.blank?
+
     check_dependencies!
+
     session = login(account)
     full_secrets = secrets.map { |secret| [ from, secret ].compact.join("/") }
     fetch_secrets(full_secrets, account: account, session: session)
+  end
+
+  def requires_account?
+    true
   end
 
   private

--- a/lib/kamal/secrets/adapters/doppler.rb
+++ b/lib/kamal/secrets/adapters/doppler.rb
@@ -1,28 +1,53 @@
 class Kamal::Secrets::Adapters::Doppler < Kamal::Secrets::Adapters::Base
+  def requires_account?
+    false
+  end
+
   private
-    def login(account)
-      unless loggedin?(account)
+    def login(*)
+      unless loggedin?
         `doppler login -y`
         raise RuntimeError, "Failed to login to Doppler" unless $?.success?
       end
     end
 
-    def loggedin?(account)
+    def loggedin?
       `doppler me --json 2> /dev/null`
       $?.success?
     end
 
-    def fetch_secrets(secrets, account:, session:)
-      project, config = account.split("/")
+    def fetch_secrets(secrets, **)
+      project_and_config_flags = ""
+      unless service_token_set?
+        project, config, _ = secrets.first.split("/")
 
-      raise RuntimeError, "Missing project or config from --acount=project/config option" unless project && config
-      raise RuntimeError, "Using --from option or FOLDER/SECRET is not supported by Doppler" if secrets.any?(/\//)
+        unless project && config
+          raise RuntimeError, "Missing project or config from '--from=project/config' option"
+        end
 
-      items = `doppler secrets get #{secrets.map(&:shellescape).join(" ")} --json -p #{project} -c #{config}`
+        project_and_config_flags = "-p #{project.shellescape} -c #{config.shellescape}"
+      end
+
+      secret_names = secrets.collect { |s| s.split("/").last }
+
+      items = `doppler secrets get #{secret_names.map(&:shellescape).join(" ")} --json #{project_and_config_flags}`
       raise RuntimeError, "Could not read #{secrets} from Doppler" unless $?.success?
 
       items = JSON.parse(items)
 
       items.transform_values { |value| value["computed"] }
+    end
+
+    def service_token_set?
+      ENV["DOPPLER_TOKEN"] && ENV["DOPPLER_TOKEN"][0, 5] == "dp.st"
+    end
+
+    def check_dependencies!
+      raise RuntimeError, "Doppler CLI is not installed" unless cli_installed?
+    end
+
+    def cli_installed?
+      `doppler --version 2> /dev/null`
+      $?.success?
     end
 end

--- a/lib/kamal/secrets/adapters/doppler.rb
+++ b/lib/kamal/secrets/adapters/doppler.rb
@@ -1,0 +1,28 @@
+class Kamal::Secrets::Adapters::Doppler < Kamal::Secrets::Adapters::Base
+  private
+    def login(account)
+      unless loggedin?(account)
+        `doppler login -y`
+        raise RuntimeError, "Failed to login to Doppler" unless $?.success?
+      end
+    end
+
+    def loggedin?(account)
+      `doppler me --json 2> /dev/null`
+      $?.success?
+    end
+
+    def fetch_secrets(secrets, account:, session:)
+      project, config = account.split("/")
+
+      raise RuntimeError, "Missing project or config from --acount=project/config option" unless project && config
+      raise RuntimeError, "Using --from option or FOLDER/SECRET is not supported by Doppler" if secrets.any?(/\//)
+
+      items = `doppler secrets get #{secrets.map(&:shellescape).join(" ")} --json -p #{project} -c #{config}`
+      raise RuntimeError, "Could not read #{secrets} from Doppler" unless $?.success?
+
+      items = JSON.parse(items)
+
+      items.transform_values { |value| value["computed"] }
+    end
+end

--- a/lib/kamal/secrets/adapters/test_optional_account.rb
+++ b/lib/kamal/secrets/adapters/test_optional_account.rb
@@ -1,18 +1,5 @@
-class Kamal::Secrets::Adapters::TestOptionalAccount < Kamal::Secrets::Adapters::Base
+class Kamal::Secrets::Adapters::TestOptionalAccount < Kamal::Secrets::Adapters::Test
   def requires_account?
     false
   end
-
-  private
-    def login(account)
-      true
-    end
-
-    def fetch_secrets(secrets, account:, session:)
-      secrets.to_h { |secret| [ secret, secret.reverse ] }
-    end
-
-    def check_dependencies!
-      # no op
-    end
 end

--- a/lib/kamal/secrets/adapters/test_optional_account.rb
+++ b/lib/kamal/secrets/adapters/test_optional_account.rb
@@ -1,0 +1,18 @@
+class Kamal::Secrets::Adapters::TestOptionalAccount < Kamal::Secrets::Adapters::Base
+  def requires_account?
+    false
+  end
+
+  private
+    def login(account)
+      true
+    end
+
+    def fetch_secrets(secrets, account:, session:)
+      secrets.to_h { |secret| [ secret, secret.reverse ] }
+    end
+
+    def check_dependencies!
+      # no op
+    end
+end

--- a/test/cli/secrets_test.rb
+++ b/test/cli/secrets_test.rb
@@ -7,6 +7,18 @@ class CliSecretsTest < CliTestCase
       run_command("fetch", "foo", "bar", "baz", "--account", "myaccount", "--adapter", "test")
   end
 
+  test "fetch missing --acount" do
+    assert_equal \
+      "No value provided for required options '--account'",
+      run_command("fetch", "foo", "bar", "baz", "--adapter", "test")
+  end
+
+  test "fetch without required --account" do
+    assert_equal \
+      "\\{\\\"foo\\\":\\\"oof\\\",\\\"bar\\\":\\\"rab\\\",\\\"baz\\\":\\\"zab\\\"\\}",
+      run_command("fetch", "foo", "bar", "baz", "--adapter", "test_optional_account")
+  end
+
   test "extract" do
     assert_equal "oof", run_command("extract", "foo", "{\"foo\":\"oof\", \"bar\":\"rab\", \"baz\":\"zab\"}")
   end

--- a/test/secrets/doppler_adapter_test.rb
+++ b/test/secrets/doppler_adapter_test.rb
@@ -1,0 +1,100 @@
+require "test_helper"
+
+class DopplerAdapterTest < SecretAdapterTestCase
+  setup do
+    `true` # Ensure $? is 0
+  end
+
+  test "fetch" do
+    stub_ticks.with("doppler me --json 2> /dev/null")
+
+    stub_ticks
+      .with("doppler secrets get SECRET1 FSECRET1 FSECRET2 --json -p my-project -c prd")
+      .returns(<<~JSON)
+        {
+          "SECRET1": {
+            "computed":"secret1",
+            "computedVisibility":"unmasked",
+            "note":""
+          },
+          "FSECRET1": {
+            "computed":"fsecret1",
+            "computedVisibility":"unmasked",
+            "note":""
+          },
+          "FSECRET2": {
+            "computed":"fsecret2",
+            "computedVisibility":"unmasked",
+            "note":""
+          }
+        }
+      JSON
+
+    json = JSON.parse(shellunescape(run_command("fetch", "SECRET1", "FSECRET1", "FSECRET2")))
+
+    expected_json = {
+      "SECRET1"=>"secret1",
+      "FSECRET1"=>"fsecret1",
+      "FSECRET2"=>"fsecret2"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch with from" do
+    stub_ticks.with("doppler me --json 2> /dev/null")
+
+    error = assert_raises RuntimeError do
+      run_command("fetch", "--from", "FOLDER1", "FSECRET1", "FSECRET2")
+    end
+
+    assert_match(/Using --from option or FOLDER\/SECRET is not supported by Doppler/, error.message)
+  end
+
+  test "fetch with folder in secret" do
+    stub_ticks.with("doppler me --json 2> /dev/null")
+
+    error = assert_raises RuntimeError do
+      run_command("fetch", "FOLDER1/FSECRET1", "SECRET2")
+    end
+
+    assert_match(/Using --from option or FOLDER\/SECRET is not supported by Doppler/, error.message)
+  end
+
+  test "fetch with signin" do
+    stub_ticks_with("doppler me --json 2> /dev/null", succeed: false)
+    stub_ticks_with("doppler login -y", succeed: true).returns("")
+    stub_ticks.with("doppler secrets get SECRET1 --json -p my-project -c prd").returns(single_item_json)
+
+    json = JSON.parse(shellunescape(run_command("fetch", "SECRET1")))
+
+    expected_json = {
+      "SECRET1"=>"secret1"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  private
+    def run_command(*command)
+      stdouted do
+        Kamal::Cli::Secrets.start \
+          [ *command,
+            "-c", "test/fixtures/deploy_with_accessories.yml",
+            "--adapter", "doppler",
+            "--account", "my-project/prd" ]
+      end
+    end
+
+    def single_item_json
+      <<~JSON
+        {
+          "SECRET1": {
+            "computed":"secret1",
+            "computedVisibility":"unmasked",
+            "note":""
+          }
+        }
+      JSON
+    end
+end

--- a/test/secrets/doppler_adapter_test.rb
+++ b/test/secrets/doppler_adapter_test.rb
@@ -6,6 +6,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch" do
+    stub_ticks_with("doppler --version 2> /dev/null", succeed: true)
     stub_ticks.with("doppler me --json 2> /dev/null")
 
     stub_ticks
@@ -30,7 +31,9 @@ class DopplerAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "SECRET1", "FSECRET1", "FSECRET2")))
+    json = JSON.parse(
+      shellunescape run_command("fetch", "--from", "my-project/prd", "SECRET1", "FSECRET1", "FSECRET2")
+    )
 
     expected_json = {
       "SECRET1"=>"secret1",
@@ -41,32 +44,106 @@ class DopplerAdapterTest < SecretAdapterTestCase
     assert_equal expected_json, json
   end
 
-  test "fetch with from" do
+  test "fetch having DOPPLER_TOKEN" do
+    ENV["DOPPLER_TOKEN"] = "dp.st.xxxxxxxxxxxxxxxxxxxxxx"
+
+    stub_ticks_with("doppler --version 2> /dev/null", succeed: true)
     stub_ticks.with("doppler me --json 2> /dev/null")
 
-    error = assert_raises RuntimeError do
-      run_command("fetch", "--from", "FOLDER1", "FSECRET1", "FSECRET2")
-    end
+    stub_ticks
+      .with("doppler secrets get SECRET1 FSECRET1 FSECRET2 --json ")
+      .returns(<<~JSON)
+        {
+          "SECRET1": {
+            "computed":"secret1",
+            "computedVisibility":"unmasked",
+            "note":""
+          },
+          "FSECRET1": {
+            "computed":"fsecret1",
+            "computedVisibility":"unmasked",
+            "note":""
+          },
+          "FSECRET2": {
+            "computed":"fsecret2",
+            "computedVisibility":"unmasked",
+            "note":""
+          }
+        }
+      JSON
 
-    assert_match(/Using --from option or FOLDER\/SECRET is not supported by Doppler/, error.message)
+    json = JSON.parse(
+      shellunescape run_command("fetch", "SECRET1", "FSECRET1", "FSECRET2")
+    )
+
+    expected_json = {
+      "SECRET1"=>"secret1",
+      "FSECRET1"=>"fsecret1",
+      "FSECRET2"=>"fsecret2"
+    }
+
+    assert_equal expected_json, json
+
+     ENV.delete("DOPPLER_TOKEN")
   end
 
   test "fetch with folder in secret" do
+    stub_ticks_with("doppler --version 2> /dev/null", succeed: true)
+    stub_ticks.with("doppler me --json 2> /dev/null")
+
+    stub_ticks
+      .with("doppler secrets get SECRET1 FSECRET1 FSECRET2 --json -p my-project -c prd")
+      .returns(<<~JSON)
+        {
+          "SECRET1": {
+            "computed":"secret1",
+            "computedVisibility":"unmasked",
+            "note":""
+          },
+          "FSECRET1": {
+            "computed":"fsecret1",
+            "computedVisibility":"unmasked",
+            "note":""
+          },
+          "FSECRET2": {
+            "computed":"fsecret2",
+            "computedVisibility":"unmasked",
+            "note":""
+          }
+        }
+      JSON
+
+    json = JSON.parse(
+      shellunescape run_command("fetch", "my-project/prd/SECRET1", "my-project/prd/FSECRET1", "my-project/prd/FSECRET2")
+    )
+
+    expected_json = {
+      "SECRET1"=>"secret1",
+      "FSECRET1"=>"fsecret1",
+      "FSECRET2"=>"fsecret2"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch without --from" do
+    stub_ticks_with("doppler --version 2> /dev/null", succeed: true)
     stub_ticks.with("doppler me --json 2> /dev/null")
 
     error = assert_raises RuntimeError do
-      run_command("fetch", "FOLDER1/FSECRET1", "SECRET2")
+      run_command("fetch", "FSECRET1", "FSECRET2")
     end
 
-    assert_match(/Using --from option or FOLDER\/SECRET is not supported by Doppler/, error.message)
+    assert_equal "Missing project or config from '--from=project/config' option", error.message
   end
 
   test "fetch with signin" do
+    stub_ticks_with("doppler --version 2> /dev/null", succeed: true)
     stub_ticks_with("doppler me --json 2> /dev/null", succeed: false)
     stub_ticks_with("doppler login -y", succeed: true).returns("")
     stub_ticks.with("doppler secrets get SECRET1 --json -p my-project -c prd").returns(single_item_json)
 
-    json = JSON.parse(shellunescape(run_command("fetch", "SECRET1")))
+    json = JSON.parse(shellunescape(run_command("fetch", "--from", "my-project/prd", "SECRET1")))
 
     expected_json = {
       "SECRET1"=>"secret1"
@@ -75,14 +152,23 @@ class DopplerAdapterTest < SecretAdapterTestCase
     assert_equal expected_json, json
   end
 
+  test "fetch without CLI installed" do
+    stub_ticks_with("doppler --version 2> /dev/null", succeed: false)
+
+    error = assert_raises RuntimeError do
+      JSON.parse(shellunescape(run_command("fetch", "HOST", "PORT")))
+    end
+
+    assert_equal "Doppler CLI is not installed", error.message
+  end
+
   private
     def run_command(*command)
       stdouted do
         Kamal::Cli::Secrets.start \
           [ *command,
             "-c", "test/fixtures/deploy_with_accessories.yml",
-            "--adapter", "doppler",
-            "--account", "my-project/prd" ]
+            "--adapter", "doppler" ]
       end
     end
 


### PR DESCRIPTION
Doppler organizes secrets in "projects" (like `my-awesome-project`) and "configs" (like `prod`, `stg`, etc.), so the pattern `project/config` is required when defining the `--account` option.

Doppler does not have a concept of folders, so using `--from` option or `FOLDER/SECRET` pattern is not supported and will raise an error.

Initially, I was thinking of using the `--from` option to define the Doppler "config", but this would require a much larger change in how secrets are "folderized", so not allowing to use that option and parsing `--account=project/config` accordingly seemed like a better approach for now.

Site documentation PR: https://github.com/basecamp/kamal-site/pull/134
