### PR TITLE
Upgrade ruby base image from 3.2.0 to 3.3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Use the official Ruby 3.2.0 Alpine image as the base image
-FROM ruby:3.2.0-alpine
+# Use the official Ruby 3.3.5 Alpine image as the base image
+FROM ruby:3.3.5-alpine
 
 # Install docker/buildx-bin
 COPY --from=docker/buildx-bin /buildx /usr/libexec/docker/cli-plugins/docker-buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:3.3.5-alpine
+FROM ruby:3.3-alpine
 
 # Install docker/buildx-bin
 COPY --from=docker/buildx-bin /buildx /usr/libexec/docker/cli-plugins/docker-buildx

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,3 @@
-# Use the official Ruby 3.3.5 Alpine image as the base image
 FROM ruby:3.3.5-alpine
 
 # Install docker/buildx-bin


### PR DESCRIPTION
This pull request addresses the security vulnerabilities present in the current Ruby base image. The existing image, version 3.2.0, is over two years old and has been identified to contain [1 Critical and 7 High Common Vulnerabilities and Exposures (CVEs)](https://hub.docker.com/layers/library/ruby/3.2.0-alpine/images/sha256-c85b4abfdee036bfd415af3cd2fa632037cd32293fe1eb8478cd8934aa9558b5?context=explore)

## Changes
- Upgrades Ruby base image from version 3.2.0 to 3.3.5 (latest, with [0 known vulnerabilities](https://hub.docker.com/layers/library/ruby/3.3.5-alpine/images/sha256-f5d5f6e6c691cde12365078aacdc0559670336127697cd37527fe527406a605c?context=explore)).

