### PR TITLE
remove shellescaping from secrets fetch output

### DIFF
--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -7,7 +7,7 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
   def fetch(*secrets)
     results = adapter(options[:adapter]).fetch(secrets, **options.slice(:account, :from).symbolize_keys)
 
-    return_or_puts JSON.dump(results).shellescape, inline: options[:inline]
+    return_or_puts JSON.dump(results), inline: options[:inline]
   end
 
   desc "extract", "Extract a single secret from the results of a fetch call"

--- a/test/cli/secrets_test.rb
+++ b/test/cli/secrets_test.rb
@@ -3,7 +3,7 @@ require_relative "cli_test_case"
 class CliSecretsTest < CliTestCase
   test "fetch" do
     assert_equal \
-      "\\{\\\"foo\\\":\\\"oof\\\",\\\"bar\\\":\\\"rab\\\",\\\"baz\\\":\\\"zab\\\"\\}",
+      "{\"foo\":\"oof\",\"bar\":\"rab\",\"baz\":\"zab\"}",
       run_command("fetch", "foo", "bar", "baz", "--account", "myaccount", "--adapter", "test")
   end
 
@@ -13,6 +13,11 @@ class CliSecretsTest < CliTestCase
 
   test "extract match from end" do
     assert_equal "oof", run_command("extract", "foo", "{\"abc/foo\":\"oof\", \"bar\":\"rab\", \"baz\":\"zab\"}")
+  end
+
+  test "extract from fetched" do
+    fetched = run_command("fetch", "foo", "bar", "baz", "--account", "myaccount", "--adapter", "test")
+    assert_equal "oof", run_command("extract", "foo", fetched)
   end
 
   test "print" do


### PR DESCRIPTION
Fix https://github.com/basecamp/kamal/issues/1112

Remove `shellescape` from `secrets fetch` output, in a way it can be directly used with `secrets extract`.