### PR TITLE
prevent escape '#' when generating env_file string

### DIFF
--- a/lib/kamal/env_file.rb
+++ b/lib/kamal/env_file.rb
@@ -37,6 +37,8 @@ class Kamal::EnvFile
     def escape_docker_env_file_ascii_value(value)
       # Doublequotes are treated literally in docker env files
       # so remove leading and trailing ones and unescape any others
-      value.to_s.dump[1..-2].gsub(/\\"/, "\"")
+      value.to_s.dump[1..-2]
+        .gsub(/\\"/, "\"")
+        .gsub(/\\#/, "#")
     end
 end

--- a/test/env_file_test.rb
+++ b/test/env_file_test.rb
@@ -11,6 +11,16 @@ class EnvFileTest < ActiveSupport::TestCase
       Kamal::EnvFile.new(env).to_s
   end
 
+  test "to_s won't escape '#'" do
+    env = {
+      "foo" => "\#$foo",
+      "bar" => "\#{bar}"
+    }
+
+    assert_equal "foo=\#$foo\nbar=\#{bar}\n", \
+      Kamal::EnvFile.new(env).to_s
+  end
+
   test "to_str won't escape chinese characters" do
     env = {
       "foo" => '你好 means hello, "欢迎" means welcome, that\'s simple! 😃 {smile}'

--- a/test/env_file_test.rb
+++ b/test/env_file_test.rb
@@ -13,8 +13,8 @@ class EnvFileTest < ActiveSupport::TestCase
 
   test "to_s won't escape '#'" do
     env = {
-      "foo" => "\#$foo",
-      "bar" => "\#{bar}"
+      "foo" => '#$foo',
+      "bar" => '#{bar}'
     }
 
     assert_equal "foo=\#$foo\nbar=\#{bar}\n", \


### PR DESCRIPTION
This PR prevents escape `#` character when generating the string used by docker `--env` argument.
The `#` was escaped because `String#dump` also consider ruby interpolation sequences as special characters, so a secret set as `PASSWORD=foo#$123` changed to `PASSWORD=foo\#$123` inside the container.