### PR TITLE
Added `kamal proxy reboot` to raised error message

### DIFF
--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -14,7 +14,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
         version = capture_with_info(*KAMAL.proxy.version).strip.presence
 
         if version && Kamal::Utils.older_version?(version, Kamal::Configuration::PROXY_MINIMUM_VERSION)
-          raise "kamal-proxy version #{version} is too old, please reboot to update to at least #{Kamal::Configuration::PROXY_MINIMUM_VERSION}. Run `kamal proxy reboot`."
+          raise "kamal-proxy version #{version} is too old, run `kamal proxy reboot` in order to update to at least #{Kamal::Configuration::PROXY_MINIMUM_VERSION}"
         end
         execute *KAMAL.proxy.start_or_run
       end

--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -14,7 +14,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
         version = capture_with_info(*KAMAL.proxy.version).strip.presence
 
         if version && Kamal::Utils.older_version?(version, Kamal::Configuration::PROXY_MINIMUM_VERSION)
-          raise "kamal-proxy version #{version} is too old, please reboot to update to at least #{Kamal::Configuration::PROXY_MINIMUM_VERSION}"
+          raise "kamal-proxy version #{version} is too old, please reboot to update to at least #{Kamal::Configuration::PROXY_MINIMUM_VERSION}. Run `kamal proxy reboot`."
         end
         execute *KAMAL.proxy.start_or_run
       end

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -22,7 +22,7 @@ class CliProxyTest < CliTestCase
       end
     end
 
-    assert_includes exception.message, "kamal-proxy version v0.0.1 is too old, please reboot to update to at least #{Kamal::Configuration::PROXY_MINIMUM_VERSION}. Run `kamal proxy reboot`."
+    assert_includes exception.message, "kamal-proxy version v0.0.1 is too old, run `kamal proxy reboot` in order to update to at least #{Kamal::Configuration::PROXY_MINIMUM_VERSION}"
   ensure
     Thread.report_on_exception = false
   end

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -22,7 +22,7 @@ class CliProxyTest < CliTestCase
       end
     end
 
-    assert_includes exception.message, "kamal-proxy version v0.0.1 is too old, please reboot to update to at least #{Kamal::Configuration::PROXY_MINIMUM_VERSION}"
+    assert_includes exception.message, "kamal-proxy version v0.0.1 is too old, please reboot to update to at least #{Kamal::Configuration::PROXY_MINIMUM_VERSION}. Run `kamal proxy reboot`."
   ensure
     Thread.report_on_exception = false
   end


### PR DESCRIPTION
When proxy needs to be rebooted because of new version the error raised says:
`kamal-proxy version v0.7.0 is too old, please reboot to update to at least v0.8.1`

I think we can skip a look in the docs if we include the reboot command in this error message like this:
`kamal-proxy version v0.7.0 is too old, please reboot to update to at least v0.8.1. Run "kamal proxy reboot".`