### PR TITLE
Raise meaningful error messages when secret adapter CLIs are not installed

### DIFF
--- a/lib/kamal/secrets/adapters/base.rb
+++ b/lib/kamal/secrets/adapters/base.rb
@@ -2,6 +2,7 @@ class Kamal::Secrets::Adapters::Base
   delegate :optionize, to: Kamal::Utils
 
   def fetch(secrets, account:, from: nil)
+    check_dependencies!
     session = login(account)
     full_secrets = secrets.map { |secret| [ from, secret ].compact.join("/") }
     fetch_secrets(full_secrets, account: account, session: session)
@@ -13,6 +14,10 @@ class Kamal::Secrets::Adapters::Base
     end
 
     def fetch_secrets(...)
+      raise NotImplementedError
+    end
+
+    def check_dependencies!
       raise NotImplementedError
     end
 end

--- a/lib/kamal/secrets/adapters/bitwarden.rb
+++ b/lib/kamal/secrets/adapters/bitwarden.rb
@@ -63,4 +63,13 @@ class Kamal::Secrets::Adapters::Bitwarden < Kamal::Secrets::Adapters::Base
       result = `#{full_command}`.strip
       raw ? result : JSON.parse(result)
     end
+
+    def check_dependencies!
+      raise RuntimeError, "Bitwarden CLI is not installed" unless cli_installed?
+    end
+
+    def cli_installed?
+      `bw --version 2> /dev/null`
+      $?.success?
+    end
 end

--- a/lib/kamal/secrets/adapters/last_pass.rb
+++ b/lib/kamal/secrets/adapters/last_pass.rb
@@ -27,4 +27,13 @@ class Kamal::Secrets::Adapters::LastPass < Kamal::Secrets::Adapters::Base
         end
       end
     end
+
+    def check_dependencies!
+      raise RuntimeError, "LastPass CLI is not installed" unless cli_installed?
+    end
+
+    def cli_installed?
+      `lpass --version 2> /dev/null`
+      $?.success?
+    end
 end

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -58,4 +58,13 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
         raise RuntimeError, "Could not read #{fields.join(", ")} from #{item} in the #{vault} 1Password vault" unless $?.success?
       end
     end
+
+    def check_dependencies!
+      raise RuntimeError, "1Password CLI is not installed" unless cli_installed?
+    end
+
+    def cli_installed?
+      `op --version 2> /dev/null`
+      $?.success?
+    end
 end

--- a/lib/kamal/secrets/adapters/test.rb
+++ b/lib/kamal/secrets/adapters/test.rb
@@ -7,4 +7,8 @@ class Kamal::Secrets::Adapters::Test < Kamal::Secrets::Adapters::Base
     def fetch_secrets(secrets, account:, session:)
       secrets.to_h { |secret| [ secret, secret.reverse ] }
     end
+
+    def check_dependencies!
+      # no op
+    end
 end

--- a/test/secrets/bitwarden_adapter_test.rb
+++ b/test/secrets/bitwarden_adapter_test.rb
@@ -2,6 +2,8 @@ require "test_helper"
 
 class BitwardenAdapterTest < SecretAdapterTestCase
   test "fetch" do
+    stub_ticks.with("bw --version 2> /dev/null")
+
     stub_unlocked
     stub_ticks.with("bw sync").returns("")
     stub_mypassword
@@ -14,6 +16,8 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with no login" do
+    stub_ticks.with("bw --version 2> /dev/null")
+
     stub_unlocked
     stub_ticks.with("bw sync").returns("")
     stub_noteitem
@@ -25,6 +29,8 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with from" do
+    stub_ticks.with("bw --version 2> /dev/null")
+
     stub_unlocked
     stub_ticks.with("bw sync").returns("")
     stub_myitem
@@ -39,6 +45,8 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with multiple items" do
+    stub_ticks.with("bw --version 2> /dev/null")
+
     stub_unlocked
 
     stub_ticks.with("bw sync").returns("")
@@ -80,6 +88,8 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch unauthenticated" do
+    stub_ticks.with("bw --version 2> /dev/null")
+
     stub_ticks
       .with("bw status")
       .returns(
@@ -101,6 +111,8 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch locked" do
+    stub_ticks.with("bw --version 2> /dev/null")
+
     stub_ticks
       .with("bw status")
       .returns(
@@ -126,6 +138,8 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch locked with session" do
+    stub_ticks.with("bw --version 2> /dev/null")
+
     stub_ticks
       .with("bw status")
       .returns(
@@ -148,6 +162,15 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     expected_json = { "mypassword"=>"secret123" }
 
     assert_equal expected_json, json
+  end
+
+  test "fetch without CLI installed" do
+    stub_ticks_with("bw --version 2> /dev/null", succeed: false)
+
+    error = assert_raises RuntimeError do
+      JSON.parse(shellunescape(run_command("fetch", "mynote")))
+    end
+    assert_equal "Bitwarden CLI is not installed", error.message
   end
 
   private

--- a/test/secrets/last_pass_adapter_test.rb
+++ b/test/secrets/last_pass_adapter_test.rb
@@ -6,6 +6,7 @@ class LastPassAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch" do
+    stub_ticks.with("lpass --version 2> /dev/null")
     stub_ticks.with("lpass status --color never").returns("Logged in as email@example.com.")
 
     stub_ticks
@@ -63,6 +64,7 @@ class LastPassAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with from" do
+    stub_ticks.with("lpass --version 2> /dev/null")
     stub_ticks.with("lpass status --color never").returns("Logged in as email@example.com.")
 
     stub_ticks
@@ -107,6 +109,8 @@ class LastPassAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with signin" do
+    stub_ticks.with("lpass --version 2> /dev/null")
+
     stub_ticks_with("lpass status --color never", succeed: false).returns("Not logged in.")
     stub_ticks_with("lpass login email@example.com", succeed: true).returns("")
     stub_ticks.with("lpass show SECRET1 --json").returns(single_item_json)
@@ -118,6 +122,15 @@ class LastPassAdapterTest < SecretAdapterTestCase
     }
 
     assert_equal expected_json, json
+  end
+
+  test "fetch without CLI installed" do
+    stub_ticks_with("lpass --version 2> /dev/null", succeed: false)
+
+    error = assert_raises RuntimeError do
+      JSON.parse(shellunescape(run_command("fetch", "SECRET1", "FOLDER1/FSECRET1", "FOLDER1/FSECRET2")))
+    end
+    assert_equal "LastPass CLI is not installed", error.message
   end
 
   private

--- a/test/secrets/one_password_adapter_test.rb
+++ b/test/secrets/one_password_adapter_test.rb
@@ -2,6 +2,7 @@ require "test_helper"
 
 class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   test "fetch" do
+    stub_ticks.with("op --version 2> /dev/null")
     stub_ticks.with("op account get --account myaccount 2> /dev/null")
 
     stub_ticks
@@ -56,6 +57,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with multiple items" do
+    stub_ticks.with("op --version 2> /dev/null")
     stub_ticks.with("op account get --account myaccount 2> /dev/null")
 
     stub_ticks
@@ -115,6 +117,8 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with signin, no session" do
+    stub_ticks.with("op --version 2> /dev/null")
+
     stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
     stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("")
 
@@ -132,6 +136,8 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with signin and session" do
+    stub_ticks.with("op --version 2> /dev/null")
+
     stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
     stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("1234567890")
 
@@ -146,6 +152,15 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     }
 
     assert_equal expected_json, json
+  end
+
+  test "fetch without CLI installed" do
+    stub_ticks_with("op --version 2> /dev/null", succeed: false)
+
+    error = assert_raises RuntimeError do
+      JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3")))
+    end
+    assert_equal "1Password CLI is not installed", error.message
   end
 
   private


### PR DESCRIPTION
While configuring the 1Password secrets adapter I kept running into a confusing error ("Failed to login to 1Password") despite having followed the documentation and read through some issues threads. I ultimately had to dive into the code to discover that it relies on a CLI that I didn't have installed.

I figured surfacing a meaningful error message when the CLI is missing might save a lot of folks time in the future.

To achieve this I added a `check_dependencies!` method to all adapters that gets called as the first line in the `fetch` method. For now each one just checks that the CLI is installed, but it's behavior could be expanded in the future. (For example, after installing the 1Password CLI you also need to configure it. In the future, the 1Password adapter's `check_dependencies!` method could be expanded to also check that the CLI is configured.)

I'm open to any and all feedback on this. Thanks!