### PR TITLE
Updated secrets error message if secrets files do not exist

### DIFF
--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -31,4 +31,18 @@ class SecretsTest < ActiveSupport::TestCase
       assert_equal "JKL", Kamal::Secrets.new(destination: "nodest")["SECRET2"]
     end
   end
+
+  test "no secrets files" do
+    with_test_secrets do
+      error = assert_raises(Kamal::ConfigurationError) do
+        Kamal::Secrets.new["SECRET"]
+      end
+      assert_equal "Secret 'SECRET' not found, no secret files (.kamal/secrets-common, .kamal/secrets) provided", error.message
+
+      error = assert_raises(Kamal::ConfigurationError) do
+        Kamal::Secrets.new(destination: "dest")["SECRET"]
+      end
+      assert_equal "Secret 'SECRET' not found, no secret files (.kamal/secrets-common, .kamal/secrets.dest) provided", error.message
+    end
+  end
 end


### PR DESCRIPTION
When you initialize a new project a `.kamal/secrets` file is created. If you create a new destination config `config/deploy.other.yml` and try to deploy you get the obscure error message `ERROR (Kamal::ConfigurationError): Secret 'KAMAL_REGISTRY_PASSWORD' not found in`. The error message should have been `Secret 'KAMAL_REGISTRY_PASSWORD' not found, no secret files provided` but there was a small bug with `[]` being considered `true`.

The original error message doesn't mention that you need to create `.kamal/secrets-common` or `.kamal/secrets.other`. This PR updates the error message so that you are made aware of the the secrets files that Kamal is looking for.