### PR TITLE
Require zeitwerk 2.6.18

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,7 +11,7 @@ PATH
       net-ssh (~> 7.0)
       sshkit (>= 1.23.0, < 2.0)
       thor (~> 1.3)
-      zeitwerk (~> 2.5)
+      zeitwerk (>= 2.6.18, < 3.0)
 
 GEM
   remote: https://rubygems.org/
@@ -167,7 +167,7 @@ GEM
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
     webrick (1.8.2)
-    zeitwerk (2.6.17)
+    zeitwerk (2.7.1)
 
 PLATFORMS
   arm64-darwin

--- a/kamal.gemspec
+++ b/kamal.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "net-ssh", "~> 7.0"
   spec.add_dependency "thor", "~> 1.3"
   spec.add_dependency "dotenv", "~> 3.1"
-  spec.add_dependency "zeitwerk", "~> 2.5"
+  spec.add_dependency "zeitwerk", ">= 2.6.18", "< 3.0"
   spec.add_dependency "ed25519", "~> 1.2"
   spec.add_dependency "bcrypt_pbkdf", "~> 1.0"
   spec.add_dependency "concurrent-ruby", "~> 1.2"


### PR DESCRIPTION
We were requiring Zeitwerk 2.5+, but calling eager_load_namespace which was added in 2.6.2.

Fixes: https://github.com/basecamp/kamal/issues/1109