### PR TITLE
Allow log max size to not be set

### DIFF
--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -37,7 +37,6 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
       ]
 
       on(KAMAL.proxy_hosts) do |host|
-        p boot_options
         execute(*KAMAL.proxy.ensure_proxy_directory)
         upload! StringIO.new(boot_options.join(" ")), KAMAL.config.proxy_options_file
       end

--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -37,6 +37,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
       ]
 
       on(KAMAL.proxy_hosts) do |host|
+        p boot_options
         execute(*KAMAL.proxy.ensure_proxy_directory)
         upload! StringIO.new(boot_options.join(" ")), KAMAL.config.proxy_options_file
       end

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -254,7 +254,7 @@ class Kamal::Configuration
   end
 
   def proxy_logging_args(max_size)
-    argumentize "--log-opt", "max-size=#{max_size}"
+    argumentize "--log-opt", "max-size=#{max_size}" if max_size.present?
   end
 
   def proxy_options_default

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -263,6 +263,15 @@ class CliProxyTest < CliTestCase
     end
   end
 
+  test "boot_config set no log max size" do
+    run_command("boot_config", "set", "--log-max-size=").tap do |output|
+      %w[ 1.1.1.1 1.1.1.2 ].each do |host|
+        assert_match "Running /usr/bin/env mkdir -p .kamal/proxy on #{host}", output
+        assert_match "Uploading \"--publish 80:80 --publish 443:443\" to .kamal/proxy/options on #{host}", output
+      end
+    end
+  end
+
   test "boot_config set custom ports" do
     run_command("boot_config", "set", "--http-port", "8080", "--https-port", "8443").tap do |output|
       %w[ 1.1.1.1 1.1.1.2 ].each do |host|


### PR DESCRIPTION
The max-size log opt is not valid for all logging drivers, such as syslog. Allow the option to be removed from the boot config with:

```
kamal proxy boot_config set --log-max-size=
or
kamal proxy boot_config set --log-max-size=""
```

Fix for https://github.com/basecamp/kamal/issues/1143