### PR TITLE
Remove trailing spaces from deploy.yml template

### DIFF
--- a/lib/kamal/cli/templates/deploy.yml
+++ b/lib/kamal/cli/templates/deploy.yml
@@ -16,8 +16,8 @@ servers:
 # Enable SSL auto certification via Let's Encrypt and allow for multiple apps on a single web server.
 # Remove this section when using multiple web servers and ensure you terminate SSL at your load balancer.
 #
-# Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption. 
-proxy: 
+# Note: If using Cloudflare, set encryption mode in SSL/TLS setting to "Full" to enable CF-to-app encryption.
+proxy:
   ssl: true
   host: app.example.com
   # Proxy connects to your container on port 80 by default.


### PR DESCRIPTION
Just a minor cleanup, nothing important.
`git` highlighted these spaces in red in my commit so I thought I'd remove them.
