### PR TITLE
Bump proxy minimum version to 0.8.2

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -14,7 +14,7 @@ class Kamal::Configuration
 
   include Validation
 
-  PROXY_MINIMUM_VERSION = "v0.8.1"
+  PROXY_MINIMUM_VERSION = "v0.8.2"
   PROXY_HTTP_PORT = 80
   PROXY_HTTPS_PORT = 443
   PROXY_LOG_MAX_SIZE = "10m"


### PR DESCRIPTION
Detect event-stream content type properly

See: https://github.com/basecamp/kamal-proxy/releases/tag/v0.8.2