### PR TITLE
add host-docker-setup hook

### DIFF
--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -32,6 +32,7 @@ class Kamal::Cli::Server < Kamal::Cli::Base
           if execute(*KAMAL.docker.superuser?, raise_on_non_zero_exit: false)
             info "Missing Docker on #{host}. Installing…"
             execute *KAMAL.docker.install
+            run_hook "host-docker-setup"
           else
             missing << host
           end

--- a/test/cli/server_test.rb
+++ b/test/cli/server_test.rb
@@ -57,11 +57,13 @@ class CliServerTest < CliTestCase
     Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).returns(true)
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with(".kamal/hooks/pre-connect", anything).at_least_once
     SSHKit::Backend::Abstract.any_instance.expects(:execute).with(".kamal/hooks/docker-setup", anything).at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(".kamal/hooks/host-docker-setup", anything).at_least_once
 
     run_command("bootstrap").tap do |output|
       ("1.1.1.1".."1.1.1.4").map do |host|
         assert_match "Missing Docker on #{host}. Installing…", output
         assert_match "Running the docker-setup hook", output
+        assert_match "Running the host-docker-setup hook", output
       end
     end
   end

--- a/test/integration/docker/deployer/app/.kamal/hooks/host-docker-setup
+++ b/test/integration/docker/deployer/app/.kamal/hooks/host-docker-setup
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Host Docker set up!"
+mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/host-docker-setup

--- a/test/integration/docker/deployer/app_with_roles/.kamal/hooks/host-docker-setup
+++ b/test/integration/docker/deployer/app_with_roles/.kamal/hooks/host-docker-setup
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Host Docker set up!"
+mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/host-docker-setup


### PR DESCRIPTION
Add new hook to run in host after docker is installed.

Motivation: Install docker plug-ins in the host, such as log-drivers.

`host-docker-setup` hook example:

```bash
#!/bin/sh

echo "Docker set up on $KAMAL_HOSTS..."

# Check if the Loki Docker Driver plug-in is already installed
if ! docker plugin ls | grep -q "loki"; then
  echo "Installing Loki Docker Driver plug-in..."
  docker plugin install grafana/loki-docker-driver:2.9.2 --alias loki --grant-all-permissions
else
  echo "Loki Docker Driver plug-in is already installed."
fi
```

This will enable the usage of custom logging driver in the config:

```yaml
# deploy.yml

logging:
  driver: loki
  options:
    loki-url: https://<user_id>:<password>@logs-us-west1.grafana.net/loki/api/v1/push
    loki-batch-size: "400"
```
