### PR TITLE
Improve error on unknown role in accessories config.

### DIFF
--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -176,7 +176,9 @@ class Kamal::Configuration::Accessory
 
     def hosts_from_roles
       if accessory_config.key?("roles")
-        accessory_config["roles"].flat_map { |role| config.role(role).hosts }
+        accessory_config["roles"].flat_map do |role|
+          config.role(role)&.hosts || raise(Kamal::ConfigurationError, "Unknown role in accessories config: '#{role}'")
+        end
       end
     end
 


### PR DESCRIPTION
Previously when unknown role (or with typo) was placed in accessories.roles, this error was thrown: `ERROR (NoMethodError): undefined method `hosts' for nil`.