### PR TITLE
Warn user on blank secrets

### DIFF
--- a/lib/kamal/configuration/registry.rb
+++ b/lib/kamal/configuration/registry.rb
@@ -24,7 +24,15 @@ class Kamal::Configuration::Registry
   private
     def lookup(key)
       if registry_config[key].is_a?(Array)
-        secrets[registry_config[key].first]
+        secret = secrets[registry_config[key].first]
+        # Although the key is present, its value may be empty due to environment
+        # variable substitution. I.e. if it refers to an empty or unset env var.
+        unless secret.present?
+          raise Kamal::ConfigurationError, "The required secret " \
+            "'registry.#{key}' does not have a value."
+        end
+
+        secret
       else
         registry_config[key]
       end

--- a/test/commands/registry_test.rb
+++ b/test/commands/registry_test.rb
@@ -49,6 +49,18 @@ class CommandsRegistryTest < ActiveSupport::TestCase
     end
   end
 
+  test "registry login with blank ENV password" do
+    with_test_secrets("secrets" => "KAMAL_REGISTRY_PASSWORD=") do
+      @config[:registry]["password"] = [ "KAMAL_REGISTRY_PASSWORD" ]
+
+      assert_raises Kamal::ConfigurationError do
+        assert_equal \
+          "docker login hub.docker.com -u \"dhh\" -p \"\"",
+          registry.login.join(" ")
+      end
+    end
+  end
+
   test "registry logout" do
     assert_equal \
       "docker logout hub.docker.com",


### PR DESCRIPTION
# Motivation

It's easy to misconfigure Kamal secrets, secret helpers, and environment variables. This is especially true for i) users who are new to Kamal, ii) users who [may not have noticed](https://github.com/basecamp/kamal/issues/970#issuecomment-2376520786) the changes to secrets between Kamal 1 and 2, and iii) users like myself who are using Kamal inside Docker and/or in remote environments.

To see how often people have challenges related to secrets, consider the number of issues opened [about them](https://github.com/basecamp/kamal/issues?q=secret+in%3Atitle+is%3Aissue). For example, #970, [#1001](https://github.com/basecamp/kamal/issues/1001#issuecomment-2381392373), #1108, and [discussion 977](https://github.com/basecamp/kamal/discussions/977#discussion-7238545). Secrets are simple yet easy to get wrong!

We should make it easier for users to get back on track when secrets are misconfigured. This PR makes it easier.

# Pain point

Currently, if secret values are blank, there is no warning.

A common special case is when `KAMAL_REGISTRY_PASSWORD` is not set, as easily happens if the user is trying to get Kamal to work in, say, a GitHub Action. This causes `kamal setup` and `kamal deploy` to emit the following output. (This example is from #970.)

```
$ kamal setup
  INFO [4a37da09] Running /usr/bin/env mkdir -p .kamal on 1.2.3.4
  INFO [4a37da09] Finished in 5.948 seconds with exit status 0 (successful).
Acquiring the deploy lock...
Ensure Docker is installed...
  INFO [312bfcba] Running docker -v on 1.2.3.4
  INFO [312bfcba] Finished in 1.201 seconds with exit status 0 (successful).
  INFO [05559197] Running docker login registry.gitlab.com -u [REDACTED] -p [REDACTED] on 1.2.3.4
Releasing the deploy lock...
  Finished all in 9.5 seconds
  ERROR (SSHKit::Command::Failed): Exception while executing on host 1.2.3.4: docker exit status: 125
docker stdout: Nothing written
docker stderr: flag needs an argument: 'p' in -p
See 'docker login --help'.
```

It's hard to understand the root cause there.

# Proposed change

* `Kamal::Secrets` should show a warning whenever it loads an empty value.
* If there is no registry password, `Kamal::Configuration::Registry` should raise a helpful exception instead of showing that Docker argument error.

# New behaviour introduced by this PR

1. Any time `Kamal::Secrets::[]` fetches a blank value, it displays a warning and tips, as shown in the next cases where a blank value is fetched by `Kamal::Configuration::Registry`.

2. If a blank registry password comes from an unset environment variable, the user sees the warning and tips, and a `Kamal::ConfigurationError` is raised. (Similar if the env var is set to the empty string.)
```
bundle exec ../kamal/bin/kamal deploy
Log into image registry...
Warning: Kamal secret key 'KAMAL_REGISTRY_PASSWORD' is blank.
Tip: see .kamal/secrets:8: KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD
Tip: the environment variable KAMAL_REGISTRY_PASSWORD is not set. Did you forget to set it?
  Finished all in 0.1 seconds
  ERROR (Kamal::ConfigurationError): The required secret 'registry.password' does not have a value.
```

3. If a blank value comes from a secret helper, these are the tips:
```
Tip: see .kamal/secrets:8: KAMAL_REGISTRY_PASSWORD=$(echo '')
Tip: the shell command `echo ''` returned an empty value.
```

# Other comments

It's true that `Kamal::Configuration::Registry` [validates](https://github.com/basecamp/kamal/blob/9cf8da64c402897701a54ddd44375df166ab5233/lib/kamal/configuration/validator/registry.rb#L10) the presence of the password key, but it does not detect when that key is replaced with an empty value.

I'm happy to make any change to this PR, just let me know. Thanks for contributing to Kamal!