### PR TITLE
Adds support for SBOM attestations

### DIFF
--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -6,7 +6,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   delegate :argumentize, to: Kamal::Utils
   delegate \
     :args, :secrets, :dockerfile, :target, :arches, :local_arches, :remote_arches, :remote,
-    :cache_from, :cache_to, :ssh, :provenance, :driver, :docker_driver?,
+    :cache_from, :cache_to, :ssh, :provenance, :sbom, :driver, :docker_driver?,
     to: :builder_config
 
   def clean
@@ -37,7 +37,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   end
 
   def build_options
-    [ *build_tags, *build_cache, *build_labels, *build_args, *build_secrets, *build_dockerfile, *build_target, *build_ssh, *builder_provenance ]
+    [ *build_tags, *build_cache, *build_labels, *build_args, *build_secrets, *build_dockerfile, *build_target, *build_ssh, *builder_provenance, *builder_sbom ]
   end
 
   def build_context
@@ -99,6 +99,10 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
 
     def builder_provenance
       argumentize "--provenance", provenance unless provenance.nil?
+    end
+
+    def builder_sbom
+      argumentize "--sbom", sbom unless sbom.nil?
     end
 
     def builder_config

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -115,6 +115,10 @@ class Kamal::Configuration::Builder
     builder_config["provenance"]
   end
 
+  def sbom
+    builder_config["sbom"]
+  end
+
   def git_clone?
     Kamal::Git.used? && builder_config["context"].nil?
   end

--- a/lib/kamal/configuration/docs/builder.yml
+++ b/lib/kamal/configuration/docs/builder.yml
@@ -108,3 +108,9 @@ builder:
   # It is used to configure provenance attestations for the build result.
   # The value can also be a boolean to enable or disable provenance attestations.
   provenance: mode=max
+
+  # SBOM (Software Bill of Materials)
+  #
+  # It is used to configure SBOM generation for the build result.
+  # The value can also be a boolean to enable or disable SBOM generation.
+  sbom: true

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -158,6 +158,20 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "push with sbom" do
+    builder = new_builder_command(builder: { "sbom" => true })
+    assert_equal \
+      "docker buildx build --push --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --sbom true .",
+      builder.push.join(" ")
+  end
+
+  test "push with sbom false" do
+    builder = new_builder_command(builder: { "sbom" => false })
+    assert_equal \
+      "docker buildx build --push --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --sbom false .",
+      builder.push.join(" ")
+  end
+
   test "mirror count" do
     command = new_builder_command
     assert_equal "docker info --format '{{index .RegistryConfig.Mirrors 0}}'", command.first_mirror.join(" ")

--- a/test/configuration/builder_test.rb
+++ b/test/configuration/builder_test.rb
@@ -144,6 +144,16 @@ class ConfigurationBuilderTest < ActiveSupport::TestCase
     assert_equal "mode=max", config.builder.provenance
   end
 
+  test "sbom" do
+    assert_nil config.builder.sbom
+  end
+
+  test "setting sbom" do
+    @deploy[:builder]["sbom"] = true
+
+    assert_equal true, config.builder.sbom
+  end
+
   test "local disabled but no remote set" do
     @deploy[:builder]["local"] = false
 


### PR DESCRIPTION
## Summary
This PR adds a `sbom` option in the builder config. You can use `sbom: true` to have the Docker buildx include `--sbom=true`, so that the generated image includes [SBOM Attestations](https://docs.docker.com/build/metadata/attestations/sbom/). This is helpful, as [Docker Scout](https://docs.docker.com/scout/) includes a default policy rule of "Missing supply chain attestation(s)" which fails for the rule "SBOM attestation (https://spdx.dev/Document) exists" for images generated by Kamal.

## Related information
This PR is modeled after the merged PR https://github.com/basecamp/kamal/pull/972 that introduced `provenance` attestations.