### PR TITLE
kamal app exec may fail if not logged in

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -97,6 +97,10 @@ class Kamal::Cli::App < Kamal::Cli::Base
   def exec(*cmd)
     cmd = Kamal::Utils.join_commands(cmd)
     env = options[:env]
+    unless options[:reuse]
+      say "Log into image registry...", :magenta
+      invoke "kamal:cli:registry:login", [], {skip_local: true}
+    end
     case
     when options[:interactive] && options[:reuse]
       say "Get current version of running container...", :magenta unless options[:version]

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -299,6 +299,17 @@ class CliAppTest < CliTestCase
     end
   end
 
+  test "exec logs into the container registry remotely for new containers" do
+    run_command("exec", "ruby -v").tap do |output|
+      assert_no_match /docker login -u \[REDACTED\] -p \[REDACTED\] as .*@localhost/, output
+      assert_match /docker login -u \[REDACTED\] -p \[REDACTED\] on 1.1.1.\d/, output
+    end
+    # Login is never required if reuse
+    run_command("exec", "-i", "--reuse", "ruby -v").tap do |output|
+      assert_no_match /docker login -u \[REDACTED\] -p \[REDACTED\] on 1.1.1.\d/, output
+    end
+  end
+
   test "containers" do
     run_command("containers").tap do |output|
       assert_match "docker container ls --all --filter label=service=app", output


### PR DESCRIPTION
# Current state

The central Kamal command, `kamal deploy`, automatically logs you in because it requires access to the container registry.

Unlike the deploy command, `kamal app exec` does not log you in. Yet it sometimes requires registry access too. In these cases, when the host is not auth'd, it fails.

Why would `kamal app exec` need auth? When you tell it to use an image that's not currently on the host, as in #1163.

Note that containers don't stay authorized very long. Container registry session tokens expire pretty quickly:

| Registry | Session expiry |
| ------| ----| 
| Amazon ECR | [12 hours](https://docs.aws.amazon.com/AmazonECR/latest/userguide/registry_auth.html#:~:text=valid%20for%2012%20hours) |
| Azure Container Registry | [3 hours](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-authentication#:~:text=3%20hours) |
| Docker Hub | [24 hours](https://docs.docker.com/security/faqs/general#:~:text=24%20hours) |
| GitHub Container Registry | varies |
| Harbor | [30 minutes?](https://github.com/goharbor/harbor/blob/main/src/common/utils/test/config.go#L55) |

# Proposed state

It would be nice for all Kamal commands to have the same “it just works” auth behavior. I think this is the simplicity that attracts people to Kamal. So it would be nice if `kamal exec` took care of its own auth, like `kamal deploy` does.

# Changes introduced by this PR

This PR makes `kamal app exec` log in before executing `docker run`.

# Other comments

If this PR is approved I'd be happy to make a follow-up PR for `kamal accessory exec`.

Resolves #1163.