### PR TITLE
[FIX] - Make kamal use ssh keys from config when performing commands

### DIFF
--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -96,12 +96,13 @@ module Kamal::Commands
       end
 
       def ssh_keys_args
-        args = ""
-        config.ssh.keys&.each do |key|
-          args << " -i #{key}"
+        "#{ ssh_keys.join("") if ssh_keys}" + "#{" -o IdentitiesOnly=yes" if config.ssh&.keys_only}"
+      end
+
+      def ssh_keys
+        config.ssh.keys&.map do |key|
+          " -i #{key}"
         end
-        args << " -o IdentitiesOnly=yes" if config.ssh&.keys_only
-        args
       end
   end
 end

--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -11,7 +11,7 @@ module Kamal::Commands
     end
 
     def run_over_ssh(*command, host:)
-      "ssh#{ssh_proxy_args} -t #{config.ssh.user}@#{host} -p #{config.ssh.port} '#{command.join(" ").gsub("'", "'\\\\''")}'"
+      "ssh#{ssh_proxy_args}#{ssh_keys_args} -t #{config.ssh.user}@#{host} -p #{config.ssh.port} '#{command.join(" ").gsub("'", "'\\\\''")}'"
     end
 
     def container_id_for(container_name:, only_running: false)
@@ -93,6 +93,15 @@ module Kamal::Commands
         when Net::SSH::Proxy::Command
           " -o ProxyCommand='#{config.ssh.proxy.command_line_template}'"
         end
+      end
+
+      def ssh_keys_args
+        args = ""
+        config.ssh.keys&.each do |key|
+          args << " -i #{key}"
+        end
+        args << " -o IdentitiesOnly=yes" if config.ssh&.keys_only
+        args
       end
   end
 end

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -315,6 +315,16 @@ class CommandsAppTest < ActiveSupport::TestCase
     assert_equal "ssh -J root@2.2.2.2 -t app@1.1.1.1 -p 22 'ls'", new_command.run_over_ssh("ls", host: "1.1.1.1")
   end
 
+  test "run over ssh with keys config" do
+    @config[:ssh] = { "keys" => [ "path_to_key.pem" ] }
+    assert_equal "ssh -i path_to_key.pem -t root@1.1.1.1 -p 22 'ls'", new_command.run_over_ssh("ls", host: "1.1.1.1")
+  end
+
+  test "run over ssh with keys config with keys_only" do
+    @config[:ssh] = { "keys" => [ "path_to_key.pem" ], "keys_only" => true }
+    assert_equal "ssh -i path_to_key.pem -o IdentitiesOnly=yes -t root@1.1.1.1 -p 22 'ls'", new_command.run_over_ssh("ls", host: "1.1.1.1")
+  end
+
   test "run over ssh with proxy_command" do
     @config[:ssh] = { "proxy_command" => "ssh -W %h:%p user@proxy-server" }
     assert_equal "ssh -o ProxyCommand='ssh -W %h:%p user@proxy-server' -t root@1.1.1.1 -p 22 'ls'", new_command.run_over_ssh("ls", host: "1.1.1.1")


### PR DESCRIPTION
Hey!

I've taken this PR: https://github.com/basecamp/kamal/pull/959 that worked fine and fixed the conflicts trying to maintain the approach of the previous code change for `ssh_proxy_args`.

I guess this PR should also fix https://github.com/basecamp/kamal/issues/1053 and so we should probably be able to close this too: https://github.com/basecamp/kamal/pull/1087