### PR TITLE
Support line filtering when running tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,6 +2,7 @@ require "bundler/setup"
 require "active_support/test_case"
 require "active_support/testing/autorun"
 require "active_support/testing/stream"
+require "rails/test_unit/line_filtering"
 require "debug"
 require "mocha/minitest" # using #stubs that can alter returns
 require "minitest/autorun" # using #stub that take args
@@ -32,6 +33,7 @@ end
 
 class ActiveSupport::TestCase
   include ActiveSupport::Testing::Stream
+  extend Rails::LineFiltering
 
   private
     def stdouted


### PR DESCRIPTION
Supports running individual tests by line number, e.g.

`bin/test test/cli/main_test.rb:461`