### PR TITLE
Add support for exec output in accessories

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -112,14 +112,15 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     end
   end
 
-  desc "exec [NAME] [CMD]", "Execute a custom command on servers (use --help to show options)"
+  desc "exec [NAME] [CMD...]", "Execute a custom command on servers within the accessory container (use --help to show options)"
   option :interactive, aliases: "-i", type: :boolean, default: false, desc: "Execute command over ssh for an interactive shell (use for console/bash)"
   option :reuse, type: :boolean, default: false, desc: "Reuse currently running container instead of starting a new one"
-  def exec(name, cmd)
+  def exec(name, *cmd)
+    cmd = Kamal::Utils.join_commands(cmd)
     with_accessory(name) do |accessory, hosts|
       case
       when options[:interactive] && options[:reuse]
-        say "Launching interactive command with via SSH from existing container...", :magenta
+        say "Launching interactive command via SSH from existing container...", :magenta
         run_locally { exec accessory.execute_in_existing_container_over_ssh(cmd) }
 
       when options[:interactive]
@@ -128,16 +129,16 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
       when options[:reuse]
         say "Launching command from existing container...", :magenta
-        on(hosts) do
+        on(hosts) do |host|
           execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{name} accessory"), verbosity: :debug
-          capture_with_info(*accessory.execute_in_existing_container(cmd))
+          puts_by_host host, capture_with_info(*accessory.execute_in_existing_container(cmd))
         end
 
       else
         say "Launching command from new container...", :magenta
-        on(hosts) do
+        on(hosts) do |host|
           execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{name} accessory"), verbosity: :debug
-          capture_with_info(*accessory.execute_in_new_container(cmd))
+          puts_by_host host, capture_with_info(*accessory.execute_in_new_container(cmd))
         end
       end
     end


### PR DESCRIPTION
When running accessory exec now you get the output from the hosts.

Also you can pass commands with arguments and it will work e.g.: cat yourfilename

I've taken the same approach that is applied on app exec, I think it's useful to get output from accessories, like for what happens with main app.