### PR TITLE
Output role name along with container logs

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -218,7 +218,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
         roles.each do |role|
           begin
-            puts_by_host host, capture_with_info(*KAMAL.app(role: role, host: host).logs(timestamps: timestamps, since: since, lines: lines, grep: grep, grep_options: grep_options))
+            puts_by_host host, capture_with_info(*KAMAL.app(role: role, host: host).logs(timestamps: timestamps, since: since, lines: lines, grep: grep, grep_options: grep_options)), type: role
           rescue SSHKit::Command::Failed
             puts_by_host host, "Nothing found"
           end


### PR DESCRIPTION
Improves the output of `kamal app logs -q -n 1`, by printing the role instead of the word "App"

**Before**

```
App Host: bc4-beta-jobs-03
2024-11-22T11:30:41.641044197Z 172.18.0.6 - - [22/Nov/2024:11:30:41 +0000] "GET /metrics HTTP/1.1" 200 - 0.0102

App Host: bc4-beta-jobs-03
2024-11-22T11:30:41.378680867Z 172.18.0.6 - - [22/Nov/2024:11:30:41 +0000] "GET /metrics HTTP/1.1" 200 - 0.0005
```

**After**

```
solid_queue_dispatcher Host: bc4-beta-jobs-03
2024-11-22T11:30:41.641044197Z 172.18.0.6 - - [22/Nov/2024:11:30:41 +0000] "GET /metrics HTTP/1.1" 200 - 0.0102

resque_jobs Host: bc4-beta-jobs-03
2024-11-22T11:30:41.378680867Z 172.18.0.6 - - [22/Nov/2024:11:30:41 +0000] "GET /metrics HTTP/1.1" 200 - 0.0005
```