### PR TITLE
Cleanly remove all accessory locations

### DIFF
--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -91,7 +91,7 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
   end
 
   def remove_service_directory
-    [ :rm, "-rf", service_name ]
+    [ :sudo, :rm, "-rf", service_name ]
   end
 
   def remove_container


### PR DESCRIPTION
**The problem**

PostgreSQL accessory might create a data directory with the following permissions:

```
$ sudo ls /home/quick_test/quick_test-postgres -all
total 12
drwxrwxr-x  3 quick_test quick_test 4096 Oct 11 14:06 .
drwxr-x---  7 quick_test quick_test 4096 Oct 11 14:06 ..
drwx------ 19        999 quick_test 4096 Oct 11 14:06 data
```

Since I used `quick_test` as my SSH user, I am not able to run `kamal remove` without failing.

**The solution**

I would like to be able to use non-root users while still being able to do a clean `kamal remove`.

Kamal doesn't come with a concept of `sudo` which would be one solution to the problem.

But we could still probably run with sudo for this one case even if we don't want to have a special
sudo commands in Kamal.

It's the only really problematic place for me while running with regular users rather than root.

I understand that this still requires the user to have this access, however, this will fail either way.