### PR TITLE
Bump proxy minimum version to 0.8.3

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -14,7 +14,7 @@ class Kamal::Configuration
 
   include Validation
 
-  PROXY_MINIMUM_VERSION = "v0.8.2"
+  PROXY_MINIMUM_VERSION = "v0.8.3"
   PROXY_HTTP_PORT = 80
   PROXY_HTTPS_PORT = 443
   PROXY_LOG_MAX_SIZE = "10m"


### PR DESCRIPTION
https://github.com/basecamp/kamal-proxy/releases/tag/v0.8.3

> - Populate X-Request-Start header
> - Log client disconnections with status 499
> - Use an identifiable `User-Agent` header on healthcheck requests
> - When target fails to become healthy, mention timeout in error message


Note: I'm also happy to implement a mechanism that doesn't require bumping the minimum version for every patch release. See #1252 