### PR TITLE
Add proxy boot_config --publish-ip argument

### DIFF
--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -23,6 +23,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
 
   desc "boot_config <set|get|reset>", "Manage kamal-proxy boot configuration"
   option :publish, type: :boolean, default: true, desc: "Publish the proxy ports on the host"
+  option :publish_ip, type: :string, desc: "IP address to bind HTTP/HTTPS traffic to. Defaults to all interfaces"
   option :http_port, type: :numeric, default: Kamal::Configuration::PROXY_HTTP_PORT, desc: "HTTP port to publish on the host"
   option :https_port, type: :numeric, default: Kamal::Configuration::PROXY_HTTPS_PORT, desc: "HTTPS port to publish on the host"
   option :log_max_size, type: :string, default: Kamal::Configuration::PROXY_LOG_MAX_SIZE, desc: "Max size of proxy logs"
@@ -31,7 +32,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
     case subcommand
     when "set"
       boot_options = [
-        *(KAMAL.config.proxy_publish_args(options[:http_port], options[:https_port]) if options[:publish]),
+        *(KAMAL.config.proxy_publish_args(options[:http_port], options[:https_port], options[:publish_ip]) if options[:publish]),
         *(KAMAL.config.proxy_logging_args(options[:log_max_size])),
         *options[:docker_options].map { |option| "--#{option}" }
       ]

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -249,8 +249,9 @@ class Kamal::Configuration
     env_tags.detect { |t| t.name == name.to_s }
   end
 
-  def proxy_publish_args(http_port, https_port)
-    argumentize "--publish", [ "#{http_port}:#{PROXY_HTTP_PORT}", "#{https_port}:#{PROXY_HTTPS_PORT}" ]
+  def proxy_publish_args(http_port, https_port, bind_ip = nil)
+    bind_ip = bind_ip ? "#{bind_ip}:" : ""
+    argumentize "--publish", [ "#{bind_ip}#{http_port}:#{PROXY_HTTP_PORT}", "#{bind_ip}#{https_port}:#{PROXY_HTTPS_PORT}" ]
   end
 
   def proxy_logging_args(max_size)

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -281,6 +281,15 @@ class CliProxyTest < CliTestCase
     end
   end
 
+  test "boot_config set custom bind ip" do
+    run_command("boot_config", "set", "--publish-ip", "127.0.0.1").tap do |output|
+      %w[ 1.1.1.1 1.1.1.2 ].each do |host|
+        assert_match "Running /usr/bin/env mkdir -p .kamal/proxy on #{host}", output
+        assert_match "Uploading \"--publish 127.0.0.1:80:80 --publish 127.0.0.1:443:443 --log-opt max-size=10m\" to .kamal/proxy/options on #{host}", output
+      end
+    end
+  end
+
   test "boot_config set docker options" do
     run_command("boot_config", "set", "--docker_options", "label=foo=bar", "add_host=thishost:thathost").tap do |output|
       %w[ 1.1.1.1 1.1.1.2 ].each do |host|


### PR DESCRIPTION
Implements https://github.com/basecamp/kamal-proxy/issues/74

Allows for `kamal proxy boot_config set --publish-ip=x.x.x.x`

Context:
By default Docker will bind to all available interfaces.