### PR TITLE
run_over_ssh does not respect the ssh keys in deploy.yml

### DIFF
--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -11,7 +11,7 @@ module Kamal::Commands
     end
 
     def run_over_ssh(*command, host:)
-      "ssh#{ssh_proxy_args} -t #{config.ssh.user}@#{host} -p #{config.ssh.port} '#{command.join(" ").gsub("'", "'\\\\''")}'"
+      "ssh#{ssh_proxy_args}#{identity_args} -t #{config.ssh.user}@#{host} -p #{config.ssh.port} '#{command.join(" ").gsub("'", "'\\\\''")}'"
     end
 
     def container_id_for(container_name:, only_running: false)
@@ -92,6 +92,14 @@ module Kamal::Commands
           " -J #{config.ssh.proxy.jump_proxies}"
         when Net::SSH::Proxy::Command
           " -o ProxyCommand='#{config.ssh.proxy.command_line_template}'"
+        end
+      end
+
+      def identity_args
+        if config.ssh.keys
+          config.ssh.keys.map { |key| " -i #{key}" }.join
+        else
+          ""
         end
       end
   end

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -290,6 +290,11 @@ class CommandsAppTest < ActiveSupport::TestCase
     assert_equal "ssh -t root@1.1.1.1 -p 22 'ls'", new_command.run_over_ssh("ls", host: "1.1.1.1")
   end
 
+   test "run over ssh with keys" do
+    @config[:ssh] = { "keys" => [ "key1", "key2" ] }
+    assert_equal "ssh -i key1 -i key2 -t root@1.1.1.1 -p 22 'ls'", new_command.run_over_ssh("ls", host: "1.1.1.1")
+  end
+
   test "run over ssh with custom user" do
     @config[:ssh] = { "user" => "app" }
     assert_equal "ssh -t app@1.1.1.1 -p 22 'ls'", new_command.run_over_ssh("ls", host: "1.1.1.1")


### PR DESCRIPTION
When `deploy.yml` is configured with 
```
ssh:
  keys: [~/.ssh/somekey]
```

Deployment is working but running a command like `app exec --interactive --reuse "bin/rails console"` failed to connect because it did not send the ssh key(s) configured in `deploy.yml`