### PR TITLE
Don't use `shellescape` with secrets extract

### DIFF
--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -3,7 +3,7 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
   option :adapter, type: :string, aliases: "-a", required: true, desc: "Which vault adapter to use"
   option :account, type: :string, required: false, desc: "The account identifier or username"
   option :from, type: :string, required: false, desc: "A vault or folder to fetch the secrets from"
-  option :inline, type: :boolean, required: false, hidden: true
+  option :inline, type: :boolean, required: false, hide: true
   def fetch(*secrets)
     adapter = initialize_adapter(options[:adapter])
 
@@ -13,11 +13,11 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
 
     results = adapter.fetch(secrets, **options.slice(:account, :from).symbolize_keys)
 
-    return_or_puts JSON.dump(results).shellescape, inline: options[:inline]
+    return_or_puts JSON.dump(results), inline: options[:inline]
   end
 
   desc "extract", "Extract a single secret from the results of a fetch call"
-  option :inline, type: :boolean, required: false, hidden: true
+  option :inline, type: :boolean, required: false, hide: true
   def extract(name, secrets)
     parsed_secrets = JSON.parse(secrets)
     value = parsed_secrets[name] || parsed_secrets.find { |k, v| k.end_with?("/#{name}") }&.last

--- a/test/cli/secrets_test.rb
+++ b/test/cli/secrets_test.rb
@@ -3,7 +3,7 @@ require_relative "cli_test_case"
 class CliSecretsTest < CliTestCase
   test "fetch" do
     assert_equal \
-      "\\{\\\"foo\\\":\\\"oof\\\",\\\"bar\\\":\\\"rab\\\",\\\"baz\\\":\\\"zab\\\"\\}",
+      "{\"foo\":\"oof\",\"bar\":\"rab\",\"baz\":\"zab\"}",
       run_command("fetch", "foo", "bar", "baz", "--account", "myaccount", "--adapter", "test")
   end
 
@@ -15,7 +15,7 @@ class CliSecretsTest < CliTestCase
 
   test "fetch without required --account" do
     assert_equal \
-      "\\{\\\"foo\\\":\\\"oof\\\",\\\"bar\\\":\\\"rab\\\",\\\"baz\\\":\\\"zab\\\"\\}",
+      "{\"foo\":\"oof\",\"bar\":\"rab\",\"baz\":\"zab\"}",
       run_command("fetch", "foo", "bar", "baz", "--adapter", "test_optional_account")
   end
 

--- a/test/secrets/aws_secrets_manager_adapter_test.rb
+++ b/test/secrets/aws_secrets_manager_adapter_test.rb
@@ -33,7 +33,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "secret/KEY1", "secret/KEY2", "secret2/KEY3")))
+    json = JSON.parse(run_command("fetch", "secret/KEY1", "secret/KEY2", "secret2/KEY3"))
 
     expected_json = {
       "secret/KEY1"=>"VALUE1",
@@ -66,7 +66,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "secret", "KEY1", "KEY2")))
+    json = JSON.parse(run_command("fetch", "--from", "secret", "KEY1", "KEY2"))
 
     expected_json = {
       "secret/KEY1"=>"VALUE1",
@@ -80,7 +80,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
     stub_ticks_with("aws --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "SECRET1")))
+      JSON.parse(run_command("fetch", "SECRET1"))
     end
     assert_equal "AWS CLI is not installed", error.message
   end

--- a/test/secrets/bitwarden_adapter_test.rb
+++ b/test/secrets/bitwarden_adapter_test.rb
@@ -8,7 +8,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("bw sync").returns("")
     stub_mypassword
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
+    json = JSON.parse(run_command("fetch", "mypassword"))
 
     expected_json = { "mypassword"=>"secret123" }
 
@@ -23,7 +23,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_noteitem
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "mynote")))
+      JSON.parse(run_command("fetch", "mynote"))
     end
     assert_match(/not a login type item/, error.message)
   end
@@ -35,7 +35,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("bw sync").returns("")
     stub_myitem
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "myitem", "field1", "field2", "field3")))
+    json = JSON.parse(run_command("fetch", "--from", "myitem", "field1", "field2", "field3"))
 
     expected_json = {
       "myitem/field1"=>"secret1", "myitem/field2"=>"blam", "myitem/field3"=>"fewgrwjgk"
@@ -51,7 +51,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("bw sync").returns("")
     stub_noteitem_with_fields
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mynotefields")))
+    json = JSON.parse(run_command("fetch", "mynotefields"))
 
     expected_json = {
       "mynotefields/field1"=>"secret1", "mynotefields/field2"=>"blam", "mynotefields/field3"=>"fewgrwjgk",
@@ -95,7 +95,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     JSON
 
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mypassword", "myitem/field1", "myitem/field2", "myitem2/field3")))
+    json = JSON.parse(run_command("fetch", "mypassword", "myitem/field1", "myitem/field2", "myitem2/field3"))
 
     expected_json = {
       "mypassword"=>"secret123", "myitem/field1"=>"secret1", "myitem/field2"=>"blam", "myitem2/field3"=>"fewgrwjgk"
@@ -120,7 +120,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("bw sync").returns("")
     stub_mypassword
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
+    json = JSON.parse(run_command("fetch", "mypassword"))
 
     expected_json = { "mypassword"=>"secret123" }
 
@@ -147,7 +147,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("bw sync").returns("")
     stub_mypassword
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
+    json = JSON.parse(run_command("fetch", "mypassword"))
 
     expected_json = { "mypassword"=>"secret123" }
 
@@ -174,7 +174,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("BW_SESSION=0987654321 bw sync").returns("")
     stub_mypassword(session: "0987654321")
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
+    json = JSON.parse(run_command("fetch", "mypassword"))
 
     expected_json = { "mypassword"=>"secret123" }
 
@@ -185,7 +185,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks_with("bw --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "mynote")))
+      JSON.parse(run_command("fetch", "mynote"))
     end
     assert_equal "Bitwarden CLI is not installed", error.message
   end

--- a/test/secrets/doppler_adapter_test.rb
+++ b/test/secrets/doppler_adapter_test.rb
@@ -32,7 +32,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "--from", "my-project/prd", "SECRET1", "FSECRET1", "FSECRET2")
+      run_command("fetch", "--from", "my-project/prd", "SECRET1", "FSECRET1", "FSECRET2")
     )
 
     expected_json = {
@@ -73,7 +73,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "SECRET1", "FSECRET1", "FSECRET2")
+      run_command("fetch", "SECRET1", "FSECRET1", "FSECRET2")
     )
 
     expected_json = {
@@ -114,7 +114,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "my-project/prd/SECRET1", "my-project/prd/FSECRET1", "my-project/prd/FSECRET2")
+      run_command("fetch", "my-project/prd/SECRET1", "my-project/prd/FSECRET1", "my-project/prd/FSECRET2")
     )
 
     expected_json = {
@@ -143,7 +143,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
     stub_ticks_with("doppler login -y", succeed: true).returns("")
     stub_ticks.with("doppler secrets get SECRET1 --json -p my-project -c prd").returns(single_item_json)
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "my-project/prd", "SECRET1")))
+    json = JSON.parse(run_command("fetch", "--from", "my-project/prd", "SECRET1"))
 
     expected_json = {
       "SECRET1"=>"secret1"
@@ -156,7 +156,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
     stub_ticks_with("doppler --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "HOST", "PORT")))
+      JSON.parse(run_command("fetch", "HOST", "PORT"))
     end
 
     assert_equal "Doppler CLI is not installed", error.message

--- a/test/secrets/last_pass_adapter_test.rb
+++ b/test/secrets/last_pass_adapter_test.rb
@@ -52,7 +52,7 @@ class LastPassAdapterTest < SecretAdapterTestCase
         ]
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "SECRET1", "FOLDER1/FSECRET1", "FOLDER1/FSECRET2")))
+    json = JSON.parse(run_command("fetch", "SECRET1", "FOLDER1/FSECRET1", "FOLDER1/FSECRET2"))
 
     expected_json = {
       "SECRET1"=>"secret1",
@@ -98,7 +98,7 @@ class LastPassAdapterTest < SecretAdapterTestCase
         ]
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "FOLDER1", "FSECRET1", "FSECRET2")))
+    json = JSON.parse(run_command("fetch", "--from", "FOLDER1", "FSECRET1", "FSECRET2"))
 
     expected_json = {
       "FOLDER1/FSECRET1"=>"fsecret1",
@@ -115,7 +115,7 @@ class LastPassAdapterTest < SecretAdapterTestCase
     stub_ticks_with("lpass login email@example.com", succeed: true).returns("")
     stub_ticks.with("lpass show SECRET1 --json").returns(single_item_json)
 
-    json = JSON.parse(shellunescape(run_command("fetch", "SECRET1")))
+    json = JSON.parse(run_command("fetch", "SECRET1"))
 
     expected_json = {
       "SECRET1"=>"secret1"
@@ -128,7 +128,7 @@ class LastPassAdapterTest < SecretAdapterTestCase
     stub_ticks_with("lpass --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "SECRET1", "FOLDER1/FSECRET1", "FOLDER1/FSECRET2")))
+      JSON.parse(run_command("fetch", "SECRET1", "FOLDER1/FSECRET1", "FOLDER1/FSECRET2"))
     end
     assert_equal "LastPass CLI is not installed", error.message
   end

--- a/test/secrets/one_password_adapter_test.rb
+++ b/test/secrets/one_password_adapter_test.rb
@@ -45,7 +45,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
         ]
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3")))
+    json = JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1",
@@ -105,7 +105,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault", "myitem/section/SECRET1", "myitem/section/SECRET2", "myitem2/section2/SECRET3")))
+    json = JSON.parse(run_command("fetch", "--from", "op://myvault", "myitem/section/SECRET1", "myitem/section/SECRET2", "myitem2/section2/SECRET3"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1",
@@ -126,7 +126,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
       .with("op item get myitem --vault \"myvault\" --fields \"label=section.SECRET1\" --format \"json\" --account \"myaccount\"")
       .returns(single_item_json)
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1")))
+    json = JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1"
@@ -145,7 +145,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
       .with("op item get myitem --vault \"myvault\" --fields \"label=section.SECRET1\" --format \"json\" --account \"myaccount\" --session \"1234567890\"")
       .returns(single_item_json)
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1")))
+    json = JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1"
@@ -158,7 +158,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     stub_ticks_with("op --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3")))
+      JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3"))
     end
     assert_equal "1Password CLI is not installed", error.message
   end


### PR DESCRIPTION
Fixes #1007 

First time Kamal user, apologies if I'm missing the point / use case of the existing code. At least I hope it opens up the conversation 🙃. I've hit this issue some others reported too when following the initial instructions #1007

I'm trying to get credentials out of 1password:
```bash
SECRETS=$(kamal secrets fetch --verbose --adapter 1password  --account "$ACCOUNT" --from "Dev/Test-Credential" credential credentialtwo)
echo $SECRETS
\{\"Dev/Test-Credential/credential\":\"test-credential-very-secure\",\"Dev/Test-Credential/credentialtwo\":\"test-credential-very-secure-two\"\}
```
What is outputted is escaped. When running the following, there's an error:
```bash
kamal secrets extract credential $SECRETS
ERROR (JSON::ParserError): unexpected token at '\{\"Dev/Test-Credential/credenti'
```

 Setting a breakpoint here:
https://github.com/basecamp/kamal/blob/fbc451588814b04d6c87476f9bdc6f0c9a2bbc49/lib/kamal/cli/secrets.rb#L21-L23

I can see that secrets are double escaped:
```
"\\{\\\"Dev/Test-Credential/credential\\\":\\\"test-credential-very-secure\\\",\\\"Dev/Test-Credential/credentialtwo\\\":\\\"test-credential-very-secure-two\\\"\\}"
```

I think at least for this case, `shellscape` should not be necessary for `fetch`. When using `extract`, the json will be interpreted correctly with `JSON.parse` already. Looking at the tests, there are calls `shellunescape` that are not performed by anything when running `kamal secrets extract`.

Also corrected `hidden` to `hide`. `inline` was being displayed in the help and I was getting confused.