### PR TITLE
Enable IPv6 connectivity for the kamal network

### DIFF
--- a/lib/kamal/commands/docker.rb
+++ b/lib/kamal/commands/docker.rb
@@ -20,7 +20,7 @@ class Kamal::Commands::Docker < Kamal::Commands::Base
   end
 
   def create_network
-    docker :network, :create, :kamal
+    docker :network, :create, "--ipv6", :kamal
   end
 
   private


### PR DESCRIPTION
This commit enables IPv6 connectivity for the kamal network.