### PR TITLE
Fix JSON ParserError with kamal secrets extract $SECRETS

### DIFF
--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -19,7 +19,7 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
   desc "extract", "Extract a single secret from the results of a fetch call"
   option :inline, type: :boolean, required: false, hidden: true
   def extract(name, secrets)
-    parsed_secrets = JSON.parse(secrets)
+    parsed_secrets = parse_secrets(secrets)
     value = parsed_secrets[name] || parsed_secrets.find { |k, v| k.end_with?("/#{name}") }&.last
 
     raise "Could not find secret #{name}" if value.nil?
@@ -35,6 +35,12 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
   end
 
   private
+    def parse_secrets(secrets)
+      secrets = secrets.shellsplit[0] if secrets.start_with?("\\{")
+
+      JSON.parse(secrets)
+    end
+
     def initialize_adapter(adapter)
       Kamal::Secrets::Adapters.lookup(adapter)
     end

--- a/test/cli/secrets_test.rb
+++ b/test/cli/secrets_test.rb
@@ -23,6 +23,10 @@ class CliSecretsTest < CliTestCase
     assert_equal "oof", run_command("extract", "foo", "{\"foo\":\"oof\", \"bar\":\"rab\", \"baz\":\"zab\"}")
   end
 
+  test "extract when value contains (" do
+    assert_equal "bar(", run_command("extract", "foo", "\\{\\\"foo\\\":\\\"bar\\(\\\"\\}")
+  end
+
   test "extract match from end" do
     assert_equal "oof", run_command("extract", "foo", "{\"abc/foo\":\"oof\", \"bar\":\"rab\", \"baz\":\"zab\"}")
   end


### PR DESCRIPTION
When running `kamal secrets extract TEST $SECRETS` and value of TEST contains a `(` the code was throwing a `JSON::ParserError`

```
secrets = { TEST: "value(" }.to_json.shellescape
JSON.parse(secrets)
```