### PR TITLE
Show hook-output by default

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -137,7 +137,9 @@ module Kamal::Cli
           say "Running the #{hook} hook...", :magenta
           with_env KAMAL.hook.env(**details, **extra_details) do
             run_locally do
-              execute *KAMAL.hook.run(hook)
+              KAMAL.with_verbosity(:debug) do
+                execute *KAMAL.hook.run(hook)
+              end
             end
           rescue SSHKit::Command::Failed => e
             raise HookError.new("Hook `#{hook}` failed:\n#{e.message}")


### PR DESCRIPTION
Previously hooks could write to stdout, but this wouldn't be visible unless `-v` was passed to increase the verbosity.

A number of the hook samples do this, so I'm assuming this is an oversight..?

I don't see any existing tests that cover output verbosity, let me know if there's a suitable place to add a test for this.

Fixes #1243
