### PR TITLE
Aws secrets manager simple strings and error checking

### DIFF
--- a/lib/kamal/secrets/adapters/aws_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/aws_secrets_manager.rb
@@ -27,7 +27,7 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
 
         return secrets["SecretValues"] unless secrets["Errors"].present?
 
-        raise RuntimeError, secrets["Errors"].map { |error| "#{error['SecretId']}: #{error['Message']}" }.join(", ")
+        raise RuntimeError, secrets["Errors"].map { |error| "#{error['SecretId']}: #{error['Message']}" }.join(" ")
       end
     end
 

--- a/lib/kamal/secrets/adapters/aws_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/aws_secrets_manager.rb
@@ -13,6 +13,8 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
           secret_string.each do |key, value|
             results["#{secret_name}/#{key}"] = value
           end
+        rescue JSON::ParserError
+          results["#{secret_name}"] = secret["SecretString"]
         end
       end
     end

--- a/test/secrets/aws_secrets_manager_adapter_test.rb
+++ b/test/secrets/aws_secrets_manager_adapter_test.rb
@@ -27,7 +27,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
       JSON.parse(shellunescape(run_command("fetch", "unknown1", "unknown2")))
     end
 
-    assert_equal ["unknown1: Secrets Manager can't find the specified secret.", "unknown2: Secrets Manager can't find the specified secret."].join(" "), error.message
+    assert_equal [ "unknown1: Secrets Manager can't find the specified secret.", "unknown2: Secrets Manager can't find the specified secret." ].join(" "), error.message
   end
 
   test "fetch" do

--- a/test/secrets/aws_secrets_manager_adapter_test.rb
+++ b/test/secrets/aws_secrets_manager_adapter_test.rb
@@ -1,6 +1,30 @@
 require "test_helper"
 
 class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
+  test "fails when errors are present" do
+    stub_ticks.with("aws --version 2> /dev/null")
+    stub_ticks
+      .with("aws secretsmanager batch-get-secret-value --secret-id-list unknown-secret-id --profile default")
+      .returns(<<~JSON)
+        {
+          "SecretValues": [],
+          "Errors": [
+            {
+                "SecretId": "unknown-secret-id",
+                "ErrorCode": "ResourceNotFoundException",
+                "Message": "Secrets Manager can't find the specified secret."
+            }
+          ]
+        }
+      JSON
+
+    error = assert_raises RuntimeError do
+      JSON.parse(shellunescape(run_command("fetch", "unknown-secret-id")))
+    end
+
+    assert_equal "unknown-secret-id: Secrets Manager can't find the specified secret.", error.message
+  end
+
   test "fetch" do
     stub_ticks.with("aws --version 2> /dev/null")
     stub_ticks

--- a/test/secrets/aws_secrets_manager_adapter_test.rb
+++ b/test/secrets/aws_secrets_manager_adapter_test.rb
@@ -80,7 +80,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
 
     expected_json = {
       "secret"=>"a-string-secret",
-      "secret/KEY2"=>"VALUE2"
+      "secret2/KEY2"=>"VALUE2"
     }
 
     assert_equal expected_json, json


### PR DESCRIPTION
### String-based secrets
`SecretString` can technically be a regular string value and not a JSON object, this PR adds support to fallback to the simple string value when JSON parsing fails.

https://docs.aws.amazon.com/secretsmanager/latest/apireference/API_SecretValueEntry.html

You still fetch the value out the same way as a JSON-based secret but from there you can process however you need.

```
SECRETS=$(kamal secrets fetch --adapter aws_secrets_manager --from PG_PASSWORD)

PG_PASSWORD=$(kamal secrets extract PG_PASSWORD $SECRETS)
```

### Errors
I also noticed that errors are not returned with a return code from the CLI but within the `Errors` array. Before this PR it just returns an empty secret value for an unknown secret, this PR checks the `Errors` array and prints out a message(from AWS) for each error.

Current output:
```
$ kamal secrets fetch --adapter aws_secrets_manager unknown-secret
\{\}
```

Updated output:
```
$ kamal secrets fetch --adapter aws_secrets_manager unknown-secret
ERROR (RuntimeError): unknown-secret: Secrets Manager can't find the specified secret.
```

https://docs.aws.amazon.com/cli/latest/reference/secretsmanager/batch-get-secret-value.html (Output -> Errors)
