### PR TITLE
Boot proxy on server setup

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -9,6 +9,9 @@ class Kamal::Cli::Main < Kamal::Cli::Base
         say "Ensure Docker is installed...", :magenta
         invoke "kamal:cli:server:bootstrap", [], invoke_options
 
+        say "Ensure kamal-proxy is running...", :magenta
+        invoke "kamal:cli:proxy:boot", [], invoke_options
+
         invoke "kamal:cli:accessory:boot", [ "all" ], invoke_options
         deploy
       end

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -8,6 +8,7 @@ class CliMainTest < CliTestCase
     invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:boot", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:deploy)
 


### PR DESCRIPTION
Accessories fail to boot on `kamal setup` when they use a proxy, because proxy is not yet running at that stage. 

This change will always boot the kamal-proxy beforehand.

Fixes #1307 