### PR TITLE
Configure the CLI to exit non-zero on failures.

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -5,7 +5,7 @@ module Kamal::Cli
   class Base < Thor
     include SSHKit::DSL
 
-    def self.exit_on_failure?() false end
+    def self.exit_on_failure?() true end
     def self.dynamic_command_class() Kamal::Cli::Alias::Command end
 
     class_option :verbose, type: :boolean, aliases: "-v", desc: "Detailed logging"

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -90,7 +90,7 @@ class MainTest < IntegrationTest
   test "setup and remove" do
     @app = "app_with_roles"
 
-    kamal :proxy, :set_config,
+    kamal :proxy, :boot_config, "set",
       "--publish=false",
       "--options=label=traefik.http.services.kamal_proxy.loadbalancer.server.scheme=http",
       "label=traefik.http.routers.kamal_proxy.rule=PathPrefix\\\(\\\`/\\\`\\\)",

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -92,7 +92,7 @@ class MainTest < IntegrationTest
 
     kamal :proxy, :boot_config, "set",
       "--publish=false",
-      "--options=label=traefik.http.services.kamal_proxy.loadbalancer.server.scheme=http",
+      "--docker-options=label=traefik.http.services.kamal_proxy.loadbalancer.server.scheme=http",
       "label=traefik.http.routers.kamal_proxy.rule=PathPrefix\\\(\\\`/\\\`\\\)",
       "label=traefik.http.routers.kamal_proxy.priority=2"
 


### PR DESCRIPTION
I noticed that `kamal` wasn't exiting non-zero for me in certain scenarios where I expected it to.

```bash
$ kamal deploy -d staging --some-option-that-doesnt-exist
ERROR: "kamal deploy" was called with arguments ["--some-option-that-doesnt-exist"]
Usage: "kamal deploy"

$ echo $?
0
```

This caught me by surprise in my CI/CD when my `staging` deployment "succeeded" super quickly and my changes started deploying to `production`. 😅 

I'm not very familiar with Ruby but I believe that this is a good change to make.

(Looks like this was previously set to `true` but was changed to `false` by @djmb [here](https://github.com/basecamp/kamal/commit/b8af719bb7c8d8739d74405d1ef4c6676c09e7f2#diff-7811997713ee765187c761fcadb6cfbfc544779b9c1e9adaa2a47f0b20327b77L9).)

### Testing

- With the proposed change in place, I manually ran `bundle exec ./bin/kamal deploy -d staging --some-option-that-doesnt-exist` and got the expected behavior (non-zero exit code).
- I tried running `bundle exec ./bin/tests` but I'm getting several `toomanyrequests` errors [1] from `docker`. The number of errors (10) seems to remain consistent with and without this change so I have _some_ confidence that it shouldn't cause any regressions but I'm not certain.

<details>

<summary>[1] - Error Message Example</summary>

```
...

  ERROR (SSHKit::Command::Failed): Exception while executing on host vm1: docker exit status: 125
docker stdout: Nothing written
docker stderr: Error response from daemon: No such container: kamal-proxy
Error: failed to start containers: kamal-proxy
cat: .kamal/proxy/options: No such file or directory
Unable to find image 'basecamp/kamal-proxy:v0.8.4' locally
docker: Error response from daemon: toomanyrequests: You have reached your pull rate limit. You may increase the limit by authenticating and upgrading: https://www.docker.com/increase-rate-limit.
See 'docker run --help'.

...
```

I went ahead and created a Docker account. I did a `docker login` (which indicated success) and tried again and still get the error. Looking at the "Usage" dashboard in Docker doesn't seem to indicate an issue. Perhaps my anonymous usage before logging in is causing my IP to be throttled? Another theory is that maybe the way the tests are run aren't making use of my logged in account. 🤷

I'm not really interested in upgrading to any sort of paid account at this time.

Any suggestions on how to work around this issue would be greatly appreciated!

</details>