### PR TITLE
Fix bug in role validate_servers.

### DIFF
--- a/lib/kamal/commander.rb
+++ b/lib/kamal/commander.rb
@@ -76,11 +76,6 @@ class Kamal::Commander
     config.accessories&.collect(&:name) || []
   end
 
-  def accessories_on(host)
-    config.accessories.select { |accessory| accessory.hosts.include?(host.to_s) }.map(&:name)
-  end
-
-
   def app(role: nil, host: nil)
     Kamal::Commands::App.new(config, role: role, host: host)
   end
@@ -128,7 +123,6 @@ class Kamal::Commander
   def alias(name)
     config.aliases[name]
   end
-
 
   def with_verbosity(level)
     old_level = self.verbosity

--- a/lib/kamal/configuration/role.rb
+++ b/lib/kamal/configuration/role.rb
@@ -10,7 +10,7 @@ class Kamal::Configuration::Role
   def initialize(name, config:)
     @name, @config = name.inquiry, config
     validate! \
-      specializations,
+      role_config,
       example: validation_yml["servers"]["workers"],
       context: "servers/#{name}",
       with: Kamal::Configuration::Validator::Role
@@ -204,11 +204,11 @@ class Kamal::Configuration::Role
     end
 
     def specializations
-      if config.raw_config.servers.is_a?(Array) || config.raw_config.servers[name].is_a?(Array)
-        {}
-      else
-        config.raw_config.servers[name]
-      end
+      @specializations ||= role_config.is_a?(Array) ? {} : role_config
+    end
+
+    def role_config
+      @role_config ||= config.raw_config.servers.is_a?(Array) ? {} : config.raw_config.servers[name]
     end
 
     def custom_labels

--- a/lib/kamal/configuration/validator/role.rb
+++ b/lib/kamal/configuration/validator/role.rb
@@ -3,7 +3,7 @@ class Kamal::Configuration::Validator::Role < Kamal::Configuration::Validator
     validate_type! config, Array, Hash
 
     if config.is_a?(Array)
-      validate_servers! "servers", config
+      validate_servers!(config)
     else
       super
     end


### PR DESCRIPTION
There were typo-bug during `validate_servers!` invocation for role. It wasn't discovered, because it never met condition. Because role_config wasn't correctly extracted for validation.

Also remove not used anymore `accessories_on`. Leftover from previous changes.