### PR TITLE
[Feature] Registry for accessory 

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -292,7 +292,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     def prepare(name)
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
-          execute *KAMAL.registry.login
+          execute *KAMAL.registry.login(registry_config: accessory.registry)
           execute *KAMAL.docker.create_network
         rescue SSHKit::Command::Failed => e
           raise unless e.message.include?("already exists")

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -4,10 +4,9 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
   attr_reader :accessory_config
   delegate :service_name, :image, :hosts, :port, :files, :directories, :cmd,
            :network_args, :publish_args, :env_args, :volume_args, :label_args, :option_args,
-           :secrets_io, :secrets_path, :env_directory, :proxy, :running_proxy?,
+           :secrets_io, :secrets_path, :env_directory, :proxy, :running_proxy?, :registry,
            to: :accessory_config
   delegate :proxy_container_name, to: :config
-
 
   def initialize(config, name:)
     super(config)
@@ -42,7 +41,6 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
     docker :ps, *service_filter
   end
 
-
   def logs(timestamps: true, since: nil, lines: nil, grep: nil, grep_options: nil)
     pipe \
       docker(:logs, service_name, (" --since #{since}" if since), (" --tail #{lines}" if lines), ("--timestamps" if timestamps), "2>&1"),
@@ -55,7 +53,6 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
         docker(:logs, service_name, ("--timestamps" if timestamps), "--tail", "10", "--follow", "2>&1"),
         (%(grep "#{grep}"#{" #{grep_options}" if grep_options}) if grep)
   end
-
 
   def execute_in_existing_container(*command, interactive: false)
     docker :exec,
@@ -86,7 +83,6 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
   def run_over_ssh(command)
     super command, host: hosts.first
   end
-
 
   def ensure_local_file_present(local_file)
     if !local_file.is_a?(StringIO) && !Pathname.new(local_file).exist?

--- a/lib/kamal/commands/registry.rb
+++ b/lib/kamal/commands/registry.rb
@@ -1,14 +1,16 @@
 class Kamal::Commands::Registry < Kamal::Commands::Base
-  delegate :registry, to: :config
+  def login(registry_config: nil)
+    registry_config ||= config.registry
 
-  def login
     docker :login,
-      registry.server,
-      "-u", sensitive(Kamal::Utils.escape_shell_value(registry.username)),
-      "-p", sensitive(Kamal::Utils.escape_shell_value(registry.password))
+      registry_config.server,
+      "-u", sensitive(Kamal::Utils.escape_shell_value(registry_config.username)),
+      "-p", sensitive(Kamal::Utils.escape_shell_value(registry_config.password))
   end
 
-  def logout
-    docker :logout, registry.server
+  def logout(registry_config: nil)
+    registry_config ||= config.registry
+
+    docker :logout, registry_config.server
   end
 end

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -59,7 +59,7 @@ class Kamal::Configuration
 
     # Eager load config to validate it, these are first as they have dependencies later on
     @servers = Servers.new(config: self)
-    @registry = Registry.new(config: raw_config, secrets: secrets)
+    @registry = Registry.new(config: @raw_config, secrets: secrets)
 
     @accessories = @raw_config.accessories&.keys&.collect { |name| Accessory.new(name, config: self) } || []
     @aliases = @raw_config.aliases&.keys&.to_h { |name| [ name, Alias.new(name, config: self) ] } || {}

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -59,7 +59,7 @@ class Kamal::Configuration
 
     # Eager load config to validate it, these are first as they have dependencies later on
     @servers = Servers.new(config: self)
-    @registry = Registry.new(config: self)
+    @registry = Registry.new(config: raw_config, secrets: secrets)
 
     @accessories = @raw_config.accessories&.keys&.collect { |name| Accessory.new(name, config: self) } || []
     @aliases = @raw_config.aliases&.keys&.to_h { |name| [ name, Alias.new(name, config: self) ] } || {}
@@ -81,7 +81,6 @@ class Kamal::Configuration
     ensure_one_host_for_ssl_roles
     ensure_unique_hosts_for_ssl_roles
   end
-
 
   def version=(version)
     @declared_version = version
@@ -106,7 +105,6 @@ class Kamal::Configuration
     raw_config.minimum_version
   end
 
-
   def roles
     servers.roles
   end
@@ -118,7 +116,6 @@ class Kamal::Configuration
   def accessory(name)
     accessories.detect { |a| a.name == name.to_s }
   end
-
 
   def all_hosts
     (roles + accessories).flat_map(&:hosts).uniq
@@ -180,7 +177,6 @@ class Kamal::Configuration
     raw_config.retain_containers || 5
   end
 
-
   def volume_args
     if raw_config.volumes.present?
       argumentize "--volume", raw_config.volumes
@@ -193,7 +189,6 @@ class Kamal::Configuration
     logging.args
   end
 
-
   def readiness_delay
     raw_config.readiness_delay || 7
   end
@@ -205,7 +200,6 @@ class Kamal::Configuration
   def drain_timeout
     raw_config.drain_timeout || 30
   end
-
 
   def run_directory
     ".kamal"
@@ -227,7 +221,6 @@ class Kamal::Configuration
     File.join app_directory, "assets"
   end
 
-
   def hooks_path
     raw_config.hooks_path || ".kamal/hooks"
   end
@@ -235,7 +228,6 @@ class Kamal::Configuration
   def asset_path
     raw_config.asset_path
   end
-
 
   def env_tags
     @env_tags ||= if (tags = raw_config.env["tags"])
@@ -276,7 +268,6 @@ class Kamal::Configuration
   def proxy_options_file
     File.join proxy_directory, "options"
   end
-
 
   def to_h
     {

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -5,7 +5,7 @@ class Kamal::Configuration::Accessory
 
   delegate :argumentize, :optionize, to: Kamal::Utils
 
-  attr_reader :name, :accessory_config, :env, :proxy
+  attr_reader :name, :env, :proxy, :registry
 
   def initialize(name, config:)
     @name, @config, @accessory_config = name.inquiry, config, config.raw_config["accessories"][name]
@@ -16,12 +16,9 @@ class Kamal::Configuration::Accessory
       context: "accessories/#{name}",
       with: Kamal::Configuration::Validator::Accessory
 
-    @env = Kamal::Configuration::Env.new \
-      config: accessory_config.fetch("env", {}),
-      secrets: config.secrets,
-      context: "accessories/#{name}/env"
-
-    initialize_proxy if running_proxy?
+    @env = initialize_env
+    @proxy = initialize_proxy if running_proxy?
+    @registry = initialize_registry if accessory_config["registry"].present?
   end
 
   def service_name
@@ -29,7 +26,7 @@ class Kamal::Configuration::Accessory
   end
 
   def image
-    accessory_config["image"]
+    [ registry&.server, accessory_config["image"] ].compact.join("/")
   end
 
   def hosts
@@ -109,18 +106,32 @@ class Kamal::Configuration::Accessory
   end
 
   def running_proxy?
-    @accessory_config["proxy"].present?
-  end
-
-  def initialize_proxy
-    @proxy = Kamal::Configuration::Proxy.new \
-      config: config,
-      proxy_config: accessory_config["proxy"],
-      context: "accessories/#{name}/proxy"
+    accessory_config["proxy"].present?
   end
 
   private
-    attr_accessor :config
+    attr_reader :config, :accessory_config
+
+    def initialize_env
+      Kamal::Configuration::Env.new \
+        config: accessory_config.fetch("env", {}),
+        secrets: config.secrets,
+        context: "accessories/#{name}/env"
+    end
+
+    def initialize_proxy
+      Kamal::Configuration::Proxy.new \
+        config: config,
+        proxy_config: accessory_config["proxy"],
+        context: "accessories/#{name}/proxy"
+    end
+
+    def initialize_registry
+      Kamal::Configuration::Registry.new \
+        config: accessory_config,
+        secrets: config.secrets,
+        context: "accessories/#{name}/registry"
+    end
 
     def default_labels
       { "service" => service_name }

--- a/lib/kamal/configuration/docs/accessory.yml
+++ b/lib/kamal/configuration/docs/accessory.yml
@@ -23,8 +23,26 @@ accessories:
 
     # Image
     #
-    # The Docker image to use, prefix it with a registry if not using Docker Hub:
+    # The Docker image to use.
+    # Prefix it with its server when using root level registry different from Docker Hub.
+    # Define registry directly or via anchors when it differs from root level registry.
     image: mysql:8.0
+
+    # Registry
+    #
+    # By default accessories use Docker Hub registry.
+    # You can specify different registry per accessory with this option.
+    # Don't prefix image with this registry server.
+    # Use anchors if you need to set the same specific registry for several accessories.
+    #
+    # ```yml
+    # registry:
+    #   <<: *specific-registry
+    # ```
+    #
+    # See kamal docs registry for more information:
+    registry:
+      ...
 
     # Accessory hosts
     #

--- a/lib/kamal/configuration/registry.rb
+++ b/lib/kamal/configuration/registry.rb
@@ -1,12 +1,10 @@
 class Kamal::Configuration::Registry
   include Kamal::Configuration::Validation
 
-  attr_reader :registry_config, :secrets
-
-  def initialize(config:)
-    @registry_config = config.raw_config.registry || {}
-    @secrets = config.secrets
-    validate! registry_config, with: Kamal::Configuration::Validator::Registry
+  def initialize(config:, secrets:, context: "registry")
+    @registry_config = config["registry"] || {}
+    @secrets = secrets
+    validate! registry_config, context: context, with: Kamal::Configuration::Validator::Registry
   end
 
   def server
@@ -22,6 +20,8 @@ class Kamal::Configuration::Registry
   end
 
   private
+    attr_reader :registry_config, :secrets
+
     def lookup(key)
       if registry_config[key].is_a?(Array)
         secrets[registry_config[key].first]

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -3,7 +3,9 @@ require "test_helper"
 class ConfigurationAccessoryTest < ActiveSupport::TestCase
   setup do
     @deploy = {
-      service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" },
+      service: "app",
+      image: "dhh/app",
+      registry: { "username" => "dhh", "password" => "secret" },
       servers: {
         "web" => [ "1.1.1.1", "1.1.1.2" ],
         "workers" => [ "1.1.1.3", "1.1.1.4" ]
@@ -12,7 +14,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
       env: { "REDIS_URL" => "redis://x/y" },
       accessories: {
         "mysql" => {
-          "image" => "mysql:8.0",
+          "image" => "public.registry/mysql:8.0",
           "host" => "1.1.1.5",
           "port" => "3306",
           "env" => {
@@ -52,6 +54,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
         "monitoring" => {
           "service" => "custom-monitoring",
           "image" => "monitoring:latest",
+          "registry" => { "server" => "other.registry", "username" => "user", "password" => "pw" },
           "roles" => [ "web" ],
           "port" => "4321:4321",
           "labels" => {
@@ -78,6 +81,21 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal "app-mysql", @config.accessory(:mysql).service_name
     assert_equal "app-redis", @config.accessory(:redis).service_name
     assert_equal "custom-monitoring", @config.accessory(:monitoring).service_name
+  end
+
+  test "image" do
+    assert_equal "public.registry/mysql:8.0", @config.accessory(:mysql).image
+    assert_equal "redis:latest", @config.accessory(:redis).image
+    assert_equal "other.registry/monitoring:latest", @config.accessory(:monitoring).image
+  end
+
+  test "registry" do
+    assert_nil @config.accessory(:mysql).registry
+    assert_nil @config.accessory(:redis).registry
+    monitoring_registry = @config.accessory(:monitoring).registry
+    assert_equal "other.registry", monitoring_registry.server
+    assert_equal "user", monitoring_registry.username
+    assert_equal "pw", monitoring_registry.password
   end
 
   test "port" do

--- a/test/fixtures/deploy_with_accessories_with_different_registries.yml
+++ b/test/fixtures/deploy_with_accessories_with_different_registries.yml
@@ -1,0 +1,47 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+    - "1.1.1.2"
+  workers:
+    - "1.1.1.3"
+    - "1.1.1.4"
+registry:
+  server: private.registry
+  username: user
+  password: pw
+builder:
+  arch: amd64
+
+accessories:
+  mysql:
+    image: private.registry/mysql:5.7
+    host: 1.1.1.3
+    port: 3306
+    env:
+      clear:
+        MYSQL_ROOT_HOST: '%'
+      secret:
+        - MYSQL_ROOT_PASSWORD
+    files:
+      - test/fixtures/files/my.cnf:/etc/mysql/my.cnf
+    directories:
+      - data:/var/lib/mysql
+  redis:
+    image: redis:latest
+    roles:
+      - web
+    port: 6379
+    directories:
+      - data:/data
+  busybox:
+    service: custom-box
+    image: busybox:latest
+    host: 1.1.1.3
+    registry:
+      server: other.registry
+      username: other_user
+      password: other_pw
+
+readiness_delay: 0


### PR DESCRIPTION
#  Context

Currently we can specify only one root level registry with main purpose of deploying our application.

Accessories by default use Docker Hub registry to pull from.
And there is option to specify root level registry server as a prefix for an accessory image, to pull them from the same root level registry.

# Feature proposal

**This PR proposes an option to specify different registry per accessory.**
- The accessory's registry data structure are the same as root level registry has.
- The option is used and validated when provided.
- It shouldn't break any existing configurations or behavior.
- Test cases to cover new option is added. Most of tests are unchanged, so previous behavior is not broken. Extended deploy config `test/fixtures/deploy_with_accessories_with_different_registries.yml` is added to test `test/cli/accessory_test.rb` with more thorough coverage of registries.

## Example

Note: Anchor was used to eliminate duplication. 

```yml
service: app
image: the_cake/is_a_lie
servers:
  - 1.1.1.1
registry:
  server: client.registry
  username: client_user
  password: client_password
builder:
  arch: amd64
x-organization-registry: &organization-registry
  server: organization.registry
  username: organization_user
  password: organization_password
accessories:
  private-organization-tool-xxx:
    image: organization_tool_xxx:latest
    host: 1.1.1.1
    port: 3333
    registry:
      <<: *organization-registry
  private-organization-tool-yyy:
    image: organization_tool_yyy:latest
    host: 1.1.1.1
    port: 3334
    registry:
      <<: *organization-registry
  private-client-tool:
    image: client.registry/client_tool:latest
    host: 1.1.1.1
    port: 4444
  redis:
    image: redis:latest
    roles:
      - web
    port: 6379
    directories:
      - data:/data
```