### PR TITLE
fix the digital ocean registry example

### DIFF
--- a/lib/kamal/configuration/docs/registry.yml
+++ b/lib/kamal/configuration/docs/registry.yml
@@ -9,11 +9,10 @@
 # A reference to a secret (in this case, `DOCKER_REGISTRY_TOKEN`) will look up the secret
 # in the local environment:
 registry:
-  server: registry.digitalocean.com
-  username:
-    - DOCKER_REGISTRY_TOKEN
+  server: registry.digitalocean.com/<your-registry>
+  username: <your-digitalocean-username>
   password:
-    - DOCKER_REGISTRY_TOKEN
+    - DIGITALOCEAN_PERSONAL_ACCESS_TOKEN
 
 # Using AWS ECR as the container registry
 #


### PR DESCRIPTION
It didn't work as shown.

Actually I'm a little confused - the same example exists in https://github.com/basecamp/kamal-site. Do I need to fix it there too?