### PR TITLE
Handle parentheses in variables in commands

### DIFF
--- a/lib/kamal/secrets/dotenv/inline_command_substitution.rb
+++ b/lib/kamal/secrets/dotenv/inline_command_substitution.rb
@@ -4,7 +4,7 @@ class Kamal::Secrets::Dotenv::InlineCommandSubstitution
       ::Dotenv::Parser.substitutions.map! { |sub| sub == ::Dotenv::Substitutions::Command ? self : sub }
     end
 
-    def call(value, _env, overwrite: false)
+    def call(value, env, overwrite: false)
       # Process interpolated shell commands
       value.gsub(Dotenv::Substitutions::Command.singleton_class::INTERPOLATED_SHELL_COMMAND) do |*|
         # Eliminate opening and closing parentheses
@@ -14,6 +14,7 @@ class Kamal::Secrets::Dotenv::InlineCommandSubstitution
           # Command is escaped, don't replace it.
           $LAST_MATCH_INFO[0][1..]
         else
+          command = ::Dotenv::Substitutions::Variable.call(command, env)
           if command =~ /\A\s*kamal\s*secrets\s+/
             # Inline the command
             inline_secrets_command(command)


### PR DESCRIPTION
Variables with parentheses are not handled correctly in commands:

```
SECRETS=\\{\\\"PASSWORD\\\":\\\"pa\\(\\(word\\\"\\}
PASSWORD=$(kamal secrets extract PASSWORD ${SECRETS})
```

Expected `kamal secrets print` output:

```
SECRETS=\{\"PASSWORD\":\"pa\(\(word\"\}
PASSWORD=pa((word
```

Actual `kamal secrets print` output:

```
SECRETS=\{\"PASSWORD\":\"pa\(\(word\"\}
PASSWORD=$(kamal secrets extract PASSWORD \{\"PASSWORD\":\"pa\(\(word\"\})
```

This PR depends on another one https://github.com/bkeepers/dotenv/pull/526. The dependency was approved https://github.com/bkeepers/dotenv/pull/526#issuecomment-2787755200 but not merged so as not to break `kamal`.

**The plan**
* Merge and release this patch. It is backward compatible and will work with patched and with unpatched `dotenv`
* Merge and release the `dotnenv` [patch](https://github.com/bkeepers/dotenv/pull/526)