### PR TITLE
Fix secrets adapters failing fetch on Windows

### DIFF
--- a/lib/kamal/secrets/adapters/aws_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/aws_secrets_manager.rb
@@ -36,7 +36,7 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
     end
 
     def cli_installed?
-      `aws --version 2> /dev/null`
+      system("aws --version", out: File::NULL, err: File::NULL)
       $?.success?
     end
 end

--- a/lib/kamal/secrets/adapters/aws_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/aws_secrets_manager.rb
@@ -36,7 +36,7 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
     end
 
     def cli_installed?
-      system("aws --version", out: File::NULL, err: File::NULL)
+      system("aws --version", err: File::NULL)
       $?.success?
     end
 end

--- a/lib/kamal/secrets/adapters/bitwarden.rb
+++ b/lib/kamal/secrets/adapters/bitwarden.rb
@@ -75,7 +75,7 @@ class Kamal::Secrets::Adapters::Bitwarden < Kamal::Secrets::Adapters::Base
     end
 
     def cli_installed?
-      system("bw --version", out: File::NULL, err: File::NULL)
+      system("bw --version", err: File::NULL)
       $?.success?
     end
 end

--- a/lib/kamal/secrets/adapters/bitwarden.rb
+++ b/lib/kamal/secrets/adapters/bitwarden.rb
@@ -75,7 +75,7 @@ class Kamal::Secrets::Adapters::Bitwarden < Kamal::Secrets::Adapters::Base
     end
 
     def cli_installed?
-      `bw --version 2> /dev/null`
+      system("bw --version", out: File::NULL, err: File::NULL)
       $?.success?
     end
 end

--- a/lib/kamal/secrets/adapters/doppler.rb
+++ b/lib/kamal/secrets/adapters/doppler.rb
@@ -47,7 +47,7 @@ class Kamal::Secrets::Adapters::Doppler < Kamal::Secrets::Adapters::Base
     end
 
     def cli_installed?
-      `doppler --version 2> /dev/null`
+      system("doppler --version", out: File::NULL, err: File::NULL)
       $?.success?
     end
 end

--- a/lib/kamal/secrets/adapters/doppler.rb
+++ b/lib/kamal/secrets/adapters/doppler.rb
@@ -12,7 +12,7 @@ class Kamal::Secrets::Adapters::Doppler < Kamal::Secrets::Adapters::Base
     end
 
     def loggedin?
-      `doppler me --json 2> /dev/null`
+      system("doppler me --json", err: File::NULL)
       $?.success?
     end
 
@@ -47,7 +47,7 @@ class Kamal::Secrets::Adapters::Doppler < Kamal::Secrets::Adapters::Base
     end
 
     def cli_installed?
-      system("doppler --version", out: File::NULL, err: File::NULL)
+      system("doppler --version", err: File::NULL)
       $?.success?
     end
 end

--- a/lib/kamal/secrets/adapters/last_pass.rb
+++ b/lib/kamal/secrets/adapters/last_pass.rb
@@ -33,7 +33,7 @@ class Kamal::Secrets::Adapters::LastPass < Kamal::Secrets::Adapters::Base
     end
 
     def cli_installed?
-      `lpass --version 2> /dev/null`
+      system("lpass --version", out: File::NULL, err: File::NULL)
       $?.success?
     end
 end

--- a/lib/kamal/secrets/adapters/last_pass.rb
+++ b/lib/kamal/secrets/adapters/last_pass.rb
@@ -33,7 +33,7 @@ class Kamal::Secrets::Adapters::LastPass < Kamal::Secrets::Adapters::Base
     end
 
     def cli_installed?
-      system("lpass --version", out: File::NULL, err: File::NULL)
+      system("lpass --version", err: File::NULL)
       $?.success?
     end
 end

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -64,7 +64,7 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
     end
 
     def cli_installed?
-      `op --version 2> /dev/null`
+      system("op --version", out: File::NULL, err: File::NULL)
       $?.success?
     end
 end

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -11,7 +11,7 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
     end
 
     def loggedin?(account)
-      `op account get --account #{account.shellescape} 2> /dev/null`
+      system("op account get --account #{account.shellescape}", err: File::NULL)
       $?.success?
     end
 
@@ -64,7 +64,7 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
     end
 
     def cli_installed?
-      system("op --version", out: File::NULL, err: File::NULL)
+      system("op --version", err: File::NULL)
       $?.success?
     end
 end

--- a/test/secrets/aws_secrets_manager_adapter_test.rb
+++ b/test/secrets/aws_secrets_manager_adapter_test.rb
@@ -2,8 +2,8 @@ require "test_helper"
 
 class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
   test "fails when errors are present" do
-    stub_ticks.with("aws --version 2> /dev/null")
-    stub_ticks
+    stub_command(:system).with("aws --version", err: File::NULL)
+    stub_command
       .with("aws secretsmanager batch-get-secret-value --secret-id-list unknown1 unknown2 --profile default")
       .returns(<<~JSON)
         {
@@ -31,8 +31,8 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch" do
-    stub_ticks.with("aws --version 2> /dev/null")
-    stub_ticks
+    stub_command(:system).with("aws --version", err: File::NULL)
+    stub_command
       .with("aws secretsmanager batch-get-secret-value --secret-id-list secret/KEY1 secret/KEY2 secret2/KEY3 --profile default")
       .returns(<<~JSON)
         {
@@ -74,8 +74,8 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with string value" do
-    stub_ticks.with("aws --version 2> /dev/null")
-    stub_ticks
+    stub_command(:system).with("aws --version", err: File::NULL)
+    stub_command
       .with("aws secretsmanager batch-get-secret-value --secret-id-list secret secret2/KEY1 --profile default")
       .returns(<<~JSON)
         {
@@ -116,8 +116,8 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with secret names" do
-    stub_ticks.with("aws --version 2> /dev/null")
-    stub_ticks
+    stub_command(:system).with("aws --version", err: File::NULL)
+    stub_command
       .with("aws secretsmanager batch-get-secret-value --secret-id-list secret/KEY1 secret/KEY2 --profile default")
       .returns(<<~JSON)
         {
@@ -148,7 +148,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch without CLI installed" do
-    stub_ticks_with("aws --version 2> /dev/null", succeed: false)
+    stub_command_with("aws --version", :system, false)
 
     error = assert_raises RuntimeError do
       JSON.parse(shellunescape(run_command("fetch", "SECRET1")))

--- a/test/secrets/bitwarden_adapter_test.rb
+++ b/test/secrets/bitwarden_adapter_test.rb
@@ -2,10 +2,10 @@ require "test_helper"
 
 class BitwardenAdapterTest < SecretAdapterTestCase
   test "fetch" do
-    stub_ticks.with("bw --version 2> /dev/null")
+    stub_command(:system).with("bw --version", err: File::NULL)
 
     stub_unlocked
-    stub_ticks.with("bw sync").returns("")
+    stub_command.with("bw sync").returns("")
     stub_mypassword
 
     json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
@@ -16,10 +16,10 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with no login" do
-    stub_ticks.with("bw --version 2> /dev/null")
+    stub_command(:system).with("bw --version", err: File::NULL)
 
     stub_unlocked
-    stub_ticks.with("bw sync").returns("")
+    stub_command.with("bw sync").returns("")
     stub_noteitem
 
     error = assert_raises RuntimeError do
@@ -29,10 +29,10 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with from" do
-    stub_ticks.with("bw --version 2> /dev/null")
+    stub_command(:system).with("bw --version", err: File::NULL)
 
     stub_unlocked
-    stub_ticks.with("bw sync").returns("")
+    stub_command.with("bw sync").returns("")
     stub_myitem
 
     json = JSON.parse(shellunescape(run_command("fetch", "--from", "myitem", "field1", "field2", "field3")))
@@ -45,10 +45,10 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch all with from" do
-    stub_ticks.with("bw --version 2> /dev/null")
+    stub_command(:system).with("bw --version", err: File::NULL)
 
     stub_unlocked
-    stub_ticks.with("bw sync").returns("")
+    stub_command.with("bw sync").returns("")
     stub_noteitem_with_fields
 
     json = JSON.parse(shellunescape(run_command("fetch", "mynotefields")))
@@ -62,15 +62,15 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with multiple items" do
-    stub_ticks.with("bw --version 2> /dev/null")
+    stub_command(:system).with("bw --version", err: File::NULL)
 
     stub_unlocked
 
-    stub_ticks.with("bw sync").returns("")
+    stub_command.with("bw sync").returns("")
     stub_mypassword
     stub_myitem
 
-    stub_ticks
+    stub_command
     .with("bw get item myitem2")
     .returns(<<~JSON)
       {
@@ -105,9 +105,9 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch unauthenticated" do
-    stub_ticks.with("bw --version 2> /dev/null")
+    stub_command(:system).with("bw --version", err: File::NULL)
 
-    stub_ticks
+    stub_command
       .with("bw status")
       .returns(
         '{"serverUrl":null,"lastSync":null,"status":"unauthenticated"}',
@@ -115,9 +115,9 @@ class BitwardenAdapterTest < SecretAdapterTestCase
         '{"serverUrl":null,"lastSync":"2024-09-04T10:11:12.433Z","userEmail":"email@example.com","userId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"unlocked"}'
       )
 
-    stub_ticks.with("bw login email@example.com").returns("1234567890")
-    stub_ticks.with("bw unlock --raw").returns("")
-    stub_ticks.with("bw sync").returns("")
+    stub_command.with("bw login email@example.com").returns("1234567890")
+    stub_command.with("bw unlock --raw").returns("")
+    stub_command.with("bw sync").returns("")
     stub_mypassword
 
     json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
@@ -128,23 +128,23 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch locked" do
-    stub_ticks.with("bw --version 2> /dev/null")
+    stub_command(:system).with("bw --version", err: File::NULL)
 
-    stub_ticks
+    stub_command
       .with("bw status")
       .returns(
         '{"serverUrl":null,"lastSync":"2024-09-04T10:11:12.433Z","userEmail":"email@example.com","userId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"locked"}'
       )
 
-    stub_ticks
+    stub_command
       .with("bw status")
       .returns(
         '{"serverUrl":null,"lastSync":"2024-09-04T10:11:12.433Z","userEmail":"email@example.com","userId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"unlocked"}'
       )
 
-    stub_ticks.with("bw login email@example.com").returns("1234567890")
-    stub_ticks.with("bw unlock --raw").returns("")
-    stub_ticks.with("bw sync").returns("")
+    stub_command.with("bw login email@example.com").returns("1234567890")
+    stub_command.with("bw unlock --raw").returns("")
+    stub_command.with("bw sync").returns("")
     stub_mypassword
 
     json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
@@ -155,23 +155,24 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch locked with session" do
-    stub_ticks.with("bw --version 2> /dev/null")
+    stub_command(:system).with("bw --version", err: File::NULL)
 
-    stub_ticks
+
+    stub_command
       .with("bw status")
       .returns(
         '{"serverUrl":null,"lastSync":"2024-09-04T10:11:12.433Z","userEmail":"email@example.com","userId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"locked"}'
       )
 
-    stub_ticks
+    stub_command
       .with("BW_SESSION=0987654321 bw status")
       .returns(
         '{"serverUrl":null,"lastSync":"2024-09-04T10:11:12.433Z","userEmail":"email@example.com","userId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"unlocked"}'
       )
 
-    stub_ticks.with("bw login email@example.com").returns("1234567890")
-    stub_ticks.with("bw unlock --raw").returns("0987654321")
-    stub_ticks.with("BW_SESSION=0987654321 bw sync").returns("")
+    stub_command.with("bw login email@example.com").returns("1234567890")
+    stub_command.with("bw unlock --raw").returns("0987654321")
+    stub_command.with("BW_SESSION=0987654321 bw sync").returns("")
     stub_mypassword(session: "0987654321")
 
     json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
@@ -182,7 +183,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch without CLI installed" do
-    stub_ticks_with(system("bw --version", out: File::NULL, err: File::NULL), succeed: false)
+    stub_command_with("bw --version", :system, false)
 
     error = assert_raises RuntimeError do
       JSON.parse(shellunescape(run_command("fetch", "mynote")))
@@ -202,7 +203,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     end
 
     def stub_unlocked
-      stub_ticks
+      stub_command
         .with("bw status")
         .returns(<<~JSON)
           {"serverUrl":null,"lastSync":"2024-09-04T10:11:12.433Z","userEmail":"email@example.com","userId":"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee","status":"unlocked"}
@@ -210,7 +211,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     end
 
     def stub_mypassword(session: nil)
-      stub_ticks
+      stub_command
         .with("#{"BW_SESSION=#{session} " if session}bw get item mypassword")
         .returns(<<~JSON)
           {
@@ -233,7 +234,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     end
 
   def stub_noteitem(session: nil)
-    stub_ticks
+    stub_command
       .with("#{"BW_SESSION=#{session} " if session}bw get item mynote")
       .returns(<<~JSON)
           {
@@ -257,7 +258,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
       end
 
       def stub_noteitem_with_fields(session: nil)
-      stub_ticks
+      stub_command
         .with("#{"BW_SESSION=#{session} " if session}bw get item mynotefields")
         .returns(<<~JSON)
             {
@@ -287,7 +288,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
       end
 
     def stub_myitem
-      stub_ticks
+      stub_command
         .with("bw get item myitem")
         .returns(<<~JSON)
           {

--- a/test/secrets/bitwarden_adapter_test.rb
+++ b/test/secrets/bitwarden_adapter_test.rb
@@ -182,7 +182,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch without CLI installed" do
-    stub_ticks_with("bw --version 2> /dev/null", succeed: false)
+    stub_ticks_with(system("bw --version", out: File::NULL, err: File::NULL), succeed: false)
 
     error = assert_raises RuntimeError do
       JSON.parse(shellunescape(run_command("fetch", "mynote")))

--- a/test/secrets/doppler_adapter_test.rb
+++ b/test/secrets/doppler_adapter_test.rb
@@ -2,14 +2,14 @@ require "test_helper"
 
 class DopplerAdapterTest < SecretAdapterTestCase
   setup do
-    `true` # Ensure $? is 0
+    `exit 0` # Ensure $? is 0
   end
 
   test "fetch" do
-    stub_ticks_with("doppler --version 2> /dev/null", succeed: true)
-    stub_ticks.with("doppler me --json 2> /dev/null")
+    stub_command_with("doppler --version", :system, true)
+    stub_command(:system).with("doppler me --json", err: File::NULL)
 
-    stub_ticks
+    stub_command
       .with("doppler secrets get SECRET1 FSECRET1 FSECRET2 --json -p my-project -c prd")
       .returns(<<~JSON)
         {
@@ -47,10 +47,10 @@ class DopplerAdapterTest < SecretAdapterTestCase
   test "fetch having DOPPLER_TOKEN" do
     ENV["DOPPLER_TOKEN"] = "dp.st.xxxxxxxxxxxxxxxxxxxxxx"
 
-    stub_ticks_with("doppler --version 2> /dev/null", succeed: true)
-    stub_ticks.with("doppler me --json 2> /dev/null")
+    stub_command_with("doppler --version", :system, true)
+    stub_command(:system).with("doppler me --json", err: File::NULL)
 
-    stub_ticks
+    stub_command
       .with("doppler secrets get SECRET1 FSECRET1 FSECRET2 --json ")
       .returns(<<~JSON)
         {
@@ -88,10 +88,10 @@ class DopplerAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with folder in secret" do
-    stub_ticks_with("doppler --version 2> /dev/null", succeed: true)
-    stub_ticks.with("doppler me --json 2> /dev/null")
+    stub_command_with("doppler --version", :system, true)
+    stub_command(:system).with("doppler me --json", err: File::NULL)
 
-    stub_ticks
+    stub_command
       .with("doppler secrets get SECRET1 FSECRET1 FSECRET2 --json -p my-project -c prd")
       .returns(<<~JSON)
         {
@@ -127,8 +127,8 @@ class DopplerAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch without --from" do
-    stub_ticks_with("doppler --version 2> /dev/null", succeed: true)
-    stub_ticks.with("doppler me --json 2> /dev/null")
+    stub_command_with("doppler --version", :system, true)
+    stub_command(:system).with("doppler me --json", err: File::NULL)
 
     error = assert_raises RuntimeError do
       run_command("fetch", "FSECRET1", "FSECRET2")
@@ -138,10 +138,10 @@ class DopplerAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with signin" do
-    stub_ticks_with("doppler --version 2> /dev/null", succeed: true)
-    stub_ticks_with("doppler me --json 2> /dev/null", succeed: false)
-    stub_ticks_with("doppler login -y", succeed: true).returns("")
-    stub_ticks.with("doppler secrets get SECRET1 --json -p my-project -c prd").returns(single_item_json)
+    stub_command_with("doppler --version", :system, true)
+    stub_command_with("doppler me --json", :system, false)
+    stub_command_with("doppler login -y", :`, true).returns("")
+    stub_command.with("doppler secrets get SECRET1 --json -p my-project -c prd").returns(single_item_json)
 
     json = JSON.parse(shellunescape(run_command("fetch", "--from", "my-project/prd", "SECRET1")))
 
@@ -153,7 +153,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch without CLI installed" do
-    stub_ticks_with("doppler --version 2> /dev/null", succeed: false)
+    stub_command_with("doppler --version", :system, false)
 
     error = assert_raises RuntimeError do
       JSON.parse(shellunescape(run_command("fetch", "HOST", "PORT")))

--- a/test/secrets/one_password_adapter_test.rb
+++ b/test/secrets/one_password_adapter_test.rb
@@ -2,10 +2,10 @@ require "test_helper"
 
 class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   test "fetch" do
-    stub_ticks.with("op --version 2> /dev/null")
-    stub_ticks.with("op account get --account myaccount 2> /dev/null")
+    stub_command(:system).with("op --version", err: File::NULL)
+    stub_command(:system).with("op account get --account myaccount", err: File::NULL)
 
-    stub_ticks
+    stub_command
       .with("op item get myitem --vault \"myvault\" --fields \"label=section.SECRET1,label=section.SECRET2,label=section2.SECRET3\" --format \"json\" --account \"myaccount\"")
       .returns(<<~JSON)
         [
@@ -57,10 +57,10 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with multiple items" do
-    stub_ticks.with("op --version 2> /dev/null")
-    stub_ticks.with("op account get --account myaccount 2> /dev/null")
+    stub_command(:system).with("op --version", err: File::NULL)
+    stub_command(:system).with("op account get --account myaccount", err: File::NULL)
 
-    stub_ticks
+    stub_command
       .with("op item get myitem --vault \"myvault\" --fields \"label=section.SECRET1,label=section.SECRET2\" --format \"json\" --account \"myaccount\"")
       .returns(<<~JSON)
         [
@@ -89,7 +89,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
         ]
       JSON
 
-    stub_ticks
+    stub_command
       .with("op item get myitem2 --vault \"myvault\" --fields \"label=section2.SECRET3\" --format \"json\" --account \"myaccount\"")
       .returns(<<~JSON)
         {
@@ -117,12 +117,12 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with signin, no session" do
-    stub_ticks.with("op --version 2> /dev/null")
+    stub_command(:system).with("op --version", err: File::NULL)
 
-    stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
-    stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("")
+    stub_command_with("op account get --account myaccount", :system, false)
+    stub_command_with("op signin --account \"myaccount\" --force --raw", :`, true).returns("")
 
-    stub_ticks
+    stub_command
       .with("op item get myitem --vault \"myvault\" --fields \"label=section.SECRET1\" --format \"json\" --account \"myaccount\"")
       .returns(single_item_json)
 
@@ -136,12 +136,12 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch with signin and session" do
-    stub_ticks.with("op --version 2> /dev/null")
+    stub_command(:system).with("op --version", err: File::NULL)
 
-    stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
-    stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("1234567890")
+    stub_command_with("op account get --account myaccount", :system, false)
+    stub_command_with("op signin --account \"myaccount\" --force --raw", :`, true).returns("1234567890")
 
-    stub_ticks
+    stub_command
       .with("op item get myitem --vault \"myvault\" --fields \"label=section.SECRET1\" --format \"json\" --account \"myaccount\" --session \"1234567890\"")
       .returns(single_item_json)
 
@@ -155,7 +155,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch without CLI installed" do
-    stub_ticks_with("op --version 2> /dev/null", succeed: false)
+    stub_command_with("op --version", :system, false)
 
     error = assert_raises RuntimeError do
       JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3")))

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,7 +75,7 @@ end
 
 class SecretAdapterTestCase < ActiveSupport::TestCase
   setup do
-    `true` # Ensure $? is 0
+    `exit 0` # Ensure $? is 0
   end
 
   private
@@ -85,7 +85,7 @@ class SecretAdapterTestCase < ActiveSupport::TestCase
 
     def stub_ticks_with(command, succeed: true)
       # Sneakily run `false`/`true` after a match to set $? to 1/0
-      stub_ticks.with { |c| c == command && (succeed ? `true` : `false`) }
+      stub_ticks.with { |c| c == command && (succeed ? `exit 0` : `exit 1`) }
       Kamal::Secrets::Adapters::Base.any_instance.stubs(:`)
     end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -79,14 +79,14 @@ class SecretAdapterTestCase < ActiveSupport::TestCase
   end
 
   private
-    def stub_ticks
-      Kamal::Secrets::Adapters::Base.any_instance.stubs(:`)
+    def stub_command(format = :`)
+      Kamal::Secrets::Adapters::Base.any_instance.stubs(format)
     end
 
-    def stub_ticks_with(command, succeed: true)
-      # Sneakily run `false`/`true` after a match to set $? to 1/0
-      stub_ticks.with { |c| c == command && (succeed ? `exit 0` : `exit 1`) }
-      Kamal::Secrets::Adapters::Base.any_instance.stubs(:`)
+    def stub_command_with(command, format = :`, succeed = true)
+      # Sneakily run `exit 1`/`exit 0` after a match to set $? to 1/0
+      stub_command(format).with { |c| c == command && (succeed ? `exit 0` : `exit 1`) }
+      Kamal::Secrets::Adapters::Base.any_instance.stubs(format)
     end
 
     def shellunescape(string)


### PR DESCRIPTION
Wanted to implement secret fetching as described in this video: https://youtu.be/sPUk9-1WVXI?si=uqoqUZx-IHrp_fxD&t=526

However, on my Windows environment, this call failed due to the nullification of stderr via `{command} 2> /dev/null` whenever the CLI was checked. Was able to fix by using the system method instead. This _should_ work on any OS, and retain the same behavior as before, though I haven't checked on Mac or Linux.

(`true` and `false` were also issues in testing, so i replaced with `exit 0` and `exit 1`)