### PR TITLE
Adds support for Docker Build Cloud

### DIFF
--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -2,7 +2,7 @@ require "active_support/core_ext/string/filters"
 
 class Kamal::Commands::Builder < Kamal::Commands::Base
   delegate :create, :remove, :push, :clean, :pull, :info, :inspect_builder, :validate_image, :first_mirror, to: :target
-  delegate :local?, :remote?, to: "config.builder"
+  delegate :local?, :remote?, :cloud?, to: "config.builder"
 
   include Clone
 
@@ -17,6 +17,8 @@ class Kamal::Commands::Builder < Kamal::Commands::Base
       else
         remote
       end
+    elsif cloud?
+      cloud
     else
       local
     end
@@ -32,6 +34,10 @@ class Kamal::Commands::Builder < Kamal::Commands::Base
 
   def hybrid
     @hybrid ||= Kamal::Commands::Builder::Hybrid.new(config)
+  end
+
+  def cloud
+    @cloud ||= Kamal::Commands::Builder::Cloud.new(config)
   end
 
 

--- a/lib/kamal/commands/builder/cloud.rb
+++ b/lib/kamal/commands/builder/cloud.rb
@@ -1,0 +1,22 @@
+class Kamal::Commands::Builder::Cloud < Kamal::Commands::Builder::Base
+  # Expects `driver` to be of format "cloud docker-org-name/builder-name"
+
+  def create
+    docker :buildx, :create, "--driver", driver
+  end
+
+  def remove
+    docker :buildx, :rm, builder_name
+  end
+
+  private
+    def builder_name
+      driver.gsub(/[ \/]/, "-")
+    end
+
+    def inspect_buildx
+      pipe \
+        docker(:buildx, :inspect, builder_name),
+        grep("-q", "Endpoint:.*cloud://.*")
+    end
+end

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -53,6 +53,10 @@ class Kamal::Configuration::Builder
     !local_disabled? && (arches.empty? || local_arches.any?)
   end
 
+  def cloud?
+    driver.start_with? "cloud"
+  end
+
   def cached?
     !!builder_config["cache"]
   end

--- a/lib/kamal/configuration/docs/builder.yml
+++ b/lib/kamal/configuration/docs/builder.yml
@@ -102,6 +102,9 @@ builder:
   #
   # The build driver to use, defaults to `docker-container`:
   driver: docker
+  #
+  # If you want to use Docker Build Cloud (https://www.docker.com/products/build-cloud/), you can set the driver to:
+  driver: cloud org-name/builder-name
 
   # Provenance
   #

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -235,6 +235,12 @@ class CliBuildTest < CliTestCase
     end
   end
 
+  test "create cloud" do
+    run_command("create", fixture: :with_cloud_builder).tap do |output|
+      assert_match /docker buildx create --driver cloud example_org\/cloud_builder/, output
+    end
+  end
+
   test "create with error" do
     stub_setup
     SSHKit::Backend::Abstract.any_instance.stubs(:execute)
@@ -249,6 +255,12 @@ class CliBuildTest < CliTestCase
   test "remove" do
     run_command("remove").tap do |output|
       assert_match /docker buildx rm kamal-local/, output
+    end
+  end
+
+  test "remove cloud" do
+    run_command("remove", fixture: :with_cloud_builder).tap do |output|
+      assert_match /docker buildx rm cloud-example_org-cloud_builder/, output
     end
   end
 

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -61,6 +61,14 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "cloud builder" do
+    builder = new_builder_command(builder: { "arch" => [ "#{local_arch}" ], "driver" => "cloud docker-org-name/builder-name" })
+    assert_equal "cloud", builder.name
+    assert_equal \
+      "docker buildx build --push --platform linux/#{local_arch} --builder cloud-docker-org-name-builder-name -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile .",
+      builder.push.join(" ")
+  end
+
   test "build args" do
     builder = new_builder_command(builder: { "args" => { "a" => 1, "b" => 2 } })
     assert_equal \

--- a/test/fixtures/deploy_with_cloud_builder.yml
+++ b/test/fixtures/deploy_with_cloud_builder.yml
@@ -1,0 +1,40 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+    - "1.1.1.2"
+  workers:
+    - "1.1.1.3"
+    - "1.1.1.4"
+registry:
+  username: user
+  password: pw
+
+accessories:
+  mysql:
+    image: mysql:5.7
+    host: 1.1.1.3
+    port: 3306
+    env:
+      clear:
+        MYSQL_ROOT_HOST: '%'
+      secret:
+        - MYSQL_ROOT_PASSWORD
+    files:
+      - test/fixtures/files/my.cnf:/etc/mysql/my.cnf
+    directories:
+      - data:/var/lib/mysql
+  redis:
+    image: redis:latest
+    roles:
+      - web
+    port: 6379
+    directories:
+      - data:/data
+
+readiness_delay: 0
+
+builder:
+  arch: <%= Kamal::Utils.docker_arch == "arm64" ? "amd64" : "arm64" %>
+  driver: cloud example_org/cloud_builder


### PR DESCRIPTION
This PR aims to add the minimal amount of code changes to support building using [Docker Build Cloud](https://www.docker.com/products/build-cloud/)

Although Kamal already currently supports remote builds using `remote: ssh://user@ip-address`, some individuals or organizations may prefer to use Docker Build Cloud for remote compiling (for example, you don't have a remote machine around to utilize remote builds) 

Assuming you're using Docker Build Cloud, and you've already created a builder on your Docker Build Cloud, then, all you need to do with Kamal is specify the driver:
```
driver: cloud org-name/builder-name
```

When specifying `driver: cloud ...`, the `buildx` commands will now pass in a `--builder cloud-org-name-builder-name` to instruct `buildx` to use that builder. It will also automatically register and remove the cloud driver as well.

Related Discussion: https://github.com/basecamp/kamal/discussions/914