### PR TITLE
Fix LastPass error message typo

### DIFF
--- a/lib/kamal/secrets/adapters/last_pass.rb
+++ b/lib/kamal/secrets/adapters/last_pass.rb
@@ -24,7 +24,7 @@ class Kamal::Secrets::Adapters::LastPass < Kamal::Secrets::Adapters::Base
         end
 
         if (missing_items = secrets - results.keys).any?
-          raise RuntimeError, "Could not find #{missing_items.join(", ")} in LassPass"
+          raise RuntimeError, "Could not find #{missing_items.join(", ")} in LastPass"
         end
       end
     end


### PR DESCRIPTION
Noticed a typo while debugging the LastPass Adapter for Kamal Secrets. Changed `LassPass` to `LastPass`.