### PR TITLE
Don't read a file in sample deploy.yml

### DIFF
--- a/lib/kamal/cli/templates/deploy.yml
+++ b/lib/kamal/cli/templates/deploy.yml
@@ -38,7 +38,7 @@ builder:
   arch: amd64
   # Pass in additional build args needed for your Dockerfile.
   # args:
-  #   RUBY_VERSION: <%= File.read('.ruby-version').strip %>
+  #   RUBY_VERSION: <%= ENV["RBENV_VERSION"] || ENV["rvm_ruby_string"] || "#{RUBY_ENGINE}-#{RUBY_ENGINE_VERSION}" %>
 
 # Inject ENV variables into containers (secrets come from .kamal/secrets).
 #


### PR DESCRIPTION
The ERB runs first so it does matter if it in a comment. If the file doesn't exist (e.g. if not using Ruby, you'll get an error).

We'll change the example to match the Rails deploy.yml template won't have than problem.

Fixes https://github.com/basecamp/kamal/issues/1304