### PR TITLE
ci: use `fail-fast: false` instead of `continue-on-error: true`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
         run: bundle exec rubocop --parallel
   tests:
     strategy:
+      fail-fast: false
       matrix:
         ruby-version:
           - "3.1"
@@ -37,7 +38,6 @@ jobs:
             gemfile: gemfiles/rails_edge.gemfile
     name: ${{ format('Tests (Ruby {0})', matrix.ruby-version) }}
     runs-on: ubuntu-latest
-    continue-on-error: true
     env:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:


### PR DESCRIPTION
This will give us proper pass/fail signal on the test suite while still running the entire matrix.

As previously configured, even if jobs fail, the overall CI status is "passed":

![image](https://github.com/user-attachments/assets/b5c705b5-4c71-4612-a3d3-da9a8db4dfc8)

