### PR TITLE
Enable IPv6 connectivity for the kamal network

### DIFF
--- a/lib/kamal/commands/docker.rb
+++ b/lib/kamal/commands/docker.rb
@@ -20,7 +20,7 @@ class Kamal::Commands::Docker < Kamal::Commands::Base
   end
 
   def create_network
-    docker :network, :create, :kamal
+    docker :network, :create, "--ipv6", :kamal
   end
 
   private

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -32,9 +32,9 @@ class CliAccessoryTest < CliTestCase
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.1", output
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.2", output
       assert_match "docker login other.registry -u [REDACTED] -p [REDACTED] on 1.1.1.3", output
-      assert_match /docker network create kamal.*on 1.1.1.1/, output
-      assert_match /docker network create kamal.*on 1.1.1.2/, output
-      assert_match /docker network create kamal.*on 1.1.1.3/, output
+      assert_match /docker network create --ipv6 kamal.*on 1.1.1.1/, output
+      assert_match /docker network create --ipv6 kamal.*on 1.1.1.2/, output
+      assert_match /docker network create --ipv6 kamal.*on 1.1.1.3/, output
       assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
       assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
       assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
@@ -234,7 +234,7 @@ class CliAccessoryTest < CliTestCase
   test "upgrade" do
     run_command("upgrade", "-y", "all").tap do |output|
       assert_match "Upgrading all accessories on 1.1.1.3,1.1.1.1,1.1.1.2...", output
-      assert_match "docker network create kamal on 1.1.1.3", output
+      assert_match "docker network create --ipv6 kamal on 1.1.1.3", output
       assert_match "docker container stop app-mysql on 1.1.1.3", output
       assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
       assert_match "Upgraded all accessories on 1.1.1.3,1.1.1.1,1.1.1.2...", output
@@ -244,7 +244,7 @@ class CliAccessoryTest < CliTestCase
   test "upgrade rolling" do
     run_command("upgrade", "--rolling", "-y", "all").tap do |output|
       assert_match "Upgrading all accessories on 1.1.1.3...", output
-      assert_match "docker network create kamal on 1.1.1.3", output
+      assert_match "docker network create --ipv6 kamal on 1.1.1.3", output
       assert_match "docker container stop app-mysql on 1.1.1.3", output
       assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
       assert_match "Upgraded all accessories on 1.1.1.3", output

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -194,7 +194,7 @@ class CliProxyTest < CliTestCase
       assert_match "docker container prune --force --filter label=org.opencontainers.image.title=kamal-proxy", output
       assert_match "docker image prune --all --force --filter label=org.opencontainers.image.title=kamal-proxy", output
       assert_match "/usr/bin/env mkdir -p .kamal", output
-      assert_match "docker network create kamal", output
+      assert_match "docker network create --ipv6 kamal", output
       assert_match "docker login -u [REDACTED] -p [REDACTED]", output
       assert_match "docker container start kamal-proxy || docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy $(cat .kamal/proxy/options || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") basecamp/kamal-proxy:#{Kamal::Configuration::PROXY_MINIMUM_VERSION}", output
       assert_match "/usr/bin/env mkdir -p .kamal", output


### PR DESCRIPTION
Based on #1280 I've updated the tests as well.
This change is needed if you want to receive the client IPv6 address in your Rails app. Without it you'll only get the IPv4 address of the docker proxy (172.x.x.x). 