### PR TITLE
Allow omitting AWS account parameter while fetching secrets

### DIFF
--- a/lib/kamal/secrets/adapters/aws_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/aws_secrets_manager.rb
@@ -48,4 +48,3 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
       $?.success?
     end
 end
-

--- a/lib/kamal/secrets/adapters/aws_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/aws_secrets_manager.rb
@@ -1,15 +1,18 @@
 class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Base
+  def requires_account?
+    false
+  end
+
   private
     def login(_account)
       nil
     end
 
-    def fetch_secrets(secrets, from:, account:, session:)
+    def fetch_secrets(secrets, from:, account: nil, session:)
       {}.tap do |results|
         get_from_secrets_manager(prefixed_secrets(secrets, from: from), account: account).each do |secret|
           secret_name = secret["Name"]
           secret_string = JSON.parse(secret["SecretString"])
-
           secret_string.each do |key, value|
             results["#{secret_name}/#{key}"] = value
           end
@@ -19,8 +22,14 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
       end
     end
 
-    def get_from_secrets_manager(secrets, account:)
-      `aws secretsmanager batch-get-secret-value --secret-id-list #{secrets.map(&:shellescape).join(" ")} --profile #{account.shellescape}`.tap do |secrets|
+    def get_from_secrets_manager(secrets, account: nil)
+      profile_opt = account ? "--profile #{account.shellescape}" : ""
+
+      args = [ "aws", "secretsmanager", "batch-get-secret-value", "--secret-id-list" ] + secrets.map(&:shellescape)
+      args += [ "--profile", account.shellescape ] if account
+      cmd = args.join(" ")
+
+      `#{cmd}`.tap do |secrets|
         raise RuntimeError, "Could not read #{secrets} from AWS Secrets Manager" unless $?.success?
 
         secrets = JSON.parse(secrets)

--- a/lib/kamal/secrets/adapters/aws_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/aws_secrets_manager.rb
@@ -48,3 +48,4 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
       $?.success?
     end
 end
+

--- a/lib/kamal/secrets/adapters/aws_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/aws_secrets_manager.rb
@@ -23,8 +23,6 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
     end
 
     def get_from_secrets_manager(secrets, account: nil)
-      profile_opt = account ? "--profile #{account.shellescape}" : ""
-
       args = [ "aws", "secretsmanager", "batch-get-secret-value", "--secret-id-list" ] + secrets.map(&:shellescape)
       args += [ "--profile", account.shellescape ] if account
       cmd = args.join(" ")

--- a/lib/kamal/secrets/adapters/aws_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/aws_secrets_manager.rb
@@ -13,6 +13,7 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
         get_from_secrets_manager(prefixed_secrets(secrets, from: from), account: account).each do |secret|
           secret_name = secret["Name"]
           secret_string = JSON.parse(secret["SecretString"])
+
           secret_string.each do |key, value|
             results["#{secret_name}/#{key}"] = value
           end


### PR DESCRIPTION
# Problem

When using OIDC in GHA to assume a role to execute commands via AWS cli, you do not have a profile.

For instance, running `aws configure list` after using OIDC:
```
      Name                    Value             Type    Location
      ----                    -----             ----    --------
   profile                <not set>             None    None
access_key     ****************AMST              env    
secret_key     ****************JxL9              env    
    region                us-east-1              env    ['AWS_REGION', 'AWS_DEFAULT_REGION']
```

You don't get any profile.

Also you'd expect `kamal secrets fetch --adapter aws_secrets_manager` to use whatever profile is exported as `AWS_DEFAULT_PROFILE`, even if it's pointing to something other than the actual profile named `default` if it exists. 

# Solution

When calling `aws secretsmanager batch-get-secret-value`, it's not actually required to pass an account id. If omitted, it'll follow the CLI's general precedence order for determining what account to use.

So, we can modify the adapter to allow omitting the account option and defaulting it to `nil`. Then, we can only add the argument conditionally if passed in.

This will correctly enable use cases like deployment via GHA and OIDC.