### PR TITLE
Allow accessory roles with no hosts

### DIFF
--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -201,7 +201,11 @@ class Kamal::Configuration::Accessory
     def hosts_from_roles
       if accessory_config.key?("roles")
         accessory_config["roles"].flat_map do |role|
-          config.role(role)&.hosts || raise(Kamal::ConfigurationError, "Unknown role in accessories config: '#{role}'")
+          unless (role = config.role(role))
+            raise Kamal::ConfigurationError, "Unknown role in accessories config: '#{role}'" unless config.role(role)
+          end
+
+          role.hosts
         end
       end
     end


### PR DESCRIPTION
Only raise an exception if the role is not found, not it it has no hosts.