### PR TITLE
Prep for 2.5

### DIFF
--- a/lib/kamal/cli/alias/command.rb
+++ b/lib/kamal/cli/alias/command.rb
@@ -1,6 +1,7 @@
 class Kamal::Cli::Alias::Command < Thor::DynamicCommand
   def run(instance, args = [])
     if (_alias = KAMAL.config.aliases[name])
+      KAMAL.reset
       Kamal::Cli::Main.start(Shellwords.split(_alias.command) + ARGV[1..-1])
     else
       super

--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -31,7 +31,7 @@ module Kamal::Cli
         super
       end
 
-      initialize_commander unless config[:invoked_via_subcommand]
+      initialize_commander unless KAMAL.configured?
     end
 
     private

--- a/lib/kamal/commander.rb
+++ b/lib/kamal/commander.rb
@@ -4,13 +4,20 @@ require "active_support/core_ext/object/blank"
 
 class Kamal::Commander
   attr_accessor :verbosity, :holding_lock, :connected
+  attr_reader :specific_roles, :specific_hosts
   delegate :hosts, :roles, :primary_host, :primary_role, :roles_on, :proxy_hosts, :accessory_hosts, to: :specifics
 
   def initialize
+    reset
+  end
+
+  def reset
     self.verbosity = :info
     self.holding_lock = false
     self.connected = false
-    @specifics = nil
+    @specifics = @specific_roles = @specific_hosts = nil
+    @config = @config_kwargs = nil
+    @commands = {}
   end
 
   def config
@@ -27,8 +34,6 @@ class Kamal::Commander
   def configured?
     @config || @config_kwargs
   end
-
-  attr_reader :specific_roles, :specific_hosts
 
   def specific_primary!
     @specifics = nil
@@ -89,35 +94,35 @@ class Kamal::Commander
   end
 
   def builder
-    @builder ||= Kamal::Commands::Builder.new(config)
+    @commands[:builder] ||= Kamal::Commands::Builder.new(config)
   end
 
   def docker
-    @docker ||= Kamal::Commands::Docker.new(config)
+    @commands[:docker] ||= Kamal::Commands::Docker.new(config)
   end
 
   def hook
-    @hook ||= Kamal::Commands::Hook.new(config)
+    @commands[:hook] ||= Kamal::Commands::Hook.new(config)
   end
 
   def lock
-    @lock ||= Kamal::Commands::Lock.new(config)
+    @commands[:lock] ||= Kamal::Commands::Lock.new(config)
   end
 
   def proxy
-    @proxy ||= Kamal::Commands::Proxy.new(config)
+    @commands[:proxy] ||= Kamal::Commands::Proxy.new(config)
   end
 
   def prune
-    @prune ||= Kamal::Commands::Prune.new(config)
+    @commands[:prune] ||= Kamal::Commands::Prune.new(config)
   end
 
   def registry
-    @registry ||= Kamal::Commands::Registry.new(config)
+    @commands[:registry] ||= Kamal::Commands::Registry.new(config)
   end
 
   def server
-    @server ||= Kamal::Commands::Server.new(config)
+    @commands[:server] ||= Kamal::Commands::Server.new(config)
   end
 
   def alias(name)

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -16,6 +16,8 @@ class Kamal::Configuration::Accessory
       context: "accessories/#{name}",
       with: Kamal::Configuration::Validator::Accessory
 
+    ensure_valid_roles
+
     @env = initialize_env
     @proxy = initialize_proxy if running_proxy?
     @registry = initialize_registry if accessory_config["registry"].present?
@@ -200,17 +202,17 @@ class Kamal::Configuration::Accessory
 
     def hosts_from_roles
       if accessory_config.key?("roles")
-        accessory_config["roles"].flat_map do |role|
-          unless (role = config.role(role))
-            raise Kamal::ConfigurationError, "Unknown role in accessories config: '#{role}'" unless config.role(role)
-          end
-
-          role.hosts
-        end
+        accessory_config["roles"].flat_map { |role| config.role(role)&.hosts }
       end
     end
 
     def network
       accessory_config["network"] || DEFAULT_NETWORK
+    end
+
+    def ensure_valid_roles
+      if accessory_config["roles"] && (missing_roles = accessory_config["roles"] - config.roles.map(&:name)).any?
+        raise Kamal::ConfigurationError, "accessories/#{name}: unknown roles #{missing_roles.join(", ")}"
+      end
     end
 end


### PR DESCRIPTION
- Reset KAMAL on alias command, rather than relying on checking "invoked_via_subcommand"
- Validate the accessories roles when loading the configuration not later on when trying to access them