### PR TITLE
Only check for docker when logging in locally

### DIFF
--- a/lib/kamal/cli/registry.rb
+++ b/lib/kamal/cli/registry.rb
@@ -3,7 +3,7 @@ class Kamal::Cli::Registry < Kamal::Cli::Base
   option :skip_local, aliases: "-L", type: :boolean, default: false, desc: "Skip local login"
   option :skip_remote, aliases: "-R", type: :boolean, default: false, desc: "Skip remote login"
   def login
-    ensure_docker_installed
+    ensure_docker_installed unless options[:skip_local]
 
     run_locally    { execute *KAMAL.registry.login } unless options[:skip_local]
     on(KAMAL.hosts) { execute *KAMAL.registry.login } unless options[:skip_remote]

--- a/test/cli/registry_test.rb
+++ b/test/cli/registry_test.rb
@@ -52,6 +52,18 @@ class CliRegistryTest < CliTestCase
     assert_raises(Kamal::Cli::DependencyError) { run_command("login") }
   end
 
+  test "allow remote login with no docker" do
+    stub_setup
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+      .with(:docker, "--version", "&&", :docker, :buildx, "version")
+      .raises(SSHKit::Command::Failed.new("command not found"))
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+      .with { |*args| args[0..1] == [ :docker, :login ] }
+
+    assert_nothing_raised { run_command("login", "--skip-local") }
+  end
+
 
   private
     def run_command(*command)


### PR DESCRIPTION
If we are skipping a local registry login, we don't need docker installed locally.

Fixes: https://github.com/basecamp/kamal/issues/1400