### PR TITLE
fix: make sure args to `echo` are quoted

### DIFF
--- a/lib/kamal/commands/auditor.rb
+++ b/lib/kamal/commands/auditor.rb
@@ -11,7 +11,7 @@ class Kamal::Commands::Auditor < Kamal::Commands::Base
     combine \
       [ :mkdir, "-p", config.run_directory ],
       append(
-        [ :echo, audit_tags(**details).except(:version, :service_version, :service).to_s, line ],
+        [ :echo, audit_tags(**details).except(:version, :service_version, :service).to_s.inspect, line.inspect ],
         audit_log_file
       )
   end


### PR DESCRIPTION
When running `kamal build pull`  (or any action that internally calls that like `kamal setup`, `kamal deploy`, `kamal redeploy`, etc) I would get this line:

```
 DEBUG [c035c395] Command: /usr/bin/env mkdir -p .kamal && echo [2025-02-07T13:42:50Z] [EMAIL] Pulled image with version f9d2e07307ea435ce6616cb6a15bb25cdddd96ba >> .kamal/PROJECT-audit.log
 DEBUG [c035c395] 	zsh:1: no matches found: [2025-02-07T13:42:50Z]
```

The issue was that the argument to echo was not being quoted. 

With this change the command is now:

```
/usr/bin/env mkdir -p .kamal && echo "[2025-02-07T13:49:23Z] [EMAIL]" "Pulled image with version f9d2e07307ea435ce6616cb6a15bb25cdddd96ba" >> .kamal/PROJECT-audit.log
```

which works just fine