### PR TITLE
Update docker setup example hook

### DIFF
--- a/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
+++ b/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
@@ -7,5 +7,4 @@ bundle exec kamal server exec "
   ufw --force enable && \
   apt-get install fail2ban -y && \
   systemctl start fail2ban && \
-  systemctl enable fail2ban && \
-  systemctl status fail2ban"
+  systemctl enable fail2ban"

--- a/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
+++ b/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
@@ -1,3 +1,11 @@
 #!/bin/sh
 
-echo "Docker set up on $KAMAL_HOSTS..."
+bundle exec kamal server exec "
+  ufw allow ssh && \
+  ufw allow http && \
+  ufw allow https && \
+  ufw --force enable && \
+  apt-get install fail2ban -y && \
+  systemctl start fail2ban && \
+  systemctl enable fail2ban && \
+  systemctl status fail2ban"

--- a/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
+++ b/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-bundle exec kamal server exec "
+bin/kamal server exec "
   ufw allow ssh && \
   ufw allow http && \
   ufw allow https && \


### PR DESCRIPTION
Thought this might be a nice addition to help people a little bit when getting a new server up and running. 

This is specifically for Ubuntu and adds some default UFW rules and a basic fail2ban install. 

```
$ .kamal/hooks/docker-setup
Running 'ufw allow ssh &&   ufw allow http &&   ufw allow https &&   ufw --force enable &&   apt-get install fail2ban -y &&   systemctl start fail2ban &&   systemctl enable fail2ban' on 867.53.0.9...
  INFO [e818ecd1] Running ufw allow ssh &&   ufw allow http &&   ufw allow https &&   ufw --force enable &&   apt-get install fail2ban -y &&   systemctl start fail2ban &&   systemctl enable fail2ban on 867.53.0.9
  INFO [e818ecd1] Finished in 2.468 seconds with exit status 0 (successful).
```

