### PR TITLE
Fail kamal app exec without a CMD

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -108,6 +108,10 @@ class Kamal::Cli::App < Kamal::Cli::Base
       raise ArgumentError, "Detach is not compatible with #{incompatible_options.join(" or ")}"
     end
 
+    if cmd.empty?
+      raise ArgumentError, "No command provided. You must specify a command to execute."
+    end
+
     cmd = Kamal::Utils.join_commands(cmd)
     env = options[:env]
     detach = options[:detach]


### PR DESCRIPTION
Related to: https://github.com/basecamp/kamal/issues/1399

It appears that there is an issue with `Thor` and parsing `key:value` pairs that results in the vague and confusing error below. 

```
weiner % kamal app exec --primary --env=TEST:1 '/usr/bin/echo :test'      
Get most recent version available as an image...
Launching command with version latest from new container...
  INFO [ab8c5ab1] Running docker run --rm --network kamal --env PORT="3000" --env TEST="1" --env /usr/bin/echo ="test" --log-opt max-size="10m" registry.hub.docker.com/<REDACTED>/<REDACTED>:latest  on <REDACTED>
  ERROR (SSHKit::Command::Failed): Exception while executing on host <REDACTED>: docker exit status: 125
docker stdout: Nothing written
docker stderr: docker: invalid reference format.
See 'docker run --help'.
```

The parsing error is not present when command and options are reordered slightly: `kamal app exec '/usr/bin/echo :test' --primary --env=TEST:1`

`thor` appears to be incorrectly parsing `/usr/bin/echo :test` as an `--env` option. My stance is that we can return a better error to the user when this invalid parsing takes place.