### PR TITLE
Raise error (instead of warn) when uncommitted git changes are detected

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -16,6 +16,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
 
   desc "deploy", "Deploy app to servers"
   option :skip_push, aliases: "-P", type: :boolean, default: false, desc: "Skip image build and push"
+  option :skip_uncommitted_changes_check, type: :boolean, default: false, desc: "Skip uncommitted git changes check"
   def deploy(boot_accessories: false)
     runtime = print_runtime do
       invoke_options = deploy_options

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -20,6 +20,8 @@ class CliBuildTest < CliTestCase
         .with(:git, "-C", anything, :status, "--porcelain")
         .returns("")
 
+      stub_no_uncommitted_git_changes
+
       run_command("push", "--verbose").tap do |output|
         assert_hook_ran "pre-build", output
         assert_match /Cloning repo into build directory/, output
@@ -41,6 +43,8 @@ class CliBuildTest < CliTestCase
       SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
         .with(:git, "-C", anything, :status, "--porcelain")
         .returns("")
+
+      stub_no_uncommitted_git_changes
 
       run_command("push", "--output=docker", "--verbose").tap do |output|
         assert_hook_ran "pre-build", output
@@ -79,6 +83,8 @@ class CliBuildTest < CliTestCase
       SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
         .with(:git, "-C", anything, :status, "--porcelain")
         .returns("")
+
+      stub_no_uncommitted_git_changes
 
       run_command("push", "--verbose").tap do |output|
         assert_match /Cloning repo into build directory/, output
@@ -124,6 +130,8 @@ class CliBuildTest < CliTestCase
 
       Dir.stubs(:chdir)
 
+      stub_no_uncommitted_git_changes
+
       run_command("push", "--verbose") do |output|
         assert_match /Cloning repo into build directory `#{build_directory}`\.\.\..*Cloning repo into build directory `#{build_directory}`\.\.\./, output
         assert_match "Resetting local clone as `#{build_directory}` already exists...", output
@@ -161,6 +169,8 @@ class CliBuildTest < CliTestCase
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
         .with(:docker, :buildx, :build, "--output=type=registry", "--platform", "linux/amd64", "--builder", "kamal-local-docker-container", "-t", "dhh/app:999", "-t", "dhh/app:latest", "--label", "service=\"app\"", "--file", "Dockerfile", ".")
+
+      stub_no_uncommitted_git_changes
 
       run_command("push").tap do |output|
         assert_match /WARN Missing compatible builder, so creating a new one first/, output

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -75,6 +75,10 @@ class ActiveSupport::TestCase
       Dir.chdir(@original_pwd)
       FileUtils.rm_rf(@secrets_tmpdir)
     end
+
+    def stub_no_uncommitted_git_changes
+      Kamal::Git.stubs(:uncommitted_changes).returns("")
+    end
 end
 
 class SecretAdapterTestCase < ActiveSupport::TestCase


### PR DESCRIPTION
After hanging around in the Discord for a few months, I've noticed that many beginners to Kamal experience "unexpected behavior" when it comes to making changes locally and then deploying, expecting that Kamal would've deployed their latest uncommitted changes.

Kamal would print out a warning message in yellow, but this can get lost in the sea of yellow messages and verbose output that Kamal prints out. Since the primary intended usage of Kamal is for you to first commit your changes before pushing/deploying, I believe it would be better to have the warning about ignoring uncommitted changes become an error, by default, and exit. If you _purposefully_ want to have ignored, uncommitted local changes while pushing/deploying, you can suppress the error via `--skip-uncommitted-changes-check`, which results in Kamal printing out a warning in yellow but still proceeding (like it did by default prior to this change).

### `kamal build push` error, by default
![Screenshot 2025-02-10 at 5 00 32 PM](https://github.com/user-attachments/assets/c52ef5de-3359-42e1-b1cb-64c8f769ed65)

### `kamal build push` skip error, via `--skip-uncommitted-changes-check`
![Screenshot 2025-02-10 at 5 00 52 PM](https://github.com/user-attachments/assets/937ab9b9-55e1-45dc-a94d-2df0798201b8)

### `kamal deploy` error, by default
![Screenshot 2025-02-10 at 5 01 27 PM](https://github.com/user-attachments/assets/7a3fe205-6489-4ce2-8529-e98717e553c8)

### `kamal deploy` skip error, via `--skip-uncommitted-changes-check`
![Screenshot 2025-02-10 at 5 03 27 PM](https://github.com/user-attachments/assets/dc359dde-b919-4736-b33a-61c6ff180264)
