### PR TITLE
Fix Docker Build under Ruby 3.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@ COPY lib/kamal/version.rb /kamal/lib/kamal/version.rb
 # Install system dependencies
 RUN apk add --no-cache build-base git docker openrc openssh-client-default yaml-dev \
     && rc-update add docker boot \
-    && gem install bundler --version=2.4.3 \
+    && gem install bundler --version=2.6.5 \
     && bundle install
 
 # Copy the rest of our application code into the container.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -48,8 +48,6 @@ GEM
     ast (2.4.2)
     base64 (0.2.0)
     bcrypt_pbkdf (1.1.1)
-    bcrypt_pbkdf (1.1.1-arm64-darwin)
-    bcrypt_pbkdf (1.1.1-x86_64-darwin)
     benchmark (0.4.0)
     bigdecimal (3.1.8)
     builder (3.3.0)
@@ -84,11 +82,15 @@ GEM
     net-sftp (4.0.0)
       net-ssh (>= 5.0.0, < 8.0.0)
     net-ssh (7.3.0)
-    nokogiri (1.17.2-arm64-darwin)
+    nokogiri (1.18.3-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.17.2-x86_64-darwin)
+    nokogiri (1.18.3-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.17.2-x86_64-linux)
+    nokogiri (1.18.3-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.18.3-x86_64-linux-gnu)
+      racc (~> 1.4)
+    nokogiri (1.18.3-x86_64-linux-musl)
       racc (~> 1.4)
     ostruct (0.6.1)
     parallel (1.26.3)
@@ -177,9 +179,11 @@ GEM
     zeitwerk (2.7.1)
 
 PLATFORMS
+  aarch64-linux-musl
   arm64-darwin
   x86_64-darwin
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   debug
@@ -189,4 +193,4 @@ DEPENDENCIES
   rubocop-rails-omakase
 
 BUNDLED WITH
-   2.4.3
+   2.6.5


### PR DESCRIPTION
Docker Build was failing after updating to use 3.4-alpine. 
This was related to nokogiri.
A nokogiri update was required for Ruby 3.4 compatibility,
but also they changed some stuff about their precompiled native gems
that was causing bundler not to be able to find the right gem, because
the declared platforms in the lockfile didn't include the necessary ones
to match the docker build environment in Github Actions.
Based on the info in the nokogiri release notes, a newer version of
Bundler is also required to support these changes with the precompiled
native gems, so this pull request also updates Bundler to the current
version.

Based on my testing, these changes should get the docker build working
again under Ruby 3.4.

Reference nokogiri release notes: https://github.com/sparklemotion/nokogiri/releases/tag/v1.18.0

Closes #1411 

CC: @djmb 