### PR TITLE
Adds the ability to alias/map secrets

### DIFF
--- a/lib/kamal/configuration/docs/env.yml
+++ b/lib/kamal/configuration/docs/env.yml
@@ -51,6 +51,30 @@ env:
   secret:
     - DB_PASSWORD
 
+# Aliased secrets
+#
+# You can also alias secrets to other secrets using a `:` separator.
+#
+# This is useful when the ENV name is different from the secret name. For example, if you have two
+# places where you need to define the ENV variable `DB_PASSWORD`, but the value is different depending
+# on the context.
+#
+# ```shell
+# SECRETS=$(kamal secrets fetch ...)
+#
+# MAIN_DB_PASSWORD=$(kamal secrets extract MAIN_DB_PASSWORD $SECRETS)
+# SECONDARY_DB_PASSWORD=$(kamal secrets extract SECONDARY_DB_PASSWORD $SECRETS)
+# ```
+accessories:
+  main_db_accessory:
+    env:
+      secret:
+        - DB_PASSWORD:MAIN_DB_PASSWORD
+  secondary_db_accessory:
+    env:
+      secret:
+        - DB_PASSWORD:SECONDARY_DB_PASSWORD
+
 # Tags
 #
 # Tags are used to add extra env variables to specific hosts.

--- a/lib/kamal/configuration/env.rb
+++ b/lib/kamal/configuration/env.rb
@@ -18,7 +18,7 @@ class Kamal::Configuration::Env
   end
 
   def secrets_io
-    Kamal::EnvFile.new(secret_keys.to_h { |key| [ key, secrets[key] ] }).to_io
+    Kamal::EnvFile.new(secrets_hash).to_io
   end
 
   def merge(other)
@@ -26,4 +26,12 @@ class Kamal::Configuration::Env
       config: { "clear" => clear.merge(other.clear), "secret" => secret_keys | other.secret_keys },
       secrets: secrets
   end
+
+  private
+    def secrets_hash
+      secret_keys.to_h do |key|
+        key_name, key_aliased_to = key.split(":")
+        [ key_name, secrets[key_aliased_to || key_name] ]
+      end
+    end
 end

--- a/test/configuration/env_test.rb
+++ b/test/configuration/env_test.rb
@@ -48,6 +48,20 @@ class ConfigurationEnvTest < ActiveSupport::TestCase
     end
   end
 
+  test "aliased secrets" do
+    with_test_secrets("secrets" => "ALIASED_PASSWORD=hello") do
+      config = {
+        "secret" => [ "PASSWORD:ALIASED_PASSWORD" ],
+        "clear" => {}
+      }
+
+      assert_config \
+        config: config,
+        clear: {},
+        secrets: { "PASSWORD" => "hello" }
+    end
+  end
+
   private
     def assert_config(config:, clear: {}, secrets: {})
       env = Kamal::Configuration::Env.new config: config, secrets: Kamal::Secrets.new


### PR DESCRIPTION
If you find yourself in a situation where you need to declare secrets for an accessory, etc. but the value of the secret is defined in your `.kamal/secrets` but under a different name, with the current implementation of `kamal`, there is no way to support this concept of aliasing/mapping.

The use case here is when you have two (or more) accessories that require the same ENV variable name, but the value is different for each accessory. For example, when defining two different Postgres backup accessories, one for your main Rails database, and another accessory for a supplementary/other database, it is not possible to have the two accessories have their own `DB_PASSWORD`, for example.

This PR modifies the way secrets work to support the concept of aliasing/mapping by using `:` as a separator. This will then allow you to declare secrets like:

```yaml
accessories:
  main_db_accessory:
    env:
      secret:
        - DB_PASSWORD:MAIN_DB_PASSWORD
  secondary_db_accessory:
    env:
      secret:
        - DB_PASSWORD:SECONDARY_DB_PASSWORD
```

Where your `.kama/secrets` could look like:
```yaml
SECRETS=$(kamal secrets fetch ...)
MAIN_DB_PASSWORD=$(kamal secrets extract MAIN_DB_PASSWORD $SECRETS)
SECONDARY_DB_PASSWORD=$(kamal secrets extract SECONDARY_DB_PASSWORD $SECRETS)
```