### PR TITLE
Fix Bitwarden Secrets Manager authentication checks

### DIFF
--- a/lib/kamal/secrets/adapters/bitwarden_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/bitwarden_secrets_manager.rb
@@ -57,7 +57,7 @@ class Kamal::Secrets::Adapters::BitwardenSecretsManager < Kamal::Secrets::Adapte
     end
 
     def login(account)
-      run_command("run 'echo OK'")
+      run_command("project list")
       raise RuntimeError, "Could not authenticate to Bitwarden Secrets Manager. Did you set a valid access token?" unless $?.success?
     end
 


### PR DESCRIPTION
I tried to get a secret using the bitwarden-sm adapter and got the following error:

```
$ kamal secrets print
error: unrecognized subcommand 'run'

Usage: bws [OPTIONS] [COMMAND]

For more information, try '--help'.
  ERROR (RuntimeError): Could not authenticate to Bitwarden Secrets Manager. Did you set a valid access token?
```

I don't know at what point, but this seems to be happening because the `run` subcommand was removed from the `bws` command. I solved this problem by using `project list` instead.
