### PR TITLE
Add `ssl_redirect` option

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -14,7 +14,7 @@ class Kamal::Configuration
 
   include Validation
 
-  PROXY_MINIMUM_VERSION = "v0.8.6"
+  PROXY_MINIMUM_VERSION = "v0.8.7"
   PROXY_HTTP_PORT = 80
   PROXY_HTTPS_PORT = 443
   PROXY_LOG_MAX_SIZE = "10m"

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -52,6 +52,13 @@ proxy:
   # Defaults to `false`:
   ssl: true
 
+  # SSL redirect
+  #
+  # By default, kamal-proxy will redirect all HTTP requests to HTTPS when SSL is enabled.
+  # If you prefer that HTTP traffic is passed through to your application (along with
+  # HTTPS traffic), you can disable this redirect by setting `ssl_redirect: false`:
+  ssl_redirect: false
+
   # Forward headers
   #
   # Whether to forward the `X-Forwarded-For` and `X-Forwarded-Proto` headers.

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -42,6 +42,7 @@ class Kamal::Configuration::Proxy
       "max-request-body": proxy_config.dig("buffering", "max_request_body"),
       "max-response-body": proxy_config.dig("buffering", "max_response_body"),
       "forward-headers": proxy_config.dig("forward_headers"),
+      "tls-redirect": proxy_config.dig("ssl_redirect"),
       "log-request-header": proxy_config.dig("logging", "request_headers") || DEFAULT_LOG_REQUEST_HEADERS,
       "log-response-header": proxy_config.dig("logging", "response_headers")
     }.compact


### PR DESCRIPTION
By default, when SSL is enabled, we redirect any HTTP traffic to HTTPS at the proxy.

In cases where an application needs to be able to serve both HTTP and HTTPS traffic (or otherwise handle the decision istelf), a new `ssl_redirect` option provides a way to turn off that automatic redirect. The default behavior is unchanged.

Required proxy version v0.8.7 (which introduced the `--tls-redirect` deploy flag).