### PR TITLE
chore: put github status checks inside block

### DIFF
--- a/lib/kamal/cli/templates/sample_hooks/pre-deploy.sample
+++ b/lib/kamal/cli/templates/sample_hooks/pre-deploy.sample
@@ -82,11 +82,12 @@ end
 
 $stdout.sync = true
 
-puts "Checking build status..."
-attempts = 0
-checks = GithubStatusChecks.new
-
 begin
+  puts "Checking build status..."
+
+  attempts = 0
+  checks = GithubStatusChecks.new
+
   loop do
     case checks.state
     when "success"


### PR DESCRIPTION
Tiny suggestion for the sample hook: check status within the `begin` block as the rescued error can happen immediately (and if I understand correctly, is probably more likely to happen on the first call than only show up later).