### PR TITLE
feat: Add KAMAL_HOST to app and accessory containers

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -13,11 +13,11 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
           directories(name)
           upload(name)
 
-          on(hosts) do
+          on(hosts) do |host|
             execute *KAMAL.auditor.record("Booted #{name} accessory"), verbosity: :debug
             execute *accessory.ensure_env_directory
             upload! accessory.secrets_io, accessory.secrets_path, mode: "0600"
-            execute *accessory.run
+            execute *accessory.run(host: host)
 
             if accessory.running_proxy?
               target = capture_with_info(*accessory.container_id_for(container_name: accessory.service_name, only_running: true)).strip

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -13,11 +13,12 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
     @accessory_config = config.accessory(name)
   end
 
-  def run
+  def run(host: nil)
     docker :run,
       "--name", service_name,
       "--detach",
       "--restart", "unless-stopped",
+      *([ "-e", "KAMAL_HOST=\"#{host}\"" ] if host),
       *network_args,
       *config.logging_args,
       *publish_args,

--- a/lib/kamal/commands/app.rb
+++ b/lib/kamal/commands/app.rb
@@ -22,6 +22,7 @@ class Kamal::Commands::App < Kamal::Commands::Base
       *([ "--hostname", hostname ] if hostname),
       "-e", "KAMAL_CONTAINER_NAME=\"#{container_name}\"",
       "-e", "KAMAL_VERSION=\"#{config.version}\"",
+      "-e", "KAMAL_HOST=\"#{host}\"",
       *role.env_args(host),
       *role.logging_args,
       *config.volume_args,


### PR DESCRIPTION
I searched existing issues and blog posts and didn't see a way to see which host a container was running on.

I'm running Opentelemetry Collector as an accessory on my hosts as a target for OTLP traces, scraper for Prometheus metrics, and using the hostmetrics receiver to grab stats about my VMs in Hetzner. Mainly for the hostmetrics I needed a way to label which VM/host it corresponds to. From what I could see apps get deployed with `<host>-<container identifier>` as their default hostname,  but accessories just got `<container identifier>`. 

I didn't see any other clean ways to set per-host environment variables so this seemed like the simplest solution.

Happy to have any feedback, and if this seems like a viable change I can go back and add some tests for it too. (So far I did manually testing with an accessory using `host`, `hosts`, and `roles`.)


*edit*: Looks like this change does need me to update some of the tests so we can probably skip running the workflow for now.

