### PR TITLE
Enforce JSON output format for aws secrets manager command

### DIFF
--- a/lib/kamal/secrets/adapters/aws_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/aws_secrets_manager.rb
@@ -26,6 +26,7 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
     def get_from_secrets_manager(secrets, account: nil)
       args = [ "aws", "secretsmanager", "batch-get-secret-value", "--secret-id-list" ] + secrets.map(&:shellescape)
       args += [ "--profile", account.shellescape ] if account
+      args += [ "--output", "json" ]
       cmd = args.join(" ")
 
       `#{cmd}`.tap do |secrets|

--- a/test/secrets/aws_secrets_manager_adapter_test.rb
+++ b/test/secrets/aws_secrets_manager_adapter_test.rb
@@ -4,7 +4,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
   test "fails when errors are present" do
     stub_ticks.with("aws --version 2> /dev/null")
     stub_ticks
-      .with("aws secretsmanager batch-get-secret-value --secret-id-list unknown1 unknown2 --profile default")
+      .with("aws secretsmanager batch-get-secret-value --secret-id-list unknown1 unknown2 --profile default --output json")
       .returns(<<~JSON)
         {
           "SecretValues": [],
@@ -33,7 +33,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
   test "fetch" do
     stub_ticks.with("aws --version 2> /dev/null")
     stub_ticks
-      .with("aws secretsmanager batch-get-secret-value --secret-id-list secret/KEY1 secret/KEY2 secret2/KEY3 --profile default")
+      .with("aws secretsmanager batch-get-secret-value --secret-id-list secret/KEY1 secret/KEY2 secret2/KEY3 --profile default --output json")
       .returns(<<~JSON)
         {
           "SecretValues": [
@@ -76,7 +76,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
   test "fetch with string value" do
     stub_ticks.with("aws --version 2> /dev/null")
     stub_ticks
-      .with("aws secretsmanager batch-get-secret-value --secret-id-list secret secret2/KEY1 --profile default")
+      .with("aws secretsmanager batch-get-secret-value --secret-id-list secret secret2/KEY1 --profile default --output json")
       .returns(<<~JSON)
         {
           "SecretValues": [
@@ -118,7 +118,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
   test "fetch with secret names" do
     stub_ticks.with("aws --version 2> /dev/null")
     stub_ticks
-      .with("aws secretsmanager batch-get-secret-value --secret-id-list secret/KEY1 secret/KEY2 --profile default")
+      .with("aws secretsmanager batch-get-secret-value --secret-id-list secret/KEY1 secret/KEY2 --profile default --output json")
       .returns(<<~JSON)
         {
           "SecretValues": [
@@ -159,7 +159,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
   test "fetch without account option omits --profile" do
     stub_ticks.with("aws --version 2> /dev/null")
     stub_ticks
-      .with("aws secretsmanager batch-get-secret-value --secret-id-list secret/KEY1 secret/KEY2")
+      .with("aws secretsmanager batch-get-secret-value --secret-id-list secret/KEY1 secret/KEY2 --output json")
       .returns(<<~JSON)
         {
           "SecretValues": [


### PR DESCRIPTION
Currently, kamal's aws secretsmanager integration expects all output to be in JSON format. Though the default output format is JSON, aws cli can be configured differently depending on developer preference.[^1]

The easiest way to see this failing in a project that uses aws secretsmanager:
```sh
AWS_DEFAULT_OUTPUT=text kamal secrets print
  ERROR (JSON::ParserError): unexpected character: 'SECRETVALUES	arn:aws:secretsmana'
```

This PR enforces the JSON format when running aws secretsmanager commands. Command line option takes precedence over the config file and env variables.[^2]

[^1]: https://docs.aws.amazon.com/cli/v1/userguide/cli-usage-output-format.html
[^2]: https://docs.aws.amazon.com/cli/v1/userguide/cli-configure-envvars.html