### PR TITLE
Use registry:3 image for the integration tests

### DIFF
--- a/test/integration/docker/registry/Dockerfile
+++ b/test/integration/docker/registry/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry
+FROM registry:3
 
 COPY boot.sh .
 

--- a/test/integration/docker/registry/boot.sh
+++ b/test/integration/docker/registry/boot.sh
@@ -2,4 +2,4 @@
 
 while [ ! -f /certs/domain.crt ]; do sleep 1; done
 
-exec /entrypoint.sh /etc/docker/registry/config.yml
+exec /entrypoint.sh /etc/distribution/config.yml


### PR DESCRIPTION
v3 was recently released which broke the integration tests. Update them to use the correct config file.

Set the major version to prevent this from happening when v4 is released.