### PR TITLE
Custom proxy image

### DIFF
--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -1,4 +1,6 @@
 class Kamal::Cli::Proxy < Kamal::Cli::Base
+  delegate :older_version?, to: Kamal::Utils
+
   desc "boot", "Boot proxy on servers"
   def boot
     with_lock do
@@ -13,7 +15,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
 
         version = capture_with_info(*KAMAL.proxy.version).strip.presence
 
-        if version && Kamal::Utils.older_version?(version, Kamal::Configuration::PROXY_MINIMUM_VERSION)
+        if version && version != "next" && older_version?(version, Kamal::Configuration::PROXY_MINIMUM_VERSION)
           raise "kamal-proxy version #{version} is too old, run `kamal proxy reboot` in order to update to at least #{Kamal::Configuration::PROXY_MINIMUM_VERSION}"
         end
         execute *KAMAL.proxy.start_or_run

--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -27,6 +27,9 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
   option :http_port, type: :numeric, default: Kamal::Configuration::PROXY_HTTP_PORT, desc: "HTTP port to publish on the host"
   option :https_port, type: :numeric, default: Kamal::Configuration::PROXY_HTTPS_PORT, desc: "HTTPS port to publish on the host"
   option :log_max_size, type: :string, default: Kamal::Configuration::PROXY_LOG_MAX_SIZE, desc: "Max size of proxy logs"
+  option :registry, type: :string, default: nil, desc: "Registry to use for the proxy image"
+  option :repository, type: :string, default: nil, desc: "Repository for the proxy image"
+  option :image_version, type: :string, default: nil, desc: "Version of the proxy to run"
   option :docker_options, type: :array, default: [], desc: "Docker options to pass to the proxy container", banner: "option=value option2=value2"
   def boot_config(subcommand)
     case subcommand
@@ -37,17 +40,43 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
         *options[:docker_options].map { |option| "--#{option}" }
       ]
 
+      default_boot_options = [
+        *(KAMAL.config.proxy_publish_args(Kamal::Configuration::PROXY_HTTP_PORT, Kamal::Configuration::PROXY_HTTPS_PORT, nil)),
+        *(KAMAL.config.proxy_logging_args(Kamal::Configuration::PROXY_LOG_MAX_SIZE)),
+      ]
+
+      image = [ options[:registry].presence, options[:repository] || KAMAL.config.proxy_repository_name, KAMAL.config.proxy_image_name ].compact.join("/")
+      image_version = options[:image_version]
+
       on(KAMAL.proxy_hosts) do |host|
         execute(*KAMAL.proxy.ensure_proxy_directory)
-        upload! StringIO.new(boot_options.join(" ")), KAMAL.config.proxy_options_file
+        if boot_options != default_boot_options
+          upload! StringIO.new(boot_options.join(" ")), KAMAL.config.proxy_options_file
+        else
+          execute *KAMAL.proxy.reset_boot_options, raise_on_non_zero_exit: false
+        end
+
+        if image != KAMAL.config.proxy_image_default
+          upload! StringIO.new(image), KAMAL.config.proxy_image_file
+        else
+          execute *KAMAL.proxy.reset_image, raise_on_non_zero_exit: false
+        end
+
+        if image_version
+          upload! StringIO.new(image_version), KAMAL.config.proxy_image_version_file
+        else
+          execute *KAMAL.proxy.reset_image_version, raise_on_non_zero_exit: false
+        end
       end
     when "get"
       on(KAMAL.proxy_hosts) do |host|
-        puts "Host #{host}: #{capture_with_info(*KAMAL.proxy.get_boot_options)}"
+        puts "Host #{host}: #{capture_with_info(*KAMAL.proxy.boot_config)}"
       end
     when "reset"
       on(KAMAL.proxy_hosts) do |host|
-        execute *KAMAL.proxy.reset_boot_options
+        execute *KAMAL.proxy.reset_boot_options, raise_on_non_zero_exit: false
+        execute *KAMAL.proxy.reset_image, raise_on_non_zero_exit: false
+        execute *KAMAL.proxy.reset_image_version, raise_on_non_zero_exit: false
       end
     else
       raise ArgumentError, "Unknown boot_config subcommand #{subcommand}"

--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -68,6 +68,10 @@ module Kamal::Commands
         combine *commands, by: "||"
       end
 
+      def substitute(*commands)
+        "\$\(#{commands.join(" ")}\)"
+      end
+
       def xargs(command)
         [ :xargs, command ].flatten
       end

--- a/lib/kamal/commands/proxy.rb
+++ b/lib/kamal/commands/proxy.rb
@@ -2,14 +2,7 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
   delegate :argumentize, :optionize, to: Kamal::Utils
 
   def run
-    pipe \
-      [ :echo, "\$\(#{get_boot_options.join(" ")}\) #{config.proxy_image}" ],
-      xargs(docker(:run,
-        "--name", container_name,
-        "--network", "kamal",
-        "--detach",
-        "--restart", "unless-stopped",
-        "--volume", "kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy"))
+    pipe echo_boot_config, xargs(docker_run)
   end
 
   def start
@@ -83,5 +76,19 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
   private
     def container_name
       config.proxy_container_name
+    end
+
+    def echo_boot_config
+      [ :echo, "\$\(#{get_boot_options.join(" ")}\) #{config.proxy_image}" ]
+    end
+
+    def docker_run
+      docker \
+        :run,
+        "--name", container_name,
+        "--network", "kamal",
+        "--detach",
+        "--restart", "unless-stopped",
+        "--volume", "kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy"
     end
 end

--- a/lib/kamal/commands/proxy.rb
+++ b/lib/kamal/commands/proxy.rb
@@ -2,7 +2,7 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
   delegate :argumentize, :optionize, to: Kamal::Utils
 
   def run
-    pipe echo_boot_config, xargs(docker_run)
+    pipe boot_config, xargs(docker_run)
   end
 
   def start
@@ -24,7 +24,7 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
   def version
     pipe \
       docker(:inspect, container_name, "--format '{{.Config.Image}}'"),
-      [ :cut, "-d:", "-f2" ]
+      [ :awk, "-F:", "'{print \$NF}'" ]
   end
 
   def logs(timestamps: true, since: nil, lines: nil, grep: nil, grep_options: nil)
@@ -65,12 +65,32 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
     remove_directory config.proxy_directory
   end
 
-  def get_boot_options
-    combine [ :cat, config.proxy_options_file, "2>", "/dev/null" ], [ :echo, "\"#{config.proxy_options_default.join(" ")}\"" ], by: "||"
+  def boot_config
+    [ :echo, "#{substitute(read_boot_options)} #{substitute(read_image)}:#{substitute(read_image_version)}" ]
+  end
+
+  def read_boot_options
+    read_file(config.proxy_options_file, default: config.proxy_options_default.join(" "))
+  end
+
+  def read_image
+    read_file(config.proxy_image_file, default: config.proxy_image_default)
+  end
+
+  def read_image_version
+    read_file(config.proxy_image_version_file, default: Kamal::Configuration::PROXY_MINIMUM_VERSION)
   end
 
   def reset_boot_options
     remove_file config.proxy_options_file
+  end
+
+  def reset_image
+    remove_file config.proxy_image_file
+  end
+
+  def reset_image_version
+    remove_file config.proxy_image_version_file
   end
 
   private
@@ -78,8 +98,8 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
       config.proxy_container_name
     end
 
-    def echo_boot_config
-      [ :echo, "\$\(#{get_boot_options.join(" ")}\) #{config.proxy_image}" ]
+    def read_file(file, default: nil)
+      combine [ :cat, file, "2>", "/dev/null" ], [ :echo, "\"#{default}\"" ], by: "||"
     end
 
     def docker_run

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -261,8 +261,16 @@ class Kamal::Configuration
     [ *proxy_publish_args(PROXY_HTTP_PORT, PROXY_HTTPS_PORT), *proxy_logging_args(PROXY_LOG_MAX_SIZE) ]
   end
 
-  def proxy_image
-    "basecamp/kamal-proxy:#{PROXY_MINIMUM_VERSION}"
+  def proxy_repository_name
+    "basecamp"
+  end
+
+  def proxy_image_name
+    "kamal-proxy"
+  end
+
+  def proxy_image_default
+    "#{proxy_repository_name}/#{proxy_image_name}"
   end
 
   def proxy_container_name
@@ -275,6 +283,14 @@ class Kamal::Configuration
 
   def proxy_options_file
     File.join proxy_directory, "options"
+  end
+
+  def proxy_image_file
+    File.join proxy_directory, "image"
+  end
+
+  def proxy_image_version_file
+    File.join proxy_directory, "image_version"
   end
 
   def to_h

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -321,7 +321,7 @@ class CliBuildTest < CliTestCase
 
   private
     def run_command(*command, fixture: :with_accessories)
-      stdouted { Kamal::Cli::Build.start([ *command, "-c", "test/fixtures/deploy_#{fixture}.yml" ]) }
+      stdouted { stderred { Kamal::Cli::Build.start([ *command, "-c", "test/fixtures/deploy_#{fixture}.yml" ]) } }
     end
 
     def stub_dependency_checks

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -15,7 +15,7 @@ class CommandsProxyTest < ActiveSupport::TestCase
 
   test "run" do
     assert_equal \
-      "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") basecamp/kamal-proxy:#{Kamal::Configuration::PROXY_MINIMUM_VERSION} | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy",
+      "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::PROXY_MINIMUM_VERSION}\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy",
       new_command.run.join(" ")
   end
 
@@ -23,7 +23,7 @@ class CommandsProxyTest < ActiveSupport::TestCase
     @config.delete(:proxy)
 
     assert_equal \
-      "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") basecamp/kamal-proxy:#{Kamal::Configuration::PROXY_MINIMUM_VERSION} | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy",
+      "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::PROXY_MINIMUM_VERSION}\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy",
       new_command.run.join(" ")
   end
 
@@ -101,7 +101,7 @@ class CommandsProxyTest < ActiveSupport::TestCase
 
   test "version" do
     assert_equal \
-      "docker inspect kamal-proxy --format '{{.Config.Image}}' | cut -d: -f2",
+      "docker inspect kamal-proxy --format '{{.Config.Image}}' | awk -F: '{print $NF}'",
       new_command.version.join(" ")
   end
 
@@ -111,16 +111,40 @@ class CommandsProxyTest < ActiveSupport::TestCase
       new_command.ensure_proxy_directory.join(" ")
   end
 
-  test "get_boot_options" do
+  test "read_boot_options" do
     assert_equal \
       "cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\"",
-      new_command.get_boot_options.join(" ")
+      new_command.read_boot_options.join(" ")
+  end
+
+  test "read_image" do
+    assert_equal \
+      "cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"",
+      new_command.read_image.join(" ")
+  end
+
+  test "read_image_version" do
+    assert_equal \
+      "cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::PROXY_MINIMUM_VERSION}\"",
+      new_command.read_image_version.join(" ")
   end
 
   test "reset_boot_options" do
     assert_equal \
       "rm .kamal/proxy/options",
       new_command.reset_boot_options.join(" ")
+  end
+
+  test "reset_image" do
+    assert_equal \
+      "rm .kamal/proxy/image",
+      new_command.reset_image.join(" ")
+  end
+
+  test "reset_image_version" do
+    assert_equal \
+      "rm .kamal/proxy/image_version",
+      new_command.reset_image_version.join(" ")
   end
 
   private

--- a/test/integration/docker/deployer/app/.kamal/hooks/pre-deploy
+++ b/test/integration/docker/deployer/app/.kamal/hooks/pre-deploy
@@ -1,3 +1,6 @@
 #!/bin/sh
+set -e
+
+kamal proxy boot_config set --registry registry:4443
 echo "Deployed!"
 mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/pre-deploy

--- a/test/integration/docker/deployer/app_with_proxied_accessory/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_proxied_accessory/config/deploy.yml
@@ -41,4 +41,4 @@ accessories:
         interval: 1
         timeout: 1
         path: "/"
-
+drain_timeout: 2

--- a/test/integration/docker/deployer/app_with_roles/.kamal/hooks/pre-deploy
+++ b/test/integration/docker/deployer/app_with_roles/.kamal/hooks/pre-deploy
@@ -1,3 +1,6 @@
 #!/bin/sh
+set -e
+
+kamal proxy boot_config set --registry registry:4443
 echo "Deployed!"
 mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/pre-deploy

--- a/test/integration/docker/deployer/app_with_traefik/.kamal/hooks/pre-deploy
+++ b/test/integration/docker/deployer/app_with_traefik/.kamal/hooks/pre-deploy
@@ -1,4 +1,7 @@
-kamal proxy boot_config set --publish false \
+set -e
+
+kamal proxy boot_config set --registry registry:4443 \
+                            --publish false \
                             --docker_options label=traefik.http.services.kamal_proxy.loadbalancer.server.scheme=http \
                                              label=traefik.http.routers.kamal_proxy.rule=PathPrefix\(\`/\`\) \
                                              sysctl=net.ipv4.ip_local_port_range=\"10000\ 60999\"

--- a/test/integration/docker/deployer/setup.sh
+++ b/test/integration/docker/deployer/setup.sh
@@ -20,6 +20,7 @@ push_image_to_registry_4443() {
 install_kamal
 push_image_to_registry_4443 nginx 1-alpine-slim
 push_image_to_registry_4443 busybox 1.36.0
+push_image_to_registry_4443 basecamp/kamal-proxy v0.8.7
 
 # .ssh is on a shared volume that persists between runs. Clean it up as the
 # churn of temporary vm IPs can eventually create conflicts.

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -12,11 +12,11 @@ class IntegrationTest < ActiveSupport::TestCase
 
   teardown do
     unless passed?
-      [ :deployer, :vm1, :vm2, :shared, :load_balancer, :registry ].each do |container|
-        puts
-        puts "Logs for #{container}:"
-        docker_compose :logs, container
-      end
+      # [ :deployer, :vm1, :vm2, :shared, :load_balancer, :registry ].each do |container|
+      #   puts
+      #   puts "Logs for #{container}:"
+      #   docker_compose :logs, container
+      # end
     end
     docker_compose "down -t 1"
   end

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -11,12 +11,12 @@ class IntegrationTest < ActiveSupport::TestCase
   end
 
   teardown do
-    unless passed?
-      # [ :deployer, :vm1, :vm2, :shared, :load_balancer, :registry ].each do |container|
-      #   puts
-      #   puts "Logs for #{container}:"
-      #   docker_compose :logs, container
-      # end
+    if !passed? && ENV["DEBUG"]
+      [ :deployer, :vm1, :vm2, :shared, :load_balancer, :registry ].each do |container|
+        puts
+        puts "Logs for #{container}:"
+        docker_compose :logs, container
+      end
     end
     docker_compose "down -t 1"
   end
@@ -25,8 +25,8 @@ class IntegrationTest < ActiveSupport::TestCase
     def docker_compose(*commands, capture: false, raise_on_error: true)
       command = "TEST_ID=#{ENV["TEST_ID"]} docker compose #{commands.join(" ")}"
       succeeded = false
-      if capture
-        result = stdouted { succeeded = system("cd test/integration && #{command}") }
+      if capture || !ENV["DEBUG"]
+        result = stdouted { stderred { succeeded = system("cd test/integration && #{command}") } }
       else
         succeeded = system("cd test/integration && #{command}")
       end

--- a/test/integration/proxy_test.rb
+++ b/test/integration/proxy_test.rb
@@ -6,6 +6,8 @@ class ProxyTest < IntegrationTest
   end
 
   test "boot, reboot, stop, start, restart, logs, remove" do
+    kamal :proxy, :boot_config, :set, "--registry", "registry:4443"
+
     kamal :proxy, :boot
     assert_proxy_running
 
@@ -46,7 +48,7 @@ class ProxyTest < IntegrationTest
     logs = kamal :proxy, :logs, capture: true
     assert_match /No previous state to restore/, logs
 
-    kamal :proxy, :boot_config, :set, "--docker-options='sysctl net.ipv4.ip_local_port_range=\"10000 60999\"'"
+    kamal :proxy, :boot_config, :set, "--registry", "registry:4443", "--docker-options='sysctl net.ipv4.ip_local_port_range=\"10000 60999\"'"
     assert_docker_options_in_file
 
     kamal :proxy, :reboot, "-y"


### PR DESCRIPTION
Add `--registry`, `--repository` and `--image_version` options to `kamal proxy boot_config set` to change the kamal-proxy image used.

We'll still insist that the image version is at least as high as the minimum except for the special case tag `next`.