### PR TITLE
Docker login if exec might pull image

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -152,6 +152,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
       when options[:interactive]
         say "Launching interactive command via SSH from new container...", :magenta
+        on(accessory.hosts.first) { execute *KAMAL.registry.login }
         run_locally { exec accessory.execute_in_new_container_over_ssh(cmd) }
 
       when options[:reuse]
@@ -164,6 +165,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
       else
         say "Launching command from new container...", :magenta
         on(hosts) do |host|
+          execute *KAMAL.registry.login
           execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{name} accessory"), verbosity: :debug
           puts_by_host host, capture_with_info(*accessory.execute_in_new_container(cmd))
         end

--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -127,6 +127,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
       say "Get most recent version available as an image...", :magenta unless options[:version]
       using_version(version_or_latest) do |version|
         say "Launching interactive command with version #{version} via SSH from new container on #{KAMAL.primary_host}...", :magenta
+        on(KAMAL.primary_host) { execute *KAMAL.registry.login }
         run_locally do
           exec KAMAL.app(role: KAMAL.primary_role, host: KAMAL.primary_host).execute_in_new_container_over_ssh(cmd, env: env)
         end
@@ -152,6 +153,8 @@ class Kamal::Cli::App < Kamal::Cli::Base
       using_version(version_or_latest) do |version|
         say "Launching command with version #{version} from new container...", :magenta
         on(KAMAL.app_hosts) do |host|
+          execute *KAMAL.registry.login
+
           roles = KAMAL.roles_on(host)
 
           roles.each do |role|

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -115,6 +115,7 @@ class CliAccessoryTest < CliTestCase
 
   test "exec" do
     run_command("exec", "mysql", "mysql -v").tap do |output|
+      assert_match "docker login private.registry -u [REDACTED] -p [REDACTED]", output
       assert_match "Launching command from new container", output
       assert_match "mysql -v", output
     end

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -307,6 +307,7 @@ class CliAppTest < CliTestCase
 
   test "exec" do
     run_command("exec", "ruby -v").tap do |output|
+      assert_match "docker login -u [REDACTED] -p [REDACTED]", output
       assert_match "docker run --rm --network kamal --env-file .kamal/apps/app/env/roles/web.env --log-opt max-size=\"10m\" dhh/app:latest ruby -v", output
     end
   end
@@ -355,6 +356,7 @@ class CliAppTest < CliTestCase
 
     run_command("exec", "-i", "ruby -v").tap do |output|
       assert_hook_ran "pre-connect", output
+      assert_match "docker login -u [REDACTED] -p [REDACTED]", output
       assert_match "Get most recent version available as an image...", output
       assert_match "Launching interactive command with version latest via SSH from new container on 1.1.1.1...", output
     end


### PR DESCRIPTION
The `app exec` and `accessory exec` commands will run `docker run` if they are not set to reuse existing containers. This might need to pull an image so let's make sure we are logged in before running the command.

Fixes: https://github.com/basecamp/kamal/issues/1163