### PR TITLE
Inherit locks

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -133,7 +133,13 @@ module Kamal::Cli
 
       def run_hook(hook, **extra_details)
         if !options[:skip_hooks] && KAMAL.hook.hook_exists?(hook)
-          details = { hosts: KAMAL.hosts.join(","), roles: KAMAL.specific_roles&.join(","), command: command, subcommand: subcommand }.compact
+          details = {
+            hosts: KAMAL.hosts.join(","),
+            roles: KAMAL.specific_roles&.join(","),
+            lock: KAMAL.holding_lock?.to_s,
+            command: command,
+            subcommand: subcommand
+          }.compact
 
           say "Running the #{hook} hook...", :magenta
           with_env KAMAL.hook.env(**details, **extra_details) do

--- a/lib/kamal/commander.rb
+++ b/lib/kamal/commander.rb
@@ -13,7 +13,7 @@ class Kamal::Commander
 
   def reset
     self.verbosity = :info
-    self.holding_lock = false
+    self.holding_lock = ENV["KAMAL_LOCK"] == "true"
     self.connected = false
     @specifics = @specific_roles = @specific_hosts = nil
     @config = @config_kwargs = nil


### PR DESCRIPTION
We'll set the KAMAL_LOCK environment when calling run hooks. If set to true we have the lock and the hook will not need to acquire it again if it runs kamal commands.

Fixes: https://github.com/basecamp/kamal/issues/1517