### PR TITLE
Add support for custom certificates

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -12,6 +12,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
           KAMAL.roles_on(host).each do |role|
             Kamal::Cli::App::Assets.new(host, role, self).run
+            Kamal::Cli::App::SslCertificates.new(host, role, self).run
           end
         end
 

--- a/lib/kamal/cli/app/ssl_certificates.rb
+++ b/lib/kamal/cli/app/ssl_certificates.rb
@@ -1,0 +1,29 @@
+class Kamal::Cli::App::SslCertificates
+  attr_reader :host, :role, :sshkit
+  delegate :execute, :info, to: :sshkit
+
+  def initialize(host, role, sshkit)
+    @host = host
+    @role = role
+    @sshkit = sshkit
+  end
+
+  def run
+    if role.running_proxy? && role.proxy.custom_ssl_certificate?
+      info "Writing SSL certificates for #{role.name} on #{host}"
+      execute *app.create_ssl_directory
+      if cert_content = role.proxy.certificate_pem_content
+        execute *app.write_certificate_file(cert_content)
+      end
+      if key_content = role.proxy.private_key_pem_content
+        execute *app.write_private_key_file(key_content)
+      end
+      execute *app.set_certificate_permissions
+    end
+  end
+
+  private
+    def app
+      @app ||= KAMAL.app(role: role, host: host)
+    end
+end

--- a/lib/kamal/commands/app/proxy.rb
+++ b/lib/kamal/commands/app/proxy.rb
@@ -21,6 +21,22 @@ module Kamal::Commands::App::Proxy
     remove_directory config.proxy_boot.app_directory
   end
 
+  def create_ssl_directory
+    make_directory(config.proxy_boot.tls_directory)
+  end
+
+  def write_certificate_file(content)
+    [ :sh, "-c", Kamal::Utils.sensitive("cat > #{config.proxy_boot.tls_directory}/cert.pem << 'KAMAL_CERT_EOF'\n#{content}\nKAMAL_CERT_EOF", redaction: "cat > #{config.proxy_boot.tls_directory}/cert.pem << 'KAMAL_CERT_EOF'\n[CERTIFICATE CONTENT REDACTED]\nKAMAL_CERT_EOF") ]
+  end
+
+  def write_private_key_file(content)
+    [ :sh, "-c", Kamal::Utils.sensitive("cat > #{config.proxy_boot.tls_directory}/key.pem << 'KAMAL_KEY_EOF'\n#{content}\nKAMAL_KEY_EOF", redaction: "cat > #{config.proxy_boot.tls_directory}/key.pem << 'KAMAL_KEY_EOF'\n[PRIVATE KEY CONTENT REDACTED]\nKAMAL_KEY_EOF") ]
+  end
+
+  def set_certificate_permissions
+    [ :docker, :exec, "--user", "root", proxy_container_name, "chown", "-R", "kamal-proxy:kamal-proxy", config.proxy_boot.tls_container_directory ]
+  end
+
   private
     def proxy_exec(*command)
       docker :exec, proxy_container_name, "kamal-proxy", *command

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -63,7 +63,7 @@ class Kamal::Configuration
     @env = Env.new(config: @raw_config.env || {}, secrets: secrets)
 
     @logging = Logging.new(logging_config: @raw_config.logging)
-    @proxy = Proxy.new(config: self, proxy_config: @raw_config.key?(:proxy) ? @raw_config.proxy : {})
+    @proxy = Proxy.new(config: self, proxy_config: @raw_config.key?(:proxy) ? @raw_config.proxy : {}, secrets: secrets)
     @proxy_boot = Proxy::Boot.new(config: self)
     @ssh = Ssh.new(config: self)
     @sshkit = Sshkit.new(config: self)

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -125,7 +125,8 @@ class Kamal::Configuration::Accessory
       Kamal::Configuration::Proxy.new \
         config: config,
         proxy_config: accessory_config["proxy"],
-        context: "accessories/#{name}/proxy"
+        context: "accessories/#{name}/proxy",
+        secrets: config.secrets
     end
 
     def initialize_registry

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -16,7 +16,6 @@
 # It is disabled by default on all other roles but can be enabled by setting
 # `proxy: true` or providing a proxy configuration.
 proxy:
-
   # Hosts
   #
   # The hosts that will be used to serve the app. The proxy will only route requests
@@ -51,6 +50,17 @@ proxy:
   #
   # Defaults to `false`:
   ssl: true
+
+  # Custom SSL certificate
+  #
+  # In scenarios where Let's Encrypt is not an option, or you already have your own
+  # certificates from a different Certificate Authority, you can configure kamal-proxy
+  # to load the certificate and the corresponding private key from disk.
+  #
+  # A reference to a secret (in this case, `CERTIFICATE_PEM` and `PRIVATE_KEY_PEM`) will look up the secret
+  # in the local environment:
+  certificate_pem: CERTIFICATE_PEM
+  private_key_pem: PRIVATE_KEY_PEM
 
   # SSL redirect
   #

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -53,12 +53,10 @@ proxy:
 
   # Custom SSL certificate
   #
-  # In scenarios where Let's Encrypt is not an option, or you already have your own
-  # certificates from a different Certificate Authority, you can configure kamal-proxy
-  # to load the certificate and the corresponding private key from disk.
-  #
-  # A reference to a secret (in this case, `CERTIFICATE_PEM` and `PRIVATE_KEY_PEM`) will look up the secret
-  # in the local environment:
+  # In some cases, using Let's Encrypt for automatic certificate management is not an 
+  # option, or you may already have SSL certificates issued by a different 
+  # Certificate Authority (CA). Kamal supports loading custom SSL certificates 
+  # directly from secrets.
   #
   # Examples:
   #   ssl: true              # Enable SSL with Let's Encrypt

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -49,7 +49,7 @@ proxy:
   # unless you explicitly set `forward_headers: true`
   #
   # Defaults to `false`:
-  ssl: true
+  ssl: ...
 
   # Custom SSL certificate
   #
@@ -59,8 +59,13 @@ proxy:
   #
   # A reference to a secret (in this case, `CERTIFICATE_PEM` and `PRIVATE_KEY_PEM`) will look up the secret
   # in the local environment:
-  certificate_pem: CERTIFICATE_PEM
-  private_key_pem: PRIVATE_KEY_PEM
+  #
+  # Examples:
+  #   ssl: true              # Enable SSL with Let's Encrypt
+  #   ssl: false             # Disable SSL
+  #   ssl:                   # Enable custom SSL
+  #     certificate_pem: CERTIFICATE_PEM
+  #     private_key_pem: PRIVATE_KEY_PEM
 
   # SSL redirect
   #

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -28,15 +28,21 @@ class Kamal::Configuration::Proxy
   end
 
   def custom_ssl_certificate?
-    proxy_config["certificate_pem"].present? && proxy_config["private_key_pem"].present?
+    ssl = proxy_config["ssl"]
+    return false unless ssl.is_a?(Hash)
+    ssl["certificate_pem"].present? && ssl["private_key_pem"].present?
   end
 
   def certificate_pem_content
-    secrets[proxy_config["certificate_pem"]]
+    ssl = proxy_config["ssl"]
+    return nil unless ssl.is_a?(Hash)
+    secrets[ssl["certificate_pem"]]
   end
 
   def private_key_pem_content
-    secrets[proxy_config["private_key_pem"]]
+    ssl = proxy_config["ssl"]
+    return nil unless ssl.is_a?(Hash)
+    secrets[ssl["private_key_pem"]]
   end
 
   def certificate_pem
@@ -54,7 +60,7 @@ class Kamal::Configuration::Proxy
   def deploy_options
     {
       host: hosts,
-      tls: proxy_config["ssl"].presence,
+      tls: ssl? ? true : nil,
       "tls-certificate-path": certificate_pem,
       "tls-private-key-path": private_key_pem,
       "deploy-timeout": seconds_duration(config.deploy_timeout),

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -6,11 +6,12 @@ class Kamal::Configuration::Proxy
 
   delegate :argumentize, :optionize, to: Kamal::Utils
 
-  attr_reader :config, :proxy_config
+  attr_reader :config, :proxy_config, :secrets
 
-  def initialize(config:, proxy_config:, context: "proxy")
+  def initialize(config:, proxy_config:, secrets:, context: "proxy")
     @config = config
     @proxy_config = proxy_config
+    @secrets = secrets
     validate! @proxy_config, with: Kamal::Configuration::Validator::Proxy, context: context
   end
 
@@ -26,10 +27,36 @@ class Kamal::Configuration::Proxy
     proxy_config["hosts"] || proxy_config["host"]&.split(",") || []
   end
 
+  def custom_ssl_certificate?
+    proxy_config["certificate_pem"].present? && proxy_config["private_key_pem"].present?
+  end
+
+  def certificate_pem_content
+    secrets[proxy_config["certificate_pem"]]
+  end
+
+  def private_key_pem_content
+    secrets[proxy_config["private_key_pem"]]
+  end
+
+  def certificate_pem
+    tls_file_path("cert.pem")
+  end
+
+  def private_key_pem
+    tls_file_path("key.pem")
+  end
+
+  def tls_file_path(filename)
+    File.join(config.proxy_boot.tls_container_directory, filename) if custom_ssl_certificate?
+  end
+
   def deploy_options
     {
       host: hosts,
       tls: proxy_config["ssl"].presence,
+      "tls-certificate-path": certificate_pem,
+      "tls-private-key-path": private_key_pem,
       "deploy-timeout": seconds_duration(config.deploy_timeout),
       "drain-timeout": seconds_duration(config.drain_timeout),
       "health-check-interval": seconds_duration(proxy_config.dig("healthcheck", "interval")),
@@ -65,7 +92,7 @@ class Kamal::Configuration::Proxy
   end
 
   def merge(other)
-    self.class.new config: config, proxy_config: proxy_config.deep_merge(other.proxy_config)
+    self.class.new config: config, proxy_config: proxy_config.deep_merge(other.proxy_config), secrets: secrets
   end
 
   private

--- a/lib/kamal/configuration/proxy/boot.rb
+++ b/lib/kamal/configuration/proxy/boot.rb
@@ -96,6 +96,14 @@ class Kamal::Configuration::Proxy::Boot
     File.join app_container_directory, "error_pages"
   end
 
+  def tls_directory
+    File.join app_directory, "tls"
+  end
+
+  def tls_container_directory
+    File.join app_container_directory, "tls"
+  end
+
   private
     def ensure_valid_bind_ips(bind_ips)
       bind_ips.present? && bind_ips.each do |ip|

--- a/lib/kamal/configuration/role.rb
+++ b/lib/kamal/configuration/role.rb
@@ -150,8 +150,8 @@ class Kamal::Configuration::Role
   end
 
   def ensure_one_host_for_ssl
-    if running_proxy? && proxy.ssl? && hosts.size > 1
-      raise Kamal::ConfigurationError, "SSL is only supported on a single server, found #{hosts.size} servers for role #{name}"
+    if running_proxy? && proxy.ssl? && hosts.size > 1 && !proxy.custom_ssl_certificate?
+      raise Kamal::ConfigurationError, "SSL is only supported on a single server unless you provide custom certificates, found #{hosts.size} servers for role #{name}"
     end
   end
 
@@ -173,6 +173,7 @@ class Kamal::Configuration::Role
         @specialized_proxy = Kamal::Configuration::Proxy.new \
           config: config,
           proxy_config: proxy_config,
+          secrets: config.secrets,
           context: "servers/#{name}/proxy"
       end
     end

--- a/lib/kamal/configuration/validator.rb
+++ b/lib/kamal/configuration/validator.rb
@@ -24,7 +24,9 @@ class Kamal::Configuration::Validator
             example_value = example[key]
 
             if example_value == "..."
-              unless key.to_s == "proxy" && boolean?(value.class)
+              if key.to_s == "ssl"
+                validate_type! value, TrueClass, FalseClass, Hash
+              elsif key.to_s != "proxy" || !boolean?(value.class)
                 validate_type! value, *(Array if key == :servers), Hash
               end
             elsif key == "hosts"

--- a/lib/kamal/configuration/validator/proxy.rb
+++ b/lib/kamal/configuration/validator/proxy.rb
@@ -10,6 +10,14 @@ class Kamal::Configuration::Validator::Proxy < Kamal::Configuration::Validator
       if (config.keys & [ "host", "hosts" ]).size > 1
         error "Specify one of 'host' or 'hosts', not both"
       end
+
+      if config["certificate_pem"].present? && config["private_key_pem"].blank?
+        error "Missing private_key_pem setting (required when certificate_pem is present)"
+      end
+
+      if config["private_key_pem"].present? && config["certificate_pem"].blank?
+        error "Missing certificate_pem setting (required when private_key_pem is present)"
+      end
     end
   end
 end

--- a/lib/kamal/configuration/validator/proxy.rb
+++ b/lib/kamal/configuration/validator/proxy.rb
@@ -11,12 +11,14 @@ class Kamal::Configuration::Validator::Proxy < Kamal::Configuration::Validator
         error "Specify one of 'host' or 'hosts', not both"
       end
 
-      if config["certificate_pem"].present? && config["private_key_pem"].blank?
-        error "Missing private_key_pem setting (required when certificate_pem is present)"
-      end
+      if config["ssl"].is_a?(Hash)
+        if config["ssl"]["certificate_pem"].present? && config["ssl"]["private_key_pem"].blank?
+          error "Missing private_key_pem setting (required when certificate_pem is present)"
+        end
 
-      if config["private_key_pem"].present? && config["certificate_pem"].blank?
-        error "Missing certificate_pem setting (required when private_key_pem is present)"
+        if config["ssl"]["private_key_pem"].present? && config["ssl"]["certificate_pem"].blank?
+          error "Missing certificate_pem setting (required when private_key_pem is present)"
+        end
       end
     end
   end

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -143,13 +143,17 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command.deploy(target: "172.1.0.2").join(" ")
   end
 
+  test "set certificate permissions" do
+    assert_equal \
+      "docker exec --user root kamal-proxy chown -R kamal-proxy:kamal-proxy /home/kamal-proxy/.apps-config/app/tls",
+      new_command.set_certificate_permissions.join(" ")
+  end
+
   test "remove" do
     assert_equal \
       "docker exec kamal-proxy kamal-proxy remove app-web",
       new_command.remove.join(" ")
   end
-
-
 
   test "logs" do
     assert_equal \

--- a/test/configuration/proxy/boot_test.rb
+++ b/test/configuration/proxy/boot_test.rb
@@ -25,5 +25,7 @@ class ConfigurationProxyBootTest < ActiveSupport::TestCase
     assert_equal "/home/kamal-proxy/.apps-config/app", @proxy_boot_config.app_container_directory
     assert_equal ".kamal/proxy/apps-config/app/error_pages", @proxy_boot_config.error_pages_directory
     assert_equal "/home/kamal-proxy/.apps-config/app/error_pages", @proxy_boot_config.error_pages_container_directory
+    assert_equal ".kamal/proxy/apps-config/app/tls", @proxy_boot_config.tls_directory
+    assert_equal "/home/kamal-proxy/.apps-config/app/tls", @proxy_boot_config.tls_container_directory
   end
 end

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -48,10 +48,11 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
   test "ssl with certificate and private key from secrets" do
     with_test_secrets("secrets" => "CERT_PEM=certificate\nKEY_PEM=private_key") do
       @deploy[:proxy] = {
-        "ssl" => true,
-        "host" => "example.com",
-        "certificate_pem" => "CERT_PEM",
-        "private_key_pem" => "KEY_PEM"
+        "ssl" => {
+          "certificate_pem" => "CERT_PEM",
+          "private_key_pem" => "KEY_PEM"
+        },
+        "host" => "example.com"
       }
 
       proxy = config.proxy
@@ -60,12 +61,31 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
     end
   end
 
+  test "deploy options with custom ssl certificates" do
+    with_test_secrets("secrets" => "CERT_PEM=certificate\nKEY_PEM=private_key") do
+      @deploy[:proxy] = {
+        "ssl" => {
+          "certificate_pem" => "CERT_PEM",
+          "private_key_pem" => "KEY_PEM"
+        },
+        "host" => "example.com"
+      }
+
+      proxy = config.proxy
+      options = proxy.deploy_options
+      assert_equal true, options[:tls]
+      assert_equal "/home/kamal-proxy/.apps-config/app/tls/cert.pem", options[:"tls-certificate-path"]
+      assert_equal "/home/kamal-proxy/.apps-config/app/tls/key.pem", options[:"tls-private-key-path"]
+    end
+  end
+
   test "ssl with certificate and no private key" do
     with_test_secrets("secrets" => "CERT_PEM=certificate") do
       @deploy[:proxy] = {
-        "ssl" => true,
-        "host" => "example.com",
-        "certificate_pem" => "CERT_PEM"
+        "ssl" => {
+          "certificate_pem" => "CERT_PEM"
+        },
+        "host" => "example.com"
       }
       assert_raises(Kamal::ConfigurationError) { config.proxy.ssl? }
     end
@@ -74,9 +94,10 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
   test "ssl with private key and no certificate" do
     with_test_secrets("secrets" => "KEY_PEM=private_key") do
       @deploy[:proxy] = {
-        "ssl" => true,
-        "host" => "example.com",
-        "private_key_pem" => "KEY_PEM"
+        "ssl" => {
+          "private_key_pem" => "KEY_PEM"
+        },
+        "host" => "example.com"
       }
       assert_raises(Kamal::ConfigurationError) { config.proxy.ssl? }
     end

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -386,7 +386,7 @@ class ConfigurationTest < ActiveSupport::TestCase
       Kamal::Configuration.new(@deploy_with_roles)
     end
 
-    assert_equal "SSL is only supported on a single server, found 2 servers for role workers", exception.message
+    assert_equal "SSL is only supported on a single server unless you provide custom certificates, found 2 servers for role workers", exception.message
   end
 
   test "two proxy ssl roles with same host" do


### PR DESCRIPTION
This PR adds support for custom SSL certificates in the proxy configuration, building upon the foundation laid by @kpumuk in PR #969. Users can now securely provide their own SSL certificates and private keys through secrets using the following configuration format:

```yaml
proxy:
  ssl:
    certificate_pem: CERTIFICATE_PEM
    private_key_pem: PRIVATE_KEY_PEM
```

### Background
This enhancement addresses scenarios where Let's Encrypt automated certificate management isn't feasible or when users already possess SSL certificates from other Certificate Authorities. The implementation maintains compatibility with existing SSL options:

 - Enable SSL with Let's Encrypt (unchanged)
```yaml
proxy:
  ssl: true
```

- Disable SSL (unchanged)
```yaml
proxy:
  ssl: false
```

- Enable custom SSL with provided certificates
```yaml
proxy:
  ssl:
    certificate_pem: CERTIFICATE_PEM
    private_key_pem: PRIVATE_KEY_PEM
```

The feature allows for a more flexible SSL setup while maintaining security best practices by using secrets for certificate management.

Site documentation PR: https://github.com/basecamp/kamal-site/pull/174