### PR TITLE
Install only docker-cli for 30% smaller kamal docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,7 @@ COPY Gemfile Gemfile.lock kamal.gemspec ./
 COPY lib/kamal/version.rb /kamal/lib/kamal/version.rb
 
 # Install system dependencies
-RUN apk add --no-cache build-base git docker openrc openssh-client-default yaml-dev \
-    && rc-update add docker boot \
+RUN apk add --no-cache build-base git docker-cli openssh-client-default yaml-dev \
     && gem install bundler --version=2.6.5 \
     && bundle install
 


### PR DESCRIPTION
As only the docker **client** is executed in the image and not the docker server/daemon, only the `docker-cli` package is needed to be installed.

The docs already include the mount of the docker **daemon** socket from the host:
`-v /var/run/docker.sock:/var/run/docker.sock` 
https://kamal-deploy.org/docs/installation/dockerized/

This reduced the image size from 733 MB to 511 MB for a local build for me, thus ca. 30% less. 
Which makes the initial pull faster both on developer machines and in CI pipelines.

The image size could probably be reduced even further with [Docker multi-stage builds](https://docs.docker.com/get-started/docker-concepts/building-images/multi-stage-builds/).

Have you thought about packaging a fully native executable of releases? e.g. with [Tebako](https://github.com/tamatebako/tebako) or [TruffleRuby](https://github.com/oracle/truffleruby)
I think for non-Ruby developers this could reduce the barrier of using Kamal, as the suggested docker approach surely also works, but might look a bit cumbersome. Such a native binary could then probably also more easily be packaged for package managers like `brew`.