### PR TITLE
Allow piping into kamal exec #1485 

### DIFF
--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -55,14 +55,14 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
 
   def execute_in_existing_container(*command, interactive: false)
     docker :exec,
-      ("-it" if interactive),
+      (docker_interactive_args if interactive),
       service_name,
       *command
   end
 
   def execute_in_new_container(*command, interactive: false)
     docker :run,
-      ("-it" if interactive),
+      (docker_interactive_args if interactive),
       "--rm",
       *network_args,
       *env_args,

--- a/lib/kamal/commands/app/execution.rb
+++ b/lib/kamal/commands/app/execution.rb
@@ -1,7 +1,7 @@
 module Kamal::Commands::App::Execution
   def execute_in_existing_container(*command, interactive: false, env:)
     docker :exec,
-      ("-it" if interactive),
+      (docker_interactive_args if interactive),
       *argumentize("--env", env),
       container_name,
       *command
@@ -9,7 +9,7 @@ module Kamal::Commands::App::Execution
 
   def execute_in_new_container(*command, interactive: false, detach: false, env:)
     docker :run,
-      ("-it" if interactive),
+      (docker_interactive_args if interactive),
       ("--detach" if detach),
       ("--rm" unless detach),
       "--network", "kamal",

--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -122,5 +122,9 @@ module Kamal::Commands
       def ensure_local_buildx_installed
         docker :buildx, "version"
       end
+
+      def docker_interactive_args
+        STDIN.isatty ? "-it" : "-i"
+      end
   end
 end

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -118,14 +118,21 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
   test "execute in new container over ssh" do
     new_command(:mysql).stub(:run_over_ssh, ->(cmd) { cmd.join(" ") }) do
       assert_match %r{docker run -it --rm --network kamal --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env private.registry/mysql:8.0 mysql -u root},
-        new_command(:mysql).execute_in_new_container_over_ssh("mysql", "-u", "root")
+        stub_stdin_tty { new_command(:mysql).execute_in_new_container_over_ssh("mysql", "-u", "root") }
     end
   end
 
   test "execute in existing container over ssh" do
     new_command(:mysql).stub(:run_over_ssh, ->(cmd) { cmd.join(" ") }) do
       assert_match %r{docker exec -it app-mysql mysql -u root},
-        new_command(:mysql).execute_in_existing_container_over_ssh("mysql", "-u", "root")
+        stub_stdin_tty { new_command(:mysql).execute_in_existing_container_over_ssh("mysql", "-u", "root") }
+    end
+  end
+
+  test "execute in existing container with piped input over ssh" do
+    new_command(:mysql).stub(:run_over_ssh, ->(cmd) { cmd.join(" ") }) do
+      assert_match %r{docker exec -i app-mysql mysql -u root},
+        stub_stdin_file { new_command(:mysql).execute_in_existing_container_over_ssh("mysql", "-u", "root") }
     end
   end
 

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -288,7 +288,7 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "execute in new container over ssh" do
     assert_match %r{docker run -it --rm --network kamal --env-file .kamal/apps/app/env/roles/web.env --log-opt max-size="10m" dhh/app:999 bin/rails c},
-      new_command.execute_in_new_container_over_ssh("bin/rails", "c", env: {})
+      stub_stdin_tty { new_command.execute_in_new_container_over_ssh("bin/rails", "c", env: {}) }
   end
 
   test "execute in new container over ssh with tags" do
@@ -296,18 +296,23 @@ class CommandsAppTest < ActiveSupport::TestCase
     @config[:env]["tags"] = { "tag1" => { "ENV1" => "value1" } }
 
     assert_equal "ssh -t root@1.1.1.1 -p 22 'docker run -it --rm --network kamal --env ENV1=\"value1\" --env-file .kamal/apps/app/env/roles/web.env --log-opt max-size=\"10m\" dhh/app:999 bin/rails c'",
-      new_command.execute_in_new_container_over_ssh("bin/rails", "c", env: {})
+      stub_stdin_tty { new_command.execute_in_new_container_over_ssh("bin/rails", "c", env: {}) }
   end
 
   test "execute in new container with custom options over ssh" do
     @config[:servers] = { "web" => { "hosts" => [ "1.1.1.1" ], "options" => { "mount" => "somewhere", "cap-add" => true } } }
     assert_match %r{docker run -it --rm --network kamal --env-file .kamal/apps/app/env/roles/web.env --log-opt max-size=\"10m\" --mount \"somewhere\" --cap-add dhh/app:999 bin/rails c},
-      new_command.execute_in_new_container_over_ssh("bin/rails", "c", env: {})
+      stub_stdin_tty { new_command.execute_in_new_container_over_ssh("bin/rails", "c", env: {}) }
   end
 
   test "execute in existing container over ssh" do
     assert_match %r{docker exec -it app-web-999 bin/rails c},
-      new_command.execute_in_existing_container_over_ssh("bin/rails", "c", env: {})
+      stub_stdin_tty { new_command.execute_in_existing_container_over_ssh("bin/rails", "c", env: {}) }
+  end
+
+  test "execute in existing container with piped input over ssh" do
+    assert_match %r{docker exec -i app-web-999 bin/rails c},
+      stub_stdin_file { new_command.execute_in_existing_container_over_ssh("bin/rails", "c", env: {}) }
   end
 
   test "run over ssh" do


### PR DESCRIPTION
This PR enables data to be piped to remote commands via STDIN.

An example use case would be to restore a database backup from your local dev machine:
`kamal accessory exec -i --reuse mysql 'mysql example_db"' < example_db_backup.sql`

As discussed in #1485, the implementation for interactive mode now checks if STDIN is connected to a TTY and only then it uses the current '-it' options for docker, else it uses '-i', which enables the transfer of data via STDIN.

The implementation should be straight forward, just the tests were a bit tricky.
I made sure the tests also still work when not run from a tty (eg within CI).
I hope it's OK like this, any comments are welcome.