### PR TITLE
Pin accessories to tags

### DIFF
--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -215,9 +215,9 @@ class Kamal::Configuration::Accessory
     def extract_hosts_from_config_with_tag(tag)
       if (servers_with_roles = config.raw_config.servers).is_a?(Hash)
         servers_with_roles.flat_map do |role, servers_in_role|
-          servers_in_role.collect do |host|
+          servers_in_role.filter_map do |host|
             host.keys.first if host.is_a?(Hash) && host.values.first.include?(tag)
-          end.compact
+          end
         end
       end
     end

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -213,16 +213,12 @@ class Kamal::Configuration::Accessory
     end
 
     def extract_hosts_from_config_with_tag(tag)
-      if config.raw_config.servers.is_a?(Hash)
-        config.raw_config.servers.flat_map do |role, servers_in_role|
+      if (servers_with_roles = config.raw_config.servers).is_a?(Hash)
+        servers_with_roles.flat_map do |role, servers_in_role|
           servers_in_role.collect do |host|
-            if host.is_a?(Hash) && host.values.first.include?(tag)
-              host.keys.first
-            end
-          end
-        end.compact
-      else
-        []
+            host.keys.first if host.is_a?(Hash) && host.values.first.include?(tag)
+          end.compact
+        end
       end
     end
 

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -208,7 +208,21 @@ class Kamal::Configuration::Accessory
 
     def hosts_from_tags
       if accessory_config.key?("tags")
-        accessory_config["tags"].flat_map { |tag| config.tag(tag)&.hosts }
+        accessory_config["tags"].flat_map { |tag| extract_hosts_from_config_with_tag(tag) }
+      end
+    end
+
+    def extract_hosts_from_config_with_tag(tag)
+      if config.raw_config.servers.is_a?(Hash)
+        config.raw_config.servers.flat_map do |(role, servers_in_role)|
+          servers_in_role.collect do |host|
+            if host.is_a?(Hash) && host.values.first.include?(tag)
+              host.keys.first
+            end
+          end
+        end.compact
+      else
+        []
       end
     end
 

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -207,7 +207,9 @@ class Kamal::Configuration::Accessory
     end
 
     def hosts_from_tags
-      if accessory_config.key?("tags")
+      if accessory_config.key?("tag")
+        extract_hosts_from_config_with_tag(accessory_config["tag"])
+      elsif accessory_config.key?("tags")
         accessory_config["tags"].flat_map { |tag| extract_hosts_from_config_with_tag(tag) }
       end
     end

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -32,7 +32,7 @@ class Kamal::Configuration::Accessory
   end
 
   def hosts
-    hosts_from_host || hosts_from_hosts || hosts_from_roles
+    hosts_from_host || hosts_from_hosts || hosts_from_roles || hosts_from_tags
   end
 
   def port
@@ -203,6 +203,12 @@ class Kamal::Configuration::Accessory
     def hosts_from_roles
       if accessory_config.key?("roles")
         accessory_config["roles"].flat_map { |role| config.role(role)&.hosts }
+      end
+    end
+
+    def hosts_from_tags
+      if accessory_config.key?("tags")
+        accessory_config["tags"].flat_map { |tag| config.tag(tag)&.hosts }
       end
     end
 

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -214,7 +214,7 @@ class Kamal::Configuration::Accessory
 
     def extract_hosts_from_config_with_tag(tag)
       if config.raw_config.servers.is_a?(Hash)
-        config.raw_config.servers.flat_map do |(role, servers_in_role)|
+        config.raw_config.servers.flat_map do |role, servers_in_role|
           servers_in_role.collect do |host|
             if host.is_a?(Hash) && host.values.first.include?(tag)
               host.keys.first

--- a/lib/kamal/configuration/docs/accessory.yml
+++ b/lib/kamal/configuration/docs/accessory.yml
@@ -46,13 +46,15 @@ accessories:
 
     # Accessory hosts
     #
-    # Specify one of `host`, `hosts`, or `roles`:
+    # Specify one of `host`, `hosts`, `roles`, or `tags`:
     host: mysql-db1
     hosts:
       - mysql-db1
       - mysql-db2
     roles:
       - mysql
+    tags:
+      - writer
 
     # Custom command
     #

--- a/lib/kamal/configuration/docs/accessory.yml
+++ b/lib/kamal/configuration/docs/accessory.yml
@@ -53,8 +53,10 @@ accessories:
       - mysql-db2
     roles:
       - mysql
+    tag: writer
     tags:
       - writer
+      - reader
 
     # Custom command
     #

--- a/lib/kamal/configuration/validator/accessory.rb
+++ b/lib/kamal/configuration/validator/accessory.rb
@@ -2,8 +2,8 @@ class Kamal::Configuration::Validator::Accessory < Kamal::Configuration::Validat
   def validate!
     super
 
-    if (config.keys & [ "host", "hosts", "roles", "tags" ]).size != 1
-      error "specify one of `host`, `hosts`, `roles` or `tags`"
+    if (config.keys & [ "host", "hosts", "roles", "tag", "tags" ]).size != 1
+      error "specify one of `host`, `hosts`, `roles`, `tag` or `tags`"
     end
 
     validate_docker_options!(config["options"])

--- a/lib/kamal/configuration/validator/accessory.rb
+++ b/lib/kamal/configuration/validator/accessory.rb
@@ -2,8 +2,8 @@ class Kamal::Configuration::Validator::Accessory < Kamal::Configuration::Validat
   def validate!
     super
 
-    if (config.keys & [ "host", "hosts", "roles" ]).size != 1
-      error "specify one of `host`, `hosts` or `roles`"
+    if (config.keys & [ "host", "hosts", "roles", "tags" ]).size != 1
+      error "specify one of `host`, `hosts`, `roles` or `tags`"
     end
 
     validate_docker_options!(config["options"])

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -116,6 +116,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "1.1.1.6", "1.1.1.7" ], @config.accessory(:redis).hosts
     assert_equal [ "1.1.1.1", "1.1.1.2" ], @config.accessory(:monitoring).hosts
     assert_equal [ "1.1.1.1", "1.1.1.3", "1.1.1.2" ], @config.accessory(:proxy).hosts
+    assert_equal [ "1.1.1.1", "1.1.1.3" ], @config.accessory(:logger).hosts
   end
 
   test "missing host" do

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -111,6 +111,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "1.1.1.5" ], @config.accessory(:mysql).hosts
     assert_equal [ "1.1.1.6", "1.1.1.7" ], @config.accessory(:redis).hosts
     assert_equal [ "1.1.1.1", "1.1.1.2" ], @config.accessory(:monitoring).hosts
+    assert_equal [ "1.1.1.1" ], @config.accessory(:proxy).hosts
   end
 
   test "missing host" do

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -73,7 +73,11 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
         },
         "proxy" => {
           "image" => "proxy:latest",
-          "tags" => [ "writer" ]
+          "tags" => [ "writer", "reader" ]
+        },
+        "logger" => {
+          "image" => "logger:latest",
+          "tag" => "writer"
         }
       }
     }
@@ -111,7 +115,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "1.1.1.5" ], @config.accessory(:mysql).hosts
     assert_equal [ "1.1.1.6", "1.1.1.7" ], @config.accessory(:redis).hosts
     assert_equal [ "1.1.1.1", "1.1.1.2" ], @config.accessory(:monitoring).hosts
-    assert_equal [ "1.1.1.1", "1.1.1.3" ], @config.accessory(:proxy).hosts
+    assert_equal [ "1.1.1.1", "1.1.1.3", "1.1.1.2" ], @config.accessory(:proxy).hosts
   end
 
   test "missing host" do
@@ -129,7 +133,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     exception = assert_raises(Kamal::ConfigurationError) do
       Kamal::Configuration.new(@deploy)
     end
-    assert_equal "accessories/mysql: specify one of `host`, `hosts`, `roles` or `tags`", exception.message
+    assert_equal "accessories/mysql: specify one of `host`, `hosts`, `roles`, `tag` or `tags`", exception.message
   end
 
   test "all hosts" do

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -7,7 +7,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
       image: "dhh/app",
       registry: { "username" => "dhh", "password" => "secret" },
       servers: {
-        "web" => [ "1.1.1.1", "1.1.1.2" ],
+        "web" => [ { "1.1.1.1" => "writer" }, { "1.1.1.2" => "reader" } ],
         "workers" => [ "1.1.1.3", "1.1.1.4" ]
       },
       builder: { "arch" => "amd64" },
@@ -70,6 +70,10 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
           "proxy" => {
             "host" => "monitoring.example.com"
           }
+        },
+        "proxy" => {
+          "image" => "proxy:latest",
+          "tags" => [ "writer" ]
         }
       }
     }
@@ -117,14 +121,14 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     end
   end
 
-  test "setting host, hosts and roles" do
+  test "setting host, hosts, roles and tags" do
     @deploy[:accessories]["mysql"]["hosts"] = [ "mysql-db1" ]
     @deploy[:accessories]["mysql"]["roles"] = [ "db" ]
 
     exception = assert_raises(Kamal::ConfigurationError) do
       Kamal::Configuration.new(@deploy)
     end
-    assert_equal "accessories/mysql: specify one of `host`, `hosts` or `roles`", exception.message
+    assert_equal "accessories/mysql: specify one of `host`, `hosts`, `roles` or `tags`", exception.message
   end
 
   test "all hosts" do

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -8,7 +8,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
       registry: { "username" => "dhh", "password" => "secret" },
       servers: {
         "web" => [ { "1.1.1.1" => "writer" }, { "1.1.1.2" => "reader" } ],
-        "workers" => [ "1.1.1.3", "1.1.1.4" ]
+        "workers" => [ { "1.1.1.3" => "writer" }, "1.1.1.4" ]
       },
       builder: { "arch" => "amd64" },
       env: { "REDIS_URL" => "redis://x/y" },
@@ -111,7 +111,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "1.1.1.5" ], @config.accessory(:mysql).hosts
     assert_equal [ "1.1.1.6", "1.1.1.7" ], @config.accessory(:redis).hosts
     assert_equal [ "1.1.1.1", "1.1.1.2" ], @config.accessory(:monitoring).hosts
-    assert_equal [ "1.1.1.1" ], @config.accessory(:proxy).hosts
+    assert_equal [ "1.1.1.1", "1.1.1.3" ], @config.accessory(:proxy).hosts
   end
 
   test "missing host" do


### PR DESCRIPTION
Allow accessories to specify which hosts they'll run on by using tags.

Example:

```yaml
servers:
  web:
    hosts:
      - fizzy-app-101: writer
      - fizzy-app-102: reader

accessories:
  beamer-primary:
    <<: *beamer-accessory
    service: beamer-primary
    cmd: beamer primary --remove-after=1h --dir=/storage
    tag: writer

  beamer-replica:
    <<: *beamer-accessory
    service: beamer-replica
    cmd: beamer replica --primary=http://fizzy-app-101:5000/ --dir=/storage
    tag: reader
```