### PR TITLE
Add support for kamal-proxy's path-prefix

### DIFF
--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -74,6 +74,17 @@ proxy:
   # How long to wait for requests to complete before timing out, defaults to 30 seconds:
   response_timeout: 10
 
+  # Path-based routing
+  #
+  # For applications that split their traffic to different services based on the request path, 
+  # you can use path-based routing to mount services under different path prefixes.
+  path_prefix: '/api'
+  # By default, the path prefix will be stripped from the request before it is forwarded upstream. 
+  # So in the example above, a request to /api/users/123 will be forwarded to web-1 as /users/123. 
+  # To instead forward the request with the original path (including the prefix), 
+  # specify --strip-path-prefix=false
+  strip_path_prefix: false
+
   # Healthcheck
   #
   # When deploying, the proxy will by default hit `/up` once every second until we hit

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -41,6 +41,8 @@ class Kamal::Configuration::Proxy
       "buffer-memory": proxy_config.dig("buffering", "memory"),
       "max-request-body": proxy_config.dig("buffering", "max_request_body"),
       "max-response-body": proxy_config.dig("buffering", "max_response_body"),
+      "path-prefix": proxy_config.dig("path_prefix"),
+      "strip-path-prefix": proxy_config.dig("strip_path_prefix"),
       "forward-headers": proxy_config.dig("forward_headers"),
       "tls-redirect": proxy_config.dig("ssl_redirect"),
       "log-request-header": proxy_config.dig("logging", "request_headers") || DEFAULT_LOG_REQUEST_HEADERS,


### PR DESCRIPTION
This PR introduces support for kamal-proxy's new path-based routing feature.  For applications that split their traffic to different services based on the request path, you can use path-based routing to mount services under different path prefixes.  

Begin by deploying the primary app that doesn’t require a path_prefix. Once that’s live, deploy your secondary app with the same host and the path_prefix feature.

## Example Usage

```
# config/deploy.yml
...
servers:
  web:
    - 192.168.0.1

proxy:
  # Don't include ssl (TLS) options
  hosts:
    - callred.com
  path_prefix: '/api'
  # strip_path_prefix: true
...
```

NOTE: SSL options (e.g., ssl: true) should be set in the proxy for the app without a path_prefix, so the app above uses SSL by inheritance. Repeating the SSL settings here will cause the deploy to fail with a TLS error in the console.

With the above configuration, all incoming requests to https://callred.com/api/* will be routed to your service. By default, the path prefix will be stripped from the request before it is forwarded upstream. So in the example above, a request to /api/users/123 will be forwarded to the secondary app as /users/123. To instead forward the request with the original path (including the prefix), set: `strip_path_prefix: true`

## Testing until added to main branch

For testing, I used the following setup in my Gemfile:
 
```
gem 'kamal', require: false, git: 'https://github.com/acpk/kamal.git', branch: 'kamal-proxy-path-prefix'
```

Deployment was performed with:

```
bundle exec kamal deploy
```