### PR TITLE
Run pre-connect hooks before building

### DIFF
--- a/lib/kamal/cli/build.rb
+++ b/lib/kamal/cli/build.rb
@@ -14,6 +14,10 @@ class Kamal::Cli::Build < Kamal::Cli::Base
   def push
     cli = self
 
+    # Ensure pre-connect hooks run before the build, they may needed for a remote builder
+    # or the pre-build hooks.
+    pre_connect_if_required
+
     ensure_docker_installed
     login_to_registry_locally
 

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -21,6 +21,7 @@ class CliBuildTest < CliTestCase
         .returns("")
 
       run_command("push", "--verbose").tap do |output|
+        assert_hook_ran "pre-connect", output
         assert_hook_ran "pre-build", output
         assert_match /Cloning repo into build directory/, output
         assert_match /git -C #{Dir.tmpdir}\/kamal-clones\/app-#{pwd_sha} clone #{Dir.pwd}/, output


### PR DESCRIPTION
They might be needed for remote builds or the pre-build hook.