### PR TITLE
Ensure primary_role app hosts are sorted first

### DIFF
--- a/lib/kamal/commander/specifics.rb
+++ b/lib/kamal/commander/specifics.rb
@@ -11,7 +11,7 @@ class Kamal::Commander::Specifics
     @primary_role = primary_or_first_role(roles_on(primary_host))
 
     stable_sort!(roles) { |role| role == primary_role ? 0 : 1 }
-    stable_sort!(hosts) { |host| roles_on(host).any? { |role| role == primary_role } ? 0 : 1 }
+    sort_primary_role_hosts_first!(hosts)
   end
 
   def roles_on(host)
@@ -19,7 +19,7 @@ class Kamal::Commander::Specifics
   end
 
   def app_hosts
-    config.app_hosts & specified_hosts
+    @app_hosts ||= sort_primary_role_hosts_first!(config.app_hosts & specified_hosts)
   end
 
   def proxy_hosts
@@ -54,5 +54,9 @@ class Kamal::Commander::Specifics
       else
         specified_hosts
       end
+    end
+
+    def sort_primary_role_hosts_first!(hosts)
+      stable_sort!(hosts) { |host| roles_on(host).any? { |role| role == primary_role } ? 0 : 1 }
     end
 end

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -149,6 +149,12 @@ class CommanderTest < ActiveSupport::TestCase
     assert_equal [], @kamal.accessory_hosts
   end
 
+  test "primary role hosts are first" do
+    configure_with(:deploy_with_roles_workers_primary)
+    assert_equal [ "1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4" ], @kamal.hosts
+    assert_equal [ "1.1.1.1", "1.1.1.2", "1.1.1.3", "1.1.1.4" ], @kamal.app_hosts
+  end
+
   private
     def configure_with(variant)
       @kamal = Kamal::Commander.new.tap do |kamal|

--- a/test/fixtures/deploy_with_roles_workers_primary.yml
+++ b/test/fixtures/deploy_with_roles_workers_primary.yml
@@ -1,0 +1,19 @@
+service: app
+image: dhh/app
+servers:
+  workers:
+    - 1.1.1.1
+    - 1.1.1.2
+  web:
+    - 1.1.1.3
+    - 1.1.1.4
+env:
+  REDIS_URL: redis://x/y
+registry:
+  server: registry.digitalocean.com
+  username: user
+  password: pw
+builder:
+  arch: amd64
+deploy_timeout: 1
+primary_role: workers


### PR DESCRIPTION
When booting non-primary role hosts we will always wait for a primary role host to boor first.

So when booting in groups, if there are no primary role hosts in the first batch, then booting will stall.

Sort primary role app_hosts first to avoid this.

Fixes: https://github.com/basecamp/kamal/issues/1553