### PR TITLE
Default the proxy config is it is nil

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -63,7 +63,7 @@ class Kamal::Configuration
     @env = Env.new(config: @raw_config.env || {}, secrets: secrets)
 
     @logging = Logging.new(logging_config: @raw_config.logging)
-    @proxy = Proxy.new(config: self, proxy_config: @raw_config.key?(:proxy) ? @raw_config.proxy : {})
+    @proxy = Proxy.new(config: self, proxy_config: @raw_config.proxy)
     @proxy_boot = Proxy::Boot.new(config: self)
     @ssh = Ssh.new(config: self)
     @sshkit = Sshkit.new(config: self)

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -11,6 +11,7 @@ class Kamal::Configuration::Proxy
   def initialize(config:, proxy_config:, context: "proxy")
     @config = config
     @proxy_config = proxy_config
+    @proxy_config = {} if @proxy_config.nil?
     validate! @proxy_config, with: Kamal::Configuration::Validator::Proxy, context: context
   end
 


### PR DESCRIPTION
Instead of checking for the proxy key, we'll set the config to {} if it is nil in the Kamal::Configuration::Proxy initializer.

This is a bit cleaner, and maybe it will help with https://github.com/basecamp/kamal/issues/1555 if somehow @raw_config.key?(:proxy) is false but @raw_config.proxy is not nil.