### PR TITLE
Drop Ruby 3.1 from the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,16 +26,12 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - "3.1"
           - "3.2"
           - "3.3"
           - "3.4"
         gemfile:
           - Gemfile
           - gemfiles/rails_edge.gemfile
-        exclude:
-          - ruby-version: "3.1"
-            gemfile: gemfiles/rails_edge.gemfile
     name: ${{ format('Tests (Ruby {0})', matrix.ruby-version) }}
     runs-on: ubuntu-latest
     env:


### PR DESCRIPTION
It is EOL since 2025-03-26.