### PR TITLE
Deploy env is authoritative (1-9-stable)

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -37,9 +37,9 @@ module Kamal::Cli
 
       def load_env
         if destination = options[:destination]
-          Dotenv.load(".env.#{destination}", ".env")
+          Dotenv.overload(".env", ".env.#{destination}")
         else
-          Dotenv.load(".env")
+          Dotenv.overload(".env")
         end
       end
 


### PR DESCRIPTION
Otherwise, having a stray `AWS_ACCESS_KEY_ID` for your dev env can leak into your production deploys. The given deploy env should always be authoritative.

Only affects Kamal 1.x due to Dotenv usage.