### PR TITLE
Enable cache-from support for GHA cache options

### DIFF
--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -177,8 +177,15 @@ class Kamal::Configuration::Builder
       [ server, cache_image ].compact.join("/")
     end
 
+    def cache_options
+      builder_config["cache"]&.fetch("options", nil)
+    end
+
     def cache_from_config_for_gha
-      "type=gha"
+      individual_options = cache_options&.split(",") || []
+      allowed_options = individual_options.select { |option| option =~ /^(url|url_v2|token|scope|timeout)=/ }
+
+      [ "type=gha", *allowed_options ].compact.join(",")
     end
 
     def cache_from_config_for_registry
@@ -186,11 +193,11 @@ class Kamal::Configuration::Builder
     end
 
     def cache_to_config_for_gha
-      [ "type=gha", builder_config["cache"]&.fetch("options", nil) ].compact.join(",")
+      [ "type=gha", cache_options ].compact.join(",")
     end
 
     def cache_to_config_for_registry
-      [ "type=registry", "ref=#{cache_image_ref}", builder_config["cache"]&.fetch("options", nil) ].compact.join(",")
+      [ "type=registry", "ref=#{cache_image_ref}", cache_options ].compact.join(",")
     end
 
     def repo_basename

--- a/test/configuration/builder_test.rb
+++ b/test/configuration/builder_test.rb
@@ -71,10 +71,10 @@ class ConfigurationBuilderTest < ActiveSupport::TestCase
   end
 
   test "setting gha cache" do
-    @deploy[:builder] = { "arch" => "amd64", "cache" => { "type" => "gha", "options" => "mode=max" } }
+    @deploy[:builder] = { "arch" => "amd64", "cache" => { "type" => "gha", "options" => "mode=max,scope=test" } }
 
-    assert_equal "type=gha", config.builder.cache_from
-    assert_equal "type=gha,mode=max", config.builder.cache_to
+    assert_equal "type=gha,scope=test", config.builder.cache_from
+    assert_equal "type=gha,mode=max,scope=test", config.builder.cache_to
   end
 
   test "setting registry cache" do


### PR DESCRIPTION
Previously, cache options were only passed to `cache-to`, not `cache-from`. This PR updates the builder to pass allowed options to `cache-from` as well. Specifically:
* `url`
* `url_v2`
* `token`
* `scope`
* `timeout`

Reference: https://docs.docker.com/build/cache/backends/gha/#synopsis