### PR TITLE
Expand secret environment variables in accessory files

### DIFF
--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -142,17 +142,17 @@ class Kamal::Configuration::Accessory
 
     def expand_local_file(local_file)
       if local_file.end_with?("erb")
-        with_clear_env_loaded { read_dynamic_file(local_file) }
+        with_env_loaded { read_dynamic_file(local_file) }
       else
         Pathname.new(File.expand_path(local_file)).to_s
       end
     end
 
-    def with_clear_env_loaded
-      env.clear.each { |k, v| ENV[k] = v }
+    def with_env_loaded
+      env.to_h.each { |k, v| ENV[k] = v }
       yield
     ensure
-      env.clear.each { |k, v| ENV.delete(k) }
+      env.to_h.each { |k, v| ENV.delete(k) }
     end
 
     def read_dynamic_file(local_file)

--- a/lib/kamal/configuration/env.rb
+++ b/lib/kamal/configuration/env.rb
@@ -27,7 +27,7 @@ class Kamal::Configuration::Env
   end
 
   def to_h
-    clear.merge(secrets.to_h)
+    clear.merge(aliased_secrets)
   end
 
   private

--- a/lib/kamal/configuration/env.rb
+++ b/lib/kamal/configuration/env.rb
@@ -1,7 +1,7 @@
 class Kamal::Configuration::Env
   include Kamal::Configuration::Validation
 
-  attr_reader :context, :clear, :secret_keys
+  attr_reader :context, :clear, :secrets, :secret_keys
   delegate :argumentize, to: Kamal::Utils
 
   def initialize(config:, secrets:, context: "env")
@@ -23,12 +23,16 @@ class Kamal::Configuration::Env
   def merge(other)
     self.class.new \
       config: { "clear" => clear.merge(other.clear), "secret" => secret_keys | other.secret_keys },
-      secrets: @secrets
+      secrets: secrets
+  end
+
+  def to_h
+    clear.merge(secrets.to_h)
   end
 
   private
     def aliased_secrets
-      secret_keys.to_h { |key| extract_alias(key) }.transform_values { |secret_key| @secrets[secret_key] }
+      secret_keys.to_h { |key| extract_alias(key) }.transform_values { |secret_key| secrets[secret_key] }
     end
 
     def extract_alias(key)

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -163,11 +163,14 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
   end
 
   test "dynamic file expansion" do
-    @deploy[:accessories]["mysql"]["files"] << "test/fixtures/files/structure.sql.erb:/docker-entrypoint-initdb.d/structure.sql"
-    @config = Kamal::Configuration.new(@deploy)
+    with_test_secrets("secrets" => "MYSQL_ROOT_PASSWORD=secret123") do
+      @deploy[:accessories]["mysql"]["files"] << "test/fixtures/files/structure.sql.erb:/docker-entrypoint-initdb.d/structure.sql"
+      @config = Kamal::Configuration.new(@deploy)
 
-    assert_match "This was dynamically expanded", @config.accessory(:mysql).files.keys[2].read
-    assert_match "%", @config.accessory(:mysql).files.keys[2].read
+      assert_match "This was dynamically expanded", @config.accessory(:mysql).files.keys[2].read
+      assert_match "%", @config.accessory(:mysql).files.keys[2].read
+      assert_match "secret123", @config.accessory(:mysql).files.keys[2].read
+    end
   end
 
   test "directory with a relative path" do

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -163,13 +163,16 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
   end
 
   test "dynamic file expansion" do
-    with_test_secrets("secrets" => "MYSQL_ROOT_PASSWORD=secret123") do
-      @deploy[:accessories]["mysql"]["files"] << "test/fixtures/files/structure.sql.erb:/docker-entrypoint-initdb.d/structure.sql"
+    @deploy[:accessories]["mysql"]["env"]["secret"] << "ENV_VAR:SECRET_VAR"
+    @deploy[:accessories]["mysql"]["files"] << "test/fixtures/files/structure.sql.erb:/docker-entrypoint-initdb.d/structure.sql"
+
+    with_test_secrets("secrets" => "MYSQL_ROOT_PASSWORD=secret123\nSECRET_VAR=secret_env_value") do
       @config = Kamal::Configuration.new(@deploy)
 
       assert_match "This was dynamically expanded", @config.accessory(:mysql).files.keys[2].read
       assert_match "%", @config.accessory(:mysql).files.keys[2].read
       assert_match "secret123", @config.accessory(:mysql).files.keys[2].read
+      assert_match "secret_env_value", @config.accessory(:mysql).files.keys[2].read
     end
   end
 

--- a/test/fixtures/files/structure.sql.erb
+++ b/test/fixtures/files/structure.sql.erb
@@ -1,3 +1,4 @@
 <%= "This was dynamically expanded" %>
 <%= ENV["MYSQL_ROOT_HOST"] %>
 <%= ENV["MYSQL_ROOT_PASSWORD"] %>
+<%= ENV["ENV_VAR"] %>

--- a/test/fixtures/files/structure.sql.erb
+++ b/test/fixtures/files/structure.sql.erb
@@ -1,2 +1,3 @@
 <%= "This was dynamically expanded" %>
 <%= ENV["MYSQL_ROOT_HOST"] %>
+<%= ENV["MYSQL_ROOT_PASSWORD"] %>


### PR DESCRIPTION
When accessory file ends with `.erb`, it's possible to interpolate environment variables in it. Currently, only clear environment variables are expanded. Not sure if it was a deliberate choice.

This PR includes all env variables (including the aliased ones) in the ERB template processing.

Background: I was trying to run PgBouncer (a PostgreSQL connection pooler) as an accessory, which required the database connection string to be present in its configuration file. I managed to work around this by generating the final config file through a Docker entrypoint script. However, if this PR is accepted, the setup would become much simpler.