### PR TITLE
Fixed docker login insecure -p usage preventing success.

### DIFF
--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -13,7 +13,7 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
 
     results = adapter.fetch(secrets, **options.slice(:account, :from).symbolize_keys)
 
-    return_or_puts JSON.dump(results), inline: options[:inline]
+    return_or_puts JSON.dump(results).shellescape, inline: options[:inline]
   end
 
   desc "extract", "Extract a single secret from the results of a fetch call"


### PR DESCRIPTION
## Changes:
- Resolve the error (below) by using `--password-stdin`

#### Setup:

- Google Artifact Registry
- 1Password secret fetch

#### .secrets

```yaml
SECRETS=$(kamal secrets fetch --adapter 1password --account xxxxxxxxx --from "Personal/Kamal Registry Key" password)
KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract "Personal/Kamal Registry Key" $SECRETS)
```

#### deploy.yml

```yml
# Credentials for your image host.
registry:
  server: us-east4-docker.pkg.dev # Google artifact registry
  username: _json_key

  # Always use an access token rather than real password (pulled from .kamal/secrets).
  password:
    - KAMAL_REGISTRY_PASSWORD
```

### Error from not using `--password-stdin`:

```bash
kamal setup
...
  ERROR (SSHKit::Command::Failed): docker exit status: 256
docker stdout: Nothing written
docker stderr: WARNING! Using --password via the CLI is insecure. Use --password-stdin.
Error response from daemon: Get "https://us-east4-docker.pkg.dev/v2/": unauthorized: authentication failed
```

Fixed inside `lib/kamal/commands/registry.rb`