### PR TITLE
Fixes incorrect host for accessory logs follow with specified host

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -188,9 +188,10 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
       if options[:follow]
         run_locally do
-          info "Following logs on #{hosts}..."
-          info accessory.follow_logs(timestamps: timestamps, grep: grep, grep_options: grep_options)
-          exec accessory.follow_logs(timestamps: timestamps, grep: grep, grep_options: grep_options)
+          first_host = hosts.first
+          info "Following logs on #{first_host}..."
+          info accessory.follow_logs(host: first_host, timestamps: timestamps, grep: grep, grep_options: grep_options)
+          exec accessory.follow_logs(host: first_host, timestamps: timestamps, grep: grep, grep_options: grep_options)
         end
       else
         since = options[:since]

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -47,11 +47,13 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
       ("grep '#{grep}'#{" #{grep_options}" if grep_options}" if grep)
   end
 
-  def follow_logs(timestamps: true, grep: nil, grep_options: nil)
+  def follow_logs(host: hosts.first, timestamps: true, grep: nil, grep_options: nil)
     run_over_ssh \
-      pipe \
+      pipe(
         docker(:logs, service_name, ("--timestamps" if timestamps), "--tail", "10", "--follow", "2>&1"),
         (%(grep "#{grep}"#{" #{grep_options}" if grep_options}) if grep)
+      ),
+      host: host
   end
 
   def execute_in_existing_container(*command, interactive: false)
@@ -80,8 +82,8 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
     run_over_ssh execute_in_new_container(*command, interactive: true)
   end
 
-  def run_over_ssh(command)
-    super command, host: hosts.first
+  def run_over_ssh(command, host: hosts.first)
+    super command, host: host
   end
 
   def ensure_local_file_present(local_file)

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -170,6 +170,16 @@ class CliAccessoryTest < CliTestCase
     assert_match "docker logs app-mysql --timestamps --tail 10 --follow 2>&1 | grep \"hey\" -C 2", run_command("logs", "mysql", "--follow", "--grep", "hey", "--grep-options", "-C 2")
   end
 
+  test "logs with follow respects hosts param" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:exec)
+      .with("ssh -t root@1.1.1.2 -p 22 'docker logs app-redis --timestamps --tail 10 --follow 2>&1'")
+
+    run_command("logs", "redis", "--follow", "--hosts", "1.1.1.2").tap do |output|
+      assert_match "Following logs on 1.1.1.2...", output
+      assert_match "ssh -t root@1.1.1.2 -p 22 'docker logs app-redis --timestamps --tail 10 --follow 2>&1'", output
+    end
+  end
+
   test "remove with confirmation" do
     Kamal::Cli::Accessory.any_instance.expects(:stop).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:remove_container).with("mysql")


### PR DESCRIPTION
# Bug
Prior to this fix, if you ran the command:
`kamal accessory logs my-accessory -h server2.hostname.com -f`

It would output:
```
INFO Following logs on ["server2.hostname.com"]...
INFO ssh -t root@server.hostname.com -p 22 'docker logs my-app-my-accessory --timestamps --tail 10 --follow 2>&1'
```

Notice it says it will follow logs on `["server2.hostname.com"]` but the `ssh` command is using the incorrect host `ssh -t root@server.hostname.com`.

# Solution
Now if you run the same command, it will now use the correct host:
```
INFO Following logs on server2.hostname.com...
INFO ssh -t root@server2.hostname.com -p 22 'docker logs my-app-my-accessory --timestamps --tail 10 --follow 2>&1'
```