### PR TITLE
Add secret support for SSH `key_data`

### DIFF
--- a/lib/kamal/configuration/docs/ssh.yml
+++ b/lib/kamal/configuration/docs/ssh.yml
@@ -58,9 +58,9 @@ ssh:
 
   # Key data
   #
-  # An array of strings, with each element of the array being
-  # a raw private key in PEM format.
-  key_data: [ "-----BEGIN OPENSSH PRIVATE KEY-----" ]
+  # An array of strings, with each element of the array being a secret name.
+  key_data:
+    - SSH_PRIVATE_KEY
 
   # Config
   #

--- a/lib/kamal/configuration/ssh.rb
+++ b/lib/kamal/configuration/ssh.rb
@@ -3,10 +3,11 @@ class Kamal::Configuration::Ssh
 
   include Kamal::Configuration::Validation
 
-  attr_reader :ssh_config
+  attr_reader :ssh_config, :secrets
 
   def initialize(config:)
     @ssh_config = config.raw_config.ssh || {}
+    @secrets = config.secrets
     validate! ssh_config
   end
 
@@ -35,7 +36,17 @@ class Kamal::Configuration::Ssh
   end
 
   def key_data
-    ssh_config["key_data"]
+    key_data = ssh_config["key_data"]
+    return unless key_data
+
+    key_data.map do |k|
+      if secrets.key?(k)
+        secrets[k]
+      else
+        warn "Inline key_data usage is deprecated and will be removed in Kamal 3. Please store your key_data in a secret."
+        k
+      end
+    end
   end
 
   def config

--- a/test/configuration/ssh_test.rb
+++ b/test/configuration/ssh_test.rb
@@ -49,4 +49,23 @@ class ConfigurationSshTest < ActiveSupport::TestCase
     config = Kamal::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "proxy" => "app@1.2.3.4" }) })
     assert_equal "app@1.2.3.4", config.ssh.options[:proxy].jump_proxies
   end
+
+  test "ssh key_data with plain value array" do
+    config = Kamal::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "key_data" => [ "-----BEGIN OPENSSH PRIVATE KEY-----" ] }) })
+    assert_equal [ "-----BEGIN OPENSSH PRIVATE KEY-----" ], config.ssh.options[:key_data]
+  end
+
+  test "ssh key_data with array containing one secret string" do
+    with_test_secrets("secrets" => "SSH_PRIVATE_KEY=secret_ssh_key") do
+      config = Kamal::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "key_data" => [ "SSH_PRIVATE_KEY" ] }) })
+      assert_equal [ "secret_ssh_key" ], config.ssh.options[:key_data]
+    end
+  end
+
+  test "ssh key_data with array containing multiple secret strings" do
+    with_test_secrets("secrets" => "SSH_PRIVATE_KEY=secret_ssh_key\nSECOND_KEY=second_secret_ssh_key") do
+      config = Kamal::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "key_data" => [ "SSH_PRIVATE_KEY", "SECOND_KEY" ] }) })
+      assert_equal [ "secret_ssh_key", "second_secret_ssh_key" ], config.ssh.options[:key_data]
+    end
+  end
 end

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -7,6 +7,19 @@ class SecretsTest < ActiveSupport::TestCase
     end
   end
 
+  test "synchronized_fetch" do
+    with_test_secrets("secrets" => "SECRET=ABC") do
+      assert_equal "ABC", Kamal::Secrets.new(secrets_path: ".kamal/secrets").send(:synchronized_fetch, "SECRET")
+    end
+  end
+
+  test "key?" do
+    with_test_secrets("secrets" => "SECRET1=ABC") do
+      assert Kamal::Secrets.new(secrets_path: ".kamal/secrets").key?("SECRET1")
+      assert_not Kamal::Secrets.new(secrets_path: ".kamal/secrets").key?("SECRET2")
+    end
+  end
+
   test "command interpolation" do
     with_test_secrets("secrets" => "SECRET=$(echo ABC)") do
       assert_equal "ABC", Kamal::Secrets.new(secrets_path: ".kamal/secrets")["SECRET"]


### PR DESCRIPTION
I've modified `key_data` under `ssh` to read from secrets. This is backwards compatible with the insecure method of storing directly in the deploy.yml. I limited the documentation to only showing the secure way since there is no reason to suggest insecure methods.