### PR TITLE
Minimize accessory downtime on reboot by pulling image prior to container stop

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -77,6 +77,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
         KAMAL.accessory_names.each { |accessory_name| reboot(accessory_name) }
       else
         prepare(name)
+        pull_image(name)
         stop(name)
         remove_container(name)
         boot(name, prepare: false)
@@ -198,6 +199,18 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
         on(hosts) do
           puts capture_with_info(*accessory.logs(timestamps: timestamps, since: since, lines: lines, grep: grep, grep_options: grep_options))
+        end
+      end
+    end
+  end
+
+  desc "pull_image [NAME]", "Pull accessory image on host", hide: true
+  def pull_image(name)
+    with_lock do
+      with_accessory(name) do |accessory, hosts|
+        on(hosts) do
+          execute *KAMAL.auditor.record("Pull #{name} accessory image"), verbosity: :debug
+          execute *accessory.pull_image
         end
       end
     end

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -90,6 +90,10 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
     end
   end
 
+  def pull_image
+    docker :image, :pull, image
+  end
+
   def remove_service_directory
     [ :rm, "-rf", service_name ]
   end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -56,6 +56,7 @@ class CliAccessoryTest < CliTestCase
 
   test "reboot" do
     Kamal::Commands::Registry.any_instance.expects(:login)
+    Kamal::Cli::Accessory.any_instance.expects(:pull_image).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:stop).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:remove_container).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:boot).with("mysql", prepare: false)
@@ -65,12 +66,15 @@ class CliAccessoryTest < CliTestCase
 
   test "reboot all" do
     Kamal::Commands::Registry.any_instance.expects(:login).times(4)
+    Kamal::Cli::Accessory.any_instance.expects(:pull_image).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:stop).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:remove_container).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:boot).with("mysql", prepare: false)
+    Kamal::Cli::Accessory.any_instance.expects(:pull_image).with("redis")
     Kamal::Cli::Accessory.any_instance.expects(:stop).with("redis")
     Kamal::Cli::Accessory.any_instance.expects(:remove_container).with("redis")
     Kamal::Cli::Accessory.any_instance.expects(:boot).with("redis", prepare: false)
+    Kamal::Cli::Accessory.any_instance.expects(:pull_image).with("busybox")
     Kamal::Cli::Accessory.any_instance.expects(:stop).with("busybox")
     Kamal::Cli::Accessory.any_instance.expects(:remove_container).with("busybox")
     Kamal::Cli::Accessory.any_instance.expects(:boot).with("busybox", prepare: false)
@@ -198,6 +202,10 @@ class CliAccessoryTest < CliTestCase
 
   test "remove_container" do
     assert_match "docker container prune --force --filter label=service=app-mysql", run_command("remove_container", "mysql")
+  end
+
+  test "pull_image" do
+    assert_match "docker image pull private.registry/mysql:5.7", run_command("pull_image", "mysql")
   end
 
   test "remove_image" do

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -170,6 +170,12 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
       new_command(:mysql).remove_container.join(" ")
   end
 
+  test "pull image" do
+    assert_equal \
+      "docker image pull private.registry/mysql:8.0",
+      new_command(:mysql).pull_image.join(" ")
+  end
+
   test "remove image" do
     assert_equal \
       "docker image rm --force private.registry/mysql:8.0",


### PR DESCRIPTION
Closes https://github.com/basecamp/kamal/issues/1616.

This PR attempts to further reduce downtime of accessories when doing `kamal accessory reboot` by pulling the container image of the accessory before stoping the running container.