### PR TITLE
Preserve file extension in destination config files

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -39,7 +39,10 @@ class Kamal::Configuration
       end
 
       def destination_config_file(base_config_file, destination)
-        base_config_file.sub_ext(".#{destination}.yml") if destination
+        if destination
+          base_extension = base_config_file.extname
+          base_config_file.sub_ext(".#{destination}#{base_extension}")
+        end
       end
   end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -262,6 +262,25 @@ class ConfigurationTest < ActiveSupport::TestCase
     end
   end
 
+  test "destination yaml config preserves extension" do
+    dest_config_file = Pathname.new(File.expand_path("fixtures/deploy_for_dest.yaml", __dir__))
+
+    config = Kamal::Configuration.create_from config_file: dest_config_file, destination: "world"
+    assert_equal "2.1.1.1", config.all_hosts.first
+  end
+
+  test "destination file preserves base file extension" do
+    # Test with .yml extension (existing behavior should still work)
+    yml_config_file = Pathname.new(File.expand_path("fixtures/deploy_for_dest.yml", __dir__))
+    config = Kamal::Configuration.create_from config_file: yml_config_file, destination: "world"
+    assert_equal "1.1.1.1", config.all_hosts.first
+
+    # Test with .yaml extension (new behavior)
+    yaml_config_file = Pathname.new(File.expand_path("fixtures/deploy_for_dest.yaml", __dir__))
+    config = Kamal::Configuration.create_from config_file: yaml_config_file, destination: "world"
+    assert_equal "2.1.1.1", config.all_hosts.first
+  end
+
   test "destination required" do
     dest_config_file = Pathname.new(File.expand_path("fixtures/deploy_for_required_dest.yml", __dir__))
 

--- a/test/fixtures/deploy_for_dest.world.yaml
+++ b/test/fixtures/deploy_for_dest.world.yaml
@@ -1,0 +1,5 @@
+servers:
+  - 2.1.1.1
+  - 2.1.1.2
+env:
+  REDIS_URL: redis://x/y

--- a/test/fixtures/deploy_for_dest.yaml
+++ b/test/fixtures/deploy_for_dest.yaml
@@ -1,0 +1,8 @@
+service: app
+image: dhh/app
+registry:
+  server: registry.digitalocean.com
+  username: <%= "my-user" %>
+  password: <%= "my-password" %>
+builder:
+  arch: amd64


### PR DESCRIPTION

Fixes #1630

## Summary

This PR fixes an issue where destination config files always used the `.yml` extension, even when the base config file used `.yaml`. Now the destination file preserves the same extension as the base config file.

## Changes

### Core Fix
- **`lib/kamal/configuration.rb`**: Modified `destination_config_file` method to preserve the base file's extension instead of hardcoding `.yml`

### Test Coverage
- **`test/configuration_test.rb`**: Added tests to verify both `.yml` and `.yaml` extensions work correctly with destinations
- **Test fixtures**: Added `.yaml` versions of existing test files (`deploy_for_dest.yaml`, `deploy_for_dest.world.yaml`)

## Behavior Changes

### Before
```bash
kamal deploy --config-file my-app.yaml -d staging
# Looked for: my-app.staging.yml ❌
```

### After  
```bash
kamal deploy --config-file my-app.yaml -d staging
# Looks for: my-app.staging.yaml ✅

kamal deploy --config-file my-app.yml -d staging  
# Looks for: my-app.staging.yml ✅ (unchanged)
```

## Backward Compatibility

✅ **Fully backward compatible** - existing `.yml` config files continue to work exactly as before. Only affects users who want to use `.yaml` extensions consistently.

## Test Plan

- [x] Existing tests pass (ensures no regression)
- [x] New tests verify `.yaml` extension preservation
- [x] New tests verify `.yml` extension still works (backward compatibility)

The fix is minimal, focused, and maintains full backward compatibility while providing the expected behavior for users who prefer `.yaml` extensions.