### PR TITLE
Stop app container by container id

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -66,25 +66,13 @@ class Kamal::Cli::App < Kamal::Cli::Base
   end
 
   desc "stop", "Stop app container on servers"
+  option :container_id, desc: "Docker container ID to stop (instead of stopping all containers)"
   def stop
     with_lock do
-      on(KAMAL.app_hosts) do |host|
-        roles = KAMAL.roles_on(host)
-
-        roles.each do |role|
-          app = KAMAL.app(role: role, host: host)
-          execute *KAMAL.auditor.record("Stopped app", role: role), verbosity: :debug
-
-          if role.running_proxy?
-            version = capture_with_info(*app.current_running_version, raise_on_non_zero_exit: false).strip
-            endpoint = capture_with_info(*app.container_id_for_version(version)).strip
-            if endpoint.present?
-              execute *app.remove, raise_on_non_zero_exit: false
-            end
-          end
-
-          execute *app.stop, raise_on_non_zero_exit: false
-        end
+      if options[:container_id]
+        stop_container(options[:container_id])
+      else
+        stop_all_containers
       end
     end
   end
@@ -396,5 +384,38 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
     def host_boot_groups
       KAMAL.config.boot.limit ? KAMAL.app_hosts.each_slice(KAMAL.config.boot.limit).to_a : [ KAMAL.app_hosts ]
+    end
+
+    def stop_container(container_id)
+      on(KAMAL.app_hosts) do |host|
+        roles = KAMAL.roles_on(host)
+
+        roles.each do |role|
+          app = KAMAL.app(role: role, host: host)
+          execute *KAMAL.auditor.record("Stopped container #{container_id}", role: role), verbosity: :debug
+          execute *app.stop_by_container_id(container_id), raise_on_non_zero_exit: false
+        end
+      end
+    end
+
+    def stop_all_containers
+      on(KAMAL.app_hosts) do |host|
+        roles = KAMAL.roles_on(host)
+
+        roles.each do |role|
+          app = KAMAL.app(role: role, host: host)
+          execute *KAMAL.auditor.record("Stopped app", role: role), verbosity: :debug
+
+          if role.running_proxy?
+            version = capture_with_info(*app.current_running_version, raise_on_non_zero_exit: false).strip
+            endpoint = capture_with_info(*app.container_id_for_version(version)).strip
+            if endpoint.present?
+              execute *app.remove, raise_on_non_zero_exit: false
+            end
+          end
+
+          execute *app.stop, raise_on_non_zero_exit: false
+        end
+      end
     end
 end

--- a/lib/kamal/commands/app.rb
+++ b/lib/kamal/commands/app.rb
@@ -47,6 +47,10 @@ class Kamal::Commands::App < Kamal::Commands::Base
       xargs(docker(:stop, *role.stop_args))
   end
 
+  def stop_by_container_id(container_id)
+    docker(:stop, *role.stop_args, container_id)
+  end
+
   def info
     docker :ps, *container_filter_args
   end

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -250,6 +250,12 @@ class CliAppTest < CliTestCase
     end
   end
 
+  test "stop with container id" do
+    run_command("stop", "--container-id", "abcd1234").tap do |output|
+      assert_match "docker stop abcd1234", output
+    end
+  end
+
   test "stale_containers" do
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :ps, "--filter", "label=service=app", "--filter", "label=destination=", "--filter", "label=role=web", "--format", "\"{{.Names}}\"", "|", "while read line; do echo ${line#app-web-}; done", raise_on_non_zero_exit: false)

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -100,6 +100,12 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command.stop(version: "123").join(" ")
   end
 
+  test "stop by container id" do
+    assert_equal \
+      "docker stop abcd1234",
+      new_command.stop_by_container_id("abcd1234").join(" ")
+  end
+
   test "info" do
     assert_equal \
       "docker ps --filter label=service=app --filter label=destination= --filter label=role=web",


### PR DESCRIPTION
Sometimes, a runaway container or a "detached" container that was started with `kamal app exec --detached` needs to be stopped. This PR adds a new option for `kamal app stop` command: `--container-id`.

The container id can be obtained from `kamal app containers` output. Then it can be stopped with:
```sh
kamal app stop --container-id 123
```