### PR TITLE
Tests: Remove docker.io package as it seems to cause conflicts with docker-ce

### DIFF
--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -4,7 +4,7 @@ WORKDIR /
 
 ENV VERBOSE=true
 
-RUN apt-get update --fix-missing && apt-get install -y ca-certificates openssh-client curl gnupg docker.io
+RUN apt-get update --fix-missing && apt-get install -y ca-certificates openssh-client curl gnupg
 
 RUN install -m 0755 -d /etc/apt/keyrings
 RUN curl -fsSL https://download.docker.com/linux/debian/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg


### PR DESCRIPTION
Got some errors from `test/integration/docker/deployer/Dockerfile` when running the tests on a fresh install:

```
5.573 Selecting previously unselected package docker-buildx-plugin.
5.575 Preparing to unpack .../4-docker-buildx-plugin_0.26.1-1~debian.13~trixie_arm64.deb ...
5.577 Unpacking docker-buildx-plugin (0.26.1-1~debian.13~trixie) ...
5.580 dpkg: error processing archive /tmp/apt-dpkg-install-sJenwn/4-docker-buildx-plugin_0.26.1-1~debian.13~trixie_arm64.deb (--unpack):
5.580  trying to overwrite '/usr/libexec/docker/cli-plugins/docker-buildx', which is also in package docker-buildx (0.13.1+ds1-3)
5.580 dpkg-deb: error: paste subprocess was killed by signal (Broken pipe)
```

Removing the `docker.io` package (`docker-ce` is installed afterwards) seems to fix it.