### PR TITLE
Don't login to registry locally for remote build

### DIFF
--- a/lib/kamal/cli/build.rb
+++ b/lib/kamal/cli/build.rb
@@ -19,7 +19,7 @@ class Kamal::Cli::Build < Kamal::Cli::Base
     pre_connect_if_required
 
     ensure_docker_installed
-    login_to_registry_locally
+    login_to_registry_locally if KAMAL.builder.login_to_registry_locally?
 
     run_hook "pre-build"
 

--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -1,8 +1,14 @@
 require "active_support/core_ext/string/filters"
 
 class Kamal::Commands::Builder < Kamal::Commands::Base
-  delegate :create, :remove, :dev, :push, :clean, :pull, :info, :inspect_builder, :validate_image, :first_mirror, to: :target
-  delegate :local?, :remote?, :pack?, :cloud?, to: "config.builder"
+  delegate \
+    :create, :remove, :dev, :push, :clean, :pull, :info, :inspect_builder,
+    :validate_image, :first_mirror, :login_to_registry_locally?,
+    to: :target
+
+  delegate \
+    :local?, :remote?, :pack?, :cloud?,
+    to: "config.builder"
 
   include Clone
 

--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -60,6 +60,10 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
     docker(:info, "--format '{{index .RegistryConfig.Mirrors 0}}'")
   end
 
+  def login_to_registry_locally?
+    true
+  end
+
   private
     def build_tag_names(tag_as_dirty: false)
       tag_names = [ config.absolute_image, config.latest_image ]

--- a/lib/kamal/commands/builder/remote.rb
+++ b/lib/kamal/commands/builder/remote.rb
@@ -24,6 +24,10 @@ class Kamal::Commands::Builder::Remote < Kamal::Commands::Builder::Base
       by: "||"
   end
 
+  def login_to_registry_locally?
+    false
+  end
+
   private
     def builder_name
       "kamal-remote-#{remote.gsub(/[^a-z0-9_-]/, "-")}"

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -44,6 +44,7 @@ class CliBuildTest < CliTestCase
         .returns("")
 
       run_command("push", "--verbose", fixture: :with_remote_builder).tap do |output|
+        assert_no_match "Running docker login -u [REDACTED] -p [REDACTED] as ", output
         assert_match "docker buildx inspect kamal-remote-ssh---app-1-1-1-5 | grep -q Endpoint:.*kamal-remote-ssh---app-1-1-1-5-context && docker context inspect kamal-remote-ssh---app-1-1-1-5-context --format '{{.Endpoints.docker.Host}}' | grep -xq ssh://app@1.1.1.5 || (echo no compatible builder && exit 1)", output
       end
     end


### PR DESCRIPTION
There's no need for a local registry login when using a remote builder.