### PR TITLE
Set proxy run configuration in deploy YAML

### DIFF
--- a/lib/kamal/commander.rb
+++ b/lib/kamal/commander.rb
@@ -109,8 +109,8 @@ class Kamal::Commander
     @commands[:lock] ||= Kamal::Commands::Lock.new(config)
   end
 
-  def proxy
-    @commands[:proxy] ||= Kamal::Commands::Proxy.new(config)
+  def proxy(host)
+    Kamal::Commands::Proxy.new(config, host: host)
   end
 
   def prune

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -148,6 +148,39 @@ proxy:
       - X-Request-ID
       - X-Request-Start
 
+  # Run configuration
+  #
+  # These options are used when booting the proxy container.
+  #
+  # `http_port` - default 80
+  # `https_port` - default 443
+  # `metrics_port` - if set, exposes this port for Prometheus metrics
+  # `debug` - if true, enables debug logging
+  # `log_max_size` - maximum size for log files, defaults to "10m"
+  # `publish` - if false, does not publish ports to the host
+  # `bind_ips` - list of IPs to bind to when publishing ports
+  # `registry` - container registry to use for pulling the kamal-proxy image, defaults to Docker Hub
+  # `repository` - container repository to use for pulling the kamal-proxy image, defaults to `basecamp/kamal-proxy`
+  # `version` - version tag of the kamal-proxy image to use
+  # `options` - additional options to pass to `docker run`
+  run:
+    http_port: 8080
+    https_port: 8443
+    metrics_port: 9090
+    debug: true
+    log_max_size: "30m"
+    publish: false
+    bind_ips:
+      - 0.0.0.0
+    registry: registry:4443
+    repository: myrepo/kamal-proxy
+    version: v0.8.0
+    options:
+      label:
+        - custom.label=kamal-proxy
+      memory: 512m
+      cpus: 0.5
+
 # Enabling/disabling the proxy on roles
 #
 # The proxy is enabled by default on the primary role but can be disabled by

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -6,8 +6,7 @@ class Kamal::Configuration::Proxy
 
   delegate :argumentize, :optionize, to: Kamal::Utils
 
-  attr_reader :config, :proxy_config, :role_name, :secrets
-
+  attr_reader :config, :proxy_config, :role_name, :run, :secrets
   def initialize(config:, proxy_config:, role_name: nil, secrets:, context: "proxy")
     @config = config
     @proxy_config = proxy_config
@@ -15,6 +14,7 @@ class Kamal::Configuration::Proxy
     @role_name = role_name
     @secrets = secrets
     validate! @proxy_config, with: Kamal::Configuration::Validator::Proxy, context: context
+    @run = Kamal::Configuration::Proxy::Run.new(config, run_config: @proxy_config["run"], context: "#{context}/run") if @proxy_config && @proxy_config["run"].present?
   end
 
   def app_port

--- a/lib/kamal/configuration/proxy/boot.rb
+++ b/lib/kamal/configuration/proxy/boot.rb
@@ -1,9 +1,4 @@
 class Kamal::Configuration::Proxy::Boot
-  MINIMUM_VERSION = "v0.9.0"
-  DEFAULT_HTTP_PORT = 80
-  DEFAULT_HTTPS_PORT = 443
-  DEFAULT_LOG_MAX_SIZE = "10m"
-
   attr_reader :config
   delegate :argumentize, :optionize, to: Kamal::Utils
 
@@ -16,8 +11,8 @@ class Kamal::Configuration::Proxy::Boot
 
     (bind_ips || [ nil ]).map do |bind_ip|
       bind_ip = format_bind_ip(bind_ip)
-      publish_http = [ bind_ip, http_port, DEFAULT_HTTP_PORT ].compact.join(":")
-      publish_https = [ bind_ip, https_port, DEFAULT_HTTPS_PORT ].compact.join(":")
+      publish_http = [ bind_ip, http_port, Kamal::Configuration::Proxy::Run::DEFAULT_HTTP_PORT ].compact.join(":")
+      publish_https = [ bind_ip, https_port, Kamal::Configuration::Proxy::Run::DEFAULT_HTTPS_PORT ].compact.join(":")
 
       argumentize "--publish", [ publish_http, publish_https ]
     end.join(" ")
@@ -29,8 +24,8 @@ class Kamal::Configuration::Proxy::Boot
 
   def default_boot_options
     [
-      *(publish_args(DEFAULT_HTTP_PORT, DEFAULT_HTTPS_PORT, nil)),
-      *(logging_args(DEFAULT_LOG_MAX_SIZE))
+      *(publish_args(Kamal::Configuration::Proxy::Run::DEFAULT_HTTP_PORT, Kamal::Configuration::Proxy::Run::DEFAULT_HTTPS_PORT, nil)),
+      *(logging_args(Kamal::Configuration::Proxy::Run::DEFAULT_LOG_MAX_SIZE))
     ]
   end
 

--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -1,0 +1,143 @@
+class Kamal::Configuration::Proxy::Run
+  MINIMUM_VERSION = "v0.9.0"
+  DEFAULT_HTTP_PORT = 80
+  DEFAULT_HTTPS_PORT = 443
+  DEFAULT_LOG_MAX_SIZE = "10m"
+
+  attr_reader :config, :run_config
+  delegate :argumentize, :optionize, to: Kamal::Utils
+
+  def initialize(config, run_config:, context: "proxy/run")
+    @config = config
+    @run_config = run_config
+    @context = context
+  end
+
+  def debug?
+    run_config.fetch("debug", nil)
+  end
+
+  def publish?
+    run_config.fetch("publish", true)
+  end
+
+  def http_port
+    run_config.fetch("http_port", DEFAULT_HTTP_PORT)
+  end
+
+  def https_port
+    run_config.fetch("https_port", DEFAULT_HTTPS_PORT)
+  end
+
+  def bind_ips
+    run_config.fetch("bind_ips", nil)
+  end
+
+  def publish_args
+    if publish?
+      (bind_ips || [ nil ]).map do |bind_ip|
+        bind_ip = format_bind_ip(bind_ip)
+        publish_http = [ bind_ip, http_port, DEFAULT_HTTP_PORT ].compact.join(":")
+        publish_https = [ bind_ip, https_port, DEFAULT_HTTPS_PORT ].compact.join(":")
+
+        argumentize "--publish", [ publish_http, publish_https ]
+      end.join(" ")
+    end
+  end
+
+  def log_max_size
+    run_config.fetch("log_max_size", DEFAULT_LOG_MAX_SIZE)
+  end
+
+  def logging_args
+    argumentize "--log-opt", "max-size=#{log_max_size}" if log_max_size.present?
+  end
+
+  def version
+    run_config.fetch("version", MINIMUM_VERSION)
+  end
+
+  def registry
+    run_config.fetch("registry", nil)
+  end
+
+  def repository
+    run_config.fetch("repository", "basecamp/kamal-proxy")
+  end
+
+  def image
+    "#{[ registry, repository ].compact.join("/")}:#{version}"
+  end
+
+  def container_name
+    "kamal-proxy"
+  end
+
+  def options_args
+    if args = run_config["options"]
+      optionize args
+    end
+  end
+
+  def run_command
+    [ "kamal-proxy", "run", *optionize(run_command_options) ].join(" ")
+  end
+
+  def metrics_port
+    run_config["metrics_port"]
+  end
+
+  def run_command_options
+    { debug: debug? || nil, "metrics-port": metrics_port }.compact
+  end
+
+  def docker_options_args
+    [
+      *apps_volume_args,
+      *publish_args,
+      *logging_args,
+      *("--expose=#{metrics_port}" if metrics_port.present?),
+      *options_args
+    ].compact
+  end
+
+  def host_directory
+    File.join config.run_directory, "proxy"
+  end
+
+  def apps_directory
+    File.join host_directory, "apps-config"
+  end
+
+  def apps_container_directory
+    "/home/kamal-proxy/.apps-config"
+  end
+
+  def apps_volume
+    Kamal::Configuration::Volume.new \
+      host_path: apps_directory,
+      container_path: apps_container_directory
+  end
+
+  def apps_volume_args
+    [ apps_volume.docker_args ]
+  end
+
+  def app_directory
+    File.join apps_directory, config.service_and_destination
+  end
+
+  def app_container_directory
+    File.join apps_container_directory, config.service_and_destination
+  end
+
+  private
+    def format_bind_ip(ip)
+      # Ensure IPv6 address inside square brackets - e.g. [::1]
+      if ip =~ Resolv::IPv6::Regex && ip !~ /\A\[.*\]\z/
+        "[#{ip}]"
+      else
+        ip
+      end
+    end
+end

--- a/lib/kamal/configuration/validator/proxy.rb
+++ b/lib/kamal/configuration/validator/proxy.rb
@@ -20,6 +20,26 @@ class Kamal::Configuration::Validator::Proxy < Kamal::Configuration::Validator
           error "Missing certificate_pem setting (required when private_key_pem is present)"
         end
       end
+
+      if run_config = config["run"]
+        if run_config["bind_ips"].present?
+          ensure_valid_bind_ips(config["bind_ips"])
+        end
+
+        if run_config["publish"] == false
+          if run_config["bind_ips"].present? || run_config["http_port"].present? || run_config["https_port"].present?
+            error "Cannot set http_port, https_port or bind_ips when publish is false"
+          end
+        end
+      end
     end
   end
+
+  private
+    def ensure_valid_bind_ips(bind_ips)
+      bind_ips.present? && bind_ips.each do |ip|
+        next if ip =~ Resolv::IPv4::Regex || ip =~ Resolv::IPv6::Regex
+        error "Invalid publish IP address: #{ip}"
+      end
+    end
 end

--- a/lib/kamal/utils.rb
+++ b/lib/kamal/utils.rb
@@ -21,11 +21,11 @@ module Kamal::Utils
   end
 
   # Returns a list of shell-dashed option arguments. If the value is true, it's treated like a value-less option.
-  def optionize(args, with: nil)
+  def optionize(args, with: nil, escape: true)
     options = if with
-      flatten_args(args).collect { |(key, value)| value == true ? "--#{key}" : "--#{key}#{with}#{escape_shell_value(value)}" }
+      flatten_args(args).collect { |(key, value)| value == true ? "--#{key}" : "--#{key}#{with}#{escape ? escape_shell_value(value) : value}" }
     else
-      flatten_args(args).collect { |(key, value)| [ "--#{key}", value == true ? nil : escape_shell_value(value) ] }
+      flatten_args(args).collect { |(key, value)| [ "--#{key}", value == true ? nil : escape ? escape_shell_value(value) : value ] }
     end
 
     options.flatten.compact

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -5,7 +5,22 @@ class CliProxyTest < CliTestCase
     run_command("boot").tap do |output|
       assert_match "docker login", output
       assert_match "mkdir -p .kamal/proxy/apps-config", output
-      assert_match "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy", output
+      assert_match "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy", output
+    end
+  end
+
+  test "boot with run config" do
+    run_command("boot", fixture: :with_proxy_run_config).tap do |output|
+      assert_match "docker login", output
+      assert_match "mkdir -p .kamal/proxy/apps-config", output
+      assert_match "docker container start kamal-proxy || docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m --expose=9090 --cpus \"1.5\" registry:4443/basecamp/kamal-proxy:v0.9.0 kamal-proxy run --debug --metrics-port \"9090\" on 1.1.1.1", output
+      assert_match "docker container start kamal-proxy || docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m --expose=9190 basecamp/kamal-proxy:v0.9.0 kamal-proxy run --metrics-port \"9190\" on 1.1.1.3", output
+    end
+  end
+
+  test "boot with run config conflicts" do
+    assert_raises Kamal::ConfigurationError, "Conflicting proxy run configurations for host 1.1.1.2" do
+      run_command("boot", fixture: :with_proxy_run_config_conflicts)
     end
   end
 
@@ -19,11 +34,11 @@ class CliProxyTest < CliTestCase
     exception = assert_raises do
       run_command("boot").tap do |output|
         assert_match "docker login", output
-        assert_match "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy", output
+        assert_match "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy", output
       end
     end
 
-    assert_includes exception.message, "kamal-proxy version v0.0.1 is too old, run `kamal proxy reboot` in order to update to at least #{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}"
+    assert_includes exception.message, "kamal-proxy version v0.0.1 is too old, run `kamal proxy reboot` in order to update to at least #{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}"
   ensure
     Thread.report_on_exception = false
   end
@@ -32,12 +47,12 @@ class CliProxyTest < CliTestCase
     Thread.report_on_exception = false
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :inspect, "kamal-proxy", "--format '{{.Config.Image}}'", "|", :awk, "-F:", "'{print $NF}'")
-      .returns(Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION)
+      .returns(Kamal::Configuration::Proxy::Run::MINIMUM_VERSION)
       .at_least_once
 
     run_command("boot").tap do |output|
       assert_match "docker login", output
-      assert_match "docker container start kamal-proxy || echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy", output
+      assert_match "docker container start kamal-proxy || echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy", output
     end
   ensure
     Thread.report_on_exception = false
@@ -48,12 +63,12 @@ class CliProxyTest < CliTestCase
       assert_match "docker container stop kamal-proxy on 1.1.1.1", output
       assert_match "docker container prune --force --filter label=org.opencontainers.image.title=kamal-proxy on 1.1.1.1", output
       assert_match "mkdir -p .kamal/proxy/apps-config on 1.1.1.1", output
-      assert_match "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config on 1.1.1.1", output
+      assert_match "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config on 1.1.1.1", output
 
       assert_match "docker container stop kamal-proxy on 1.1.1.2", output
       assert_match "docker container prune --force --filter label=org.opencontainers.image.title=kamal-proxy on 1.1.1.2", output
       assert_match "mkdir -p .kamal/proxy/apps-config on 1.1.1.1", output
-      assert_match "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config on 1.1.1.2", output
+      assert_match "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config on 1.1.1.2", output
     end
   end
 
@@ -161,7 +176,7 @@ class CliProxyTest < CliTestCase
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :inspect, "kamal-proxy", "--format '{{.Config.Image}}'", "|", :awk, "-F:", "'{print $NF}'")
-      .returns(Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION)
+      .returns(Kamal::Configuration::Proxy::Run::MINIMUM_VERSION)
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :container, :ls, "--all", "--filter", "name=^app-workers-latest$", "--quiet", "|", :xargs, :docker, :inspect, "--format", "'{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'")
@@ -177,7 +192,7 @@ class CliProxyTest < CliTestCase
       assert_match "/usr/bin/env mkdir -p .kamal", output
       assert_match "docker network create kamal", output
       assert_match "docker login -u [REDACTED] -p [REDACTED]", output
-      assert_match "docker container start kamal-proxy || echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy", output
+      assert_match "docker container start kamal-proxy || echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy", output
       assert_match "/usr/bin/env mkdir -p .kamal", output
       assert_match %r{docker rename app-web-latest app-web-latest_replaced_.*}, output
       assert_match "/usr/bin/env mkdir -p .kamal/apps/app/env/roles", output
@@ -200,7 +215,7 @@ class CliProxyTest < CliTestCase
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :inspect, "kamal-proxy", "--format '{{.Config.Image}}'", "|", :awk, "-F:", "'{print $NF}'")
-      .returns(Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION)
+      .returns(Kamal::Configuration::Proxy::Run::MINIMUM_VERSION)
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :container, :ls, "--all", "--filter", "name=^app-workers-latest$", "--quiet", "|", :xargs, :docker, :inspect, "--format", "'{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'")
@@ -371,7 +386,7 @@ class CliProxyTest < CliTestCase
 
   test "boot_config get" do
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
-      .with(:echo, "$(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\")")
+      .with(:echo, "$(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\")")
       .returns("--publish 80:80 --publish 8443:443 --label=foo=bar basecamp/kamal-proxy:v1.0.0")
       .twice
 

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -15,7 +15,7 @@ class CommandsProxyTest < ActiveSupport::TestCase
 
   test "run" do
     assert_equal \
-      "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config",
+      "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config",
       new_command.run.join(" ")
   end
 
@@ -23,7 +23,7 @@ class CommandsProxyTest < ActiveSupport::TestCase
     @config.delete(:proxy)
 
     assert_equal \
-      "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config",
+      "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config",
       new_command.run.join(" ")
   end
 
@@ -125,7 +125,7 @@ class CommandsProxyTest < ActiveSupport::TestCase
 
   test "read_image_version" do
     assert_equal \
-      "cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}\"",
+      "cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\"",
       new_command.read_image_version.join(" ")
   end
 
@@ -165,8 +165,64 @@ class CommandsProxyTest < ActiveSupport::TestCase
       new_command.reset_run_command.join(" ")
   end
 
+  test "registry run config" do
+    @config[:proxy] = { "run" => { "registry" => "registry:4443" } }
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m registry:4443/basecamp/kamal-proxy:v0.9.0 kamal-proxy run",
+      new_command.run.join(" ")
+  end
+
+  test "repository run config" do
+    @config[:proxy] = { "run" => { "repository" => "custom/repo" } }
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m custom/repo:v0.9.0 kamal-proxy run",
+      new_command.run.join(" ")
+  end
+
+  test "image_version run config" do
+    @config[:proxy] = { "run" => { "version" => "v1.2.3" } }
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m basecamp/kamal-proxy:v1.2.3 kamal-proxy run",
+      new_command.run.join(" ")
+  end
+
+  test "bind_ips run config" do
+    @config[:proxy] = { "run" => { "bind_ips" => [ "0.0.0.0", "127.0.0.1" ] } }
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 0.0.0.0:80:80 --publish 0.0.0.0:443:443 --publish 127.0.0.1:80:80 --publish 127.0.0.1:443:443 --log-opt max-size=10m basecamp/kamal-proxy:v0.9.0 kamal-proxy run",
+      new_command.run.join(" ")
+  end
+
+  test "log_max_size run config" do
+    @config[:proxy] = { "run" => { "log_max_size" => "50m" } }
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=50m basecamp/kamal-proxy:v0.9.0 kamal-proxy run",
+      new_command.run.join(" ")
+  end
+
+  test "debug run config" do
+    @config[:proxy] = { "run" => { "debug" => true } }
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m basecamp/kamal-proxy:v0.9.0 kamal-proxy run --debug",
+      new_command.run.join(" ")
+  end
+
+  test "metrics_port run config" do
+    @config[:proxy] = { "run" => { "metrics_port" => 9090 } }
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m --expose=9090 basecamp/kamal-proxy:v0.9.0 kamal-proxy run --metrics-port \"9090\"",
+      new_command.run.join(" ")
+  end
+
+  test "don't publish run config" do
+    @config[:proxy] = { "run" => { "publish" => false } }
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $(pwd)/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --log-opt max-size=10m basecamp/kamal-proxy:v0.9.0 kamal-proxy run",
+      new_command.run.join(" ")
+  end
+
   private
     def new_command
-      Kamal::Commands::Proxy.new(Kamal::Configuration.new(@config, version: "123"))
+      Kamal::Commands::Proxy.new(Kamal::Configuration.new(@config, version: "123"), host: "1.1.1.1")
     end
 end

--- a/test/fixtures/deploy_with_proxy_run_config.yml
+++ b/test/fixtures/deploy_with_proxy_run_config.yml
@@ -1,0 +1,51 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+    - "1.1.1.2"
+  workers:
+    - "1.1.1.3"
+    - "1.1.1.4"
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64
+proxy:
+  run:
+    registry: registry:4443
+    debug: true
+    metrics_port: 9090
+    options:
+      cpus: 1.5
+
+
+accessories:
+  mysql:
+    image: mysql:5.7
+    host: 1.1.1.3
+    port: 3306
+    env:
+      clear:
+        MYSQL_ROOT_HOST: '%'
+      secret:
+        - MYSQL_ROOT_PASSWORD
+    files:
+      - test/fixtures/files/my.cnf:/etc/mysql/my.cnf
+    directories:
+      - data:/var/lib/mysql
+    proxy:
+      run:
+        debug: false
+        metrics_port: 9190
+  redis:
+    image: redis:latest
+    roles:
+      - web
+    port: 6379
+    directories:
+      - data:/data
+
+readiness_delay: 0
+deploy_timeout: 6

--- a/test/fixtures/deploy_with_proxy_run_config_conflicts.yml
+++ b/test/fixtures/deploy_with_proxy_run_config_conflicts.yml
@@ -1,0 +1,45 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+    - "1.1.1.2"
+  workers:
+    - "1.1.1.3"
+    - "1.1.1.4"
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64
+proxy:
+  run:
+    debug: true
+
+accessories:
+  mysql:
+    image: mysql:5.7
+    host: 1.1.1.2
+    port: 3306
+    env:
+      clear:
+        MYSQL_ROOT_HOST: '%'
+      secret:
+        - MYSQL_ROOT_PASSWORD
+    files:
+      - test/fixtures/files/my.cnf:/etc/mysql/my.cnf
+    directories:
+      - data:/var/lib/mysql
+    proxy:
+      run:
+        debug: false
+  redis:
+    image: redis:latest
+    roles:
+      - web
+    port: 6379
+    directories:
+      - data:/data
+
+readiness_delay: 0
+deploy_timeout: 6

--- a/test/integration/docker/deployer/app/.kamal/hooks/pre-deploy
+++ b/test/integration/docker/deployer/app/.kamal/hooks/pre-deploy
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -e
 
-kamal proxy boot_config set --registry registry:4443
 echo "Deployed!"
 mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/pre-deploy

--- a/test/integration/docker/deployer/app/config/deploy.yml
+++ b/test/integration/docker/deployer/app/config/deploy.yml
@@ -25,6 +25,8 @@ drain_timeout: 2
 readiness_delay: 0
 proxy:
   host: 127.0.0.1
+  run:
+    registry: registry:4443
 registry:
   server: localhost:5000
 builder:

--- a/test/integration/docker/deployer/app_with_proxied_accessory/.kamal/hooks/pre-deploy
+++ b/test/integration/docker/deployer/app_with_proxied_accessory/.kamal/hooks/pre-deploy
@@ -1,4 +1,0 @@
-#!/bin/sh
-set -e
-
-kamal proxy boot_config set --registry registry:4443

--- a/test/integration/docker/deployer/app_with_proxied_accessory/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_proxied_accessory/config/deploy.yml
@@ -31,6 +31,8 @@ accessories:
     host: vm1
     port: 12345:80
     proxy:
+      run:
+        registry: registry:4443
       host: netcat
       ssl: false
       healthcheck:

--- a/test/integration/docker/deployer/app_with_roles/.kamal/hooks/pre-deploy
+++ b/test/integration/docker/deployer/app_with_roles/.kamal/hooks/pre-deploy
@@ -1,6 +1,5 @@
 #!/bin/sh
 set -e
 
-kamal proxy boot_config set --registry registry:4443
 echo "Deployed!"
 mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/pre-deploy

--- a/test/integration/docker/deployer/app_with_roles/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_roles/config/deploy.yml
@@ -14,6 +14,8 @@ drain_timeout: 2
 readiness_delay: 0
 
 proxy:
+  run:
+    registry: registry:4443
   host: localhost
   ssl: false
   healthcheck:

--- a/test/integration/docker/deployer/app_with_traefik/.kamal/hooks/pre-deploy
+++ b/test/integration/docker/deployer/app_with_traefik/.kamal/hooks/pre-deploy
@@ -1,7 +1,0 @@
-set -e
-
-kamal proxy boot_config set --registry registry:4443 \
-                            --publish false \
-                            --docker_options label=traefik.http.services.kamal_proxy.loadbalancer.server.scheme=http \
-                                             label=traefik.http.routers.kamal_proxy.rule=PathPrefix\(\`/\`\) \
-                                             sysctl=net.ipv4.ip_local_port_range=\"10000\ 60999\"

--- a/test/integration/docker/deployer/app_with_traefik/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_traefik/config/deploy.yml
@@ -16,6 +16,15 @@ builder:
   arch: <%= Kamal::Utils.docker_arch %>
   args:
     COMMIT_SHA: <%= `git rev-parse HEAD` %>
+proxy:
+  run:
+    registry: registry:4443
+    publish: false
+    options:
+      label:
+        - traefik.http.services.kamal_proxy.loadbalancer.server.scheme=http
+        - traefik.http.routers.kamal_proxy.rule=PathPrefix(`/`)
+      sysctl: net.ipv4.ip_local_port_range=10000 60999
 accessories:
   traefik:
     service: traefik

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -32,7 +32,7 @@ class MainTest < IntegrationTest
     assert_match /Proxy Host: vm2/, details
     assert_match /App Host: vm1/, details
     assert_match /App Host: vm2/, details
-    assert_match /basecamp\/kamal-proxy:#{Kamal::Configuration::Proxy::Boot::MINIMUM_VERSION}/, details
+    assert_match /basecamp\/kamal-proxy:#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}/, details
     assert_match /localhost:5000\/app:#{first_version}/, details
 
     audit = kamal :audit, capture: true

--- a/test/integration/proxy_test.rb
+++ b/test/integration/proxy_test.rb
@@ -6,8 +6,6 @@ class ProxyTest < IntegrationTest
   end
 
   test "boot, reboot, stop, start, restart, logs, remove" do
-    kamal :proxy, :boot_config, :set, "--registry", "registry:4443"
-
     kamal :proxy, :boot
     assert_proxy_running
 
@@ -47,14 +45,6 @@ class ProxyTest < IntegrationTest
 
     logs = kamal :proxy, :logs, capture: true
     assert_match /No previous state to restore/, logs
-
-    kamal :proxy, :boot_config, :set, "--registry", "registry:4443", "--docker-options='sysctl net.ipv4.ip_local_port_range=\"10000 60999\"'"
-    assert_docker_options_in_file
-
-    kamal :proxy, :reboot, "-y"
-    assert_docker_options_in_container
-
-    kamal :proxy, :boot_config, :reset
 
     kamal :proxy, :remove
     assert_proxy_not_running


### PR DESCRIPTION
With Kamal 2.0 the plan was to have kamal proxy as a zero config proxy, so that you could run multiple apps through a single proxy instance without configuration conflicts - as such a lot of configuration is done at deploy time, rather than boot time.

But there's actually quite a lot of configuration that's needed at boot time - anything that needs to be set where the container is started - ports, logging options, image version, custom docker options etc.

This can all be currently set with `kamal proxy boot_config set ...` but that is cumbersome and the config is stored on the servers which is not ideal. In practice you end up needing to set the config in a hook for consistency so it's in the app repo anyway.

So let's allow the config to be set in the deploy YAML at `proxy/run` instead. We'll keep the `kamal proxy boot_config` commands and use them if no run config is set, but we'll print a deprecation warning.

If you have conflicting proxy configs for a single host in an app, we'll raise a configuration error. If you have them across multiple apps, we'll just use them both and the container will use whichever config it was last booted with.

In the next major version we'll remove the boot_config commands and just use the run config.