### PR TITLE
Don't login to registry locally for remote build: take 2

### DIFF
--- a/lib/kamal/cli/build.rb
+++ b/lib/kamal/cli/build.rb
@@ -19,7 +19,7 @@ class Kamal::Cli::Build < Kamal::Cli::Base
     pre_connect_if_required
 
     ensure_docker_installed
-    login_to_registry_locally
+    login_to_registry_locally if KAMAL.builder.login_to_registry_locally?
 
     run_hook "pre-build"
 

--- a/lib/kamal/cli/build.rb
+++ b/lib/kamal/cli/build.rb
@@ -59,7 +59,7 @@ class Kamal::Cli::Build < Kamal::Cli::Base
         push = KAMAL.builder.push(cli.options[:output])
 
         KAMAL.with_verbosity(:debug) do
-          Dir.chdir(KAMAL.config.builder.build_directory) { execute *push }
+          Dir.chdir(KAMAL.config.builder.build_directory) { execute *push, env: KAMAL.builder.push_env }
         end
       end
     end

--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -3,7 +3,7 @@ require "active_support/core_ext/string/filters"
 class Kamal::Commands::Builder < Kamal::Commands::Base
   delegate \
     :create, :remove, :dev, :push, :clean, :pull, :info, :inspect_builder,
-    :validate_image, :first_mirror, :login_to_registry_locally?,
+    :validate_image, :first_mirror, :login_to_registry_locally?, :push_env,
     to: :target
 
   delegate \

--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -1,8 +1,14 @@
 require "active_support/core_ext/string/filters"
 
 class Kamal::Commands::Builder < Kamal::Commands::Base
-  delegate :create, :remove, :dev, :push, :clean, :pull, :info, :inspect_builder, :validate_image, :first_mirror, to: :target
-  delegate :local?, :remote?, :pack?, :cloud?, to: "config.builder"
+  delegate \
+    :create, :remove, :dev, :push, :clean, :pull, :info, :inspect_builder,
+    :validate_image, :first_mirror, :login_to_registry_locally?,
+    to: :target
+
+  delegate \
+    :local?, :remote?, :pack?, :cloud?,
+    to: "config.builder"
 
   include Clone
 

--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -64,6 +64,10 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
     true
   end
 
+  def push_env
+    {}
+  end
+
   private
     def build_tag_names(tag_as_dirty: false)
       tag_names = [ config.absolute_image, config.latest_image ]

--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -60,6 +60,10 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
     docker(:info, "--format '{{index .RegistryConfig.Mirrors 0}}'")
   end
 
+  def login_to_registry_locally?
+    true
+  end
+
   private
     def build_tag_names(tag_as_dirty: false)
       tag_names = [ config.absolute_image, config.latest_image ]

--- a/lib/kamal/commands/builder/remote.rb
+++ b/lib/kamal/commands/builder/remote.rb
@@ -24,6 +24,10 @@ class Kamal::Commands::Builder::Remote < Kamal::Commands::Builder::Base
       by: "||"
   end
 
+  def login_to_registry_locally?
+    false
+  end
+
   private
     def builder_name
       "kamal-remote-#{remote.gsub(/[^a-z0-9_-]/, "-")}"

--- a/lib/kamal/commands/builder/remote.rb
+++ b/lib/kamal/commands/builder/remote.rb
@@ -28,6 +28,10 @@ class Kamal::Commands::Builder::Remote < Kamal::Commands::Builder::Base
     false
   end
 
+  def push_env
+    { "BUILDKIT_NO_CLIENT_TOKEN" => "1" }
+  end
+
   private
     def builder_name
       "kamal-remote-#{remote.gsub(/[^a-z0-9_-]/, "-")}"

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -44,6 +44,7 @@ class CliBuildTest < CliTestCase
         .returns("")
 
       run_command("push", "--verbose", fixture: :with_remote_builder).tap do |output|
+        assert_no_match "Running docker login -u [REDACTED] -p [REDACTED] as ", output
         assert_match "docker buildx inspect kamal-remote-ssh---app-1-1-1-5 | grep -q Endpoint:.*kamal-remote-ssh---app-1-1-1-5-context && docker context inspect kamal-remote-ssh---app-1-1-1-5-context --format '{{.Endpoints.docker.Host}}' | grep -xq ssh://app@1.1.1.5 || (echo no compatible builder && exit 1)", output
       end
     end

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -46,6 +46,7 @@ class CliBuildTest < CliTestCase
       run_command("push", "--verbose", fixture: :with_remote_builder).tap do |output|
         assert_no_match "Running docker login -u [REDACTED] -p [REDACTED] as ", output
         assert_match "docker buildx inspect kamal-remote-ssh---app-1-1-1-5 | grep -q Endpoint:.*kamal-remote-ssh---app-1-1-1-5-context && docker context inspect kamal-remote-ssh---app-1-1-1-5-context --format '{{.Endpoints.docker.Host}}' | grep -xq ssh://app@1.1.1.5 || (echo no compatible builder && exit 1)", output
+        assert_match "Command: ( export BUILDKIT_NO_CLIENT_TOKEN=\"1\" ; docker buildx build --output=type=registry --platform linux/arm64 --builder kamal-remote-ssh---app-1-1-1-5 -t dhh/app:999 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1 )", output
       end
     end
   end
@@ -91,7 +92,7 @@ class CliBuildTest < CliTestCase
       SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:git, "-C", build_directory, :submodule, :update, "--init")
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
-        .with(:docker, :buildx, :build, "--output=type=registry", "--platform", "linux/amd64", "--builder", "kamal-local-docker-container", "-t", "dhh/app:999", "-t", "dhh/app:latest", "--label", "service=\"app\"", "--file", "Dockerfile", ".", "2>&1")
+        .with(:docker, :buildx, :build, "--output=type=registry", "--platform", "linux/amd64", "--builder", "kamal-local-docker-container", "-t", "dhh/app:999", "-t", "dhh/app:latest", "--label", "service=\"app\"", "--file", "Dockerfile", ".", "2>&1", env: {})
 
       SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
         .with(:git, "-C", anything, :"rev-parse", :HEAD)
@@ -185,7 +186,7 @@ class CliBuildTest < CliTestCase
         .returns("")
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
-        .with(:docker, :buildx, :build, "--output=type=registry", "--platform", "linux/amd64", "--builder", "kamal-local-docker-container", "-t", "dhh/app:999", "-t", "dhh/app:latest", "--label", "service=\"app\"", "--file", "Dockerfile", ".", "2>&1")
+        .with(:docker, :buildx, :build, "--output=type=registry", "--platform", "linux/amd64", "--builder", "kamal-local-docker-container", "-t", "dhh/app:999", "-t", "dhh/app:latest", "--label", "service=\"app\"", "--file", "Dockerfile", ".", "2>&1", env: {})
 
       run_command("push").tap do |output|
         assert_match /WARN Missing compatible builder, so creating a new one first/, output


### PR DESCRIPTION
Reverts basecamp/kamal#1662

Then set BUILDKIT_NO_CLIENT_TOKEN=1 in the env for the remote build push command to allow the remote builder to push without a local login.