### PR TITLE
Pack builder updates for no cache and dirty tags

### DIFF
--- a/lib/kamal/commands/builder/pack.rb
+++ b/lib/kamal/commands/builder/pack.rb
@@ -1,7 +1,7 @@
 class Kamal::Commands::Builder::Pack < Kamal::Commands::Builder::Base
-  def push(export_action = "registry")
+  def push(export_action = "registry", tag_as_dirty: false, no_cache: false)
     combine \
-      build,
+      build(tag_as_dirty: tag_as_dirty, no_cache: no_cache),
       export(export_action)
   end
 
@@ -13,15 +13,15 @@ class Kamal::Commands::Builder::Pack < Kamal::Commands::Builder::Base
   alias_method :inspect_builder, :info
 
   private
-    def build
+    def build(tag_as_dirty: false, no_cache: false)
       pack(:build,
         config.repository,
         "--platform", platform,
         "--creation-time", "now",
         "--builder", pack_builder,
         buildpacks,
-        "-t", config.absolute_image,
-        "-t", config.latest_image,
+        *build_tag_options(tag_as_dirty: tag_as_dirty),
+        *([ "--clear-cache" ] if no_cache),
         "--env", "BP_IMAGE_LABELS=service=#{config.service}",
         *argumentize("--env", args),
         *argumentize("--env", secrets, sensitive: true),

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -77,6 +77,14 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder.push.join(" ")
   end
 
+  test "pack build with no cache" do
+    builder = new_builder_command(image: "dhh/app", builder: { "args" => { "a" => 1, "b" => 2 }, "arch" => "amd64", "pack" => { "builder" => "heroku/builder:24", "buildpacks" => [ "heroku/ruby", "heroku/procfile" ] } })
+
+    assert_equal \
+      "pack build dhh/app --platform linux/amd64 --creation-time now --builder heroku/builder:24 --buildpack heroku/ruby --buildpack heroku/procfile --buildpack paketo-buildpacks/image-labels -t dhh/app:123 -t dhh/app:latest --clear-cache --env BP_IMAGE_LABELS=service=app --env a=\"1\" --env b=\"2\" --path . && docker push dhh/app:123 && docker push dhh/app:latest",
+    builder.push("registry", no_cache: true).join(" ")
+  end
+
   test "pack build secrets as env" do
     with_test_secrets("secrets" => "token_a=foo\ntoken_b=bar") do
       builder = new_builder_command(image: "dhh/app", builder: { "secrets" => [ "token_a", "token_b" ], "arch" => "amd64", "pack" => { "builder" => "heroku/builder:24", "buildpacks" => [ "heroku/ruby", "heroku/procfile" ] } })


### PR DESCRIPTION
There are a few new build options that were added in #1357(tag as dirty) and #1639(no cache) that need to be added to the pack builder options. 

This PR adds support for the `--no-cache` options with Pack's `--clear-cache` option.
> --clear-cache                     Clear image's associated cache before building

I've also updated the way tags are built to use the base `build_tag_options` to leverage the `tag_as_dirty` option.

https://buildpacks.io/docs/for-platform-operators/how-to/integrate-ci/pack/cli/pack_build/