### PR TITLE
Update registry config documentation to reflect Kamal 2.8.0 changes

### DIFF
--- a/lib/kamal/configuration/docs/registry.yml
+++ b/lib/kamal/configuration/docs/registry.yml
@@ -1,19 +1,27 @@
 # Registry
 #
 # The default registry is Docker Hub, but you can change it using `registry/server`.
+
+# Using a local container registry
+#
+# If the registry server starts with `localhost`, Kamal will start a local Docker registry
+# on that port and push the app image to it.
+registry:
+  server: localhost:5555
+
+# Using Docker Hub as the container registry
 #
 # By default, Docker Hub creates public repositories. To avoid making your images public,
 # set up a private repository before deploying, or change the default repository privacy
 # settings to private in your [Docker Hub settings](https://hub.docker.com/repository-settings/default-privacy).
 #
-# A reference to a secret (in this case, `DOCKER_REGISTRY_TOKEN`) will look up the secret
+# A reference to a secret (in this case, `KAMAL_REGISTRY_PASSWORD`) will look up the secret
 # in the local environment:
 registry:
-  server: registry.digitalocean.com
   username:
-    - DOCKER_REGISTRY_TOKEN
+    - <your docker hub username>
   password:
-    - DOCKER_REGISTRY_TOKEN
+    - KAMAL_REGISTRY_PASSWORD
 
 # Using AWS ECR as the container registry
 #


### PR DESCRIPTION
Kamal 2.8.0 introduced a local docker registry to push and pull app images, see:  #1355. This PR updates the registry configuration documentation to reflect these changes. It also fixes some minor inconsistencies in the configuration examples.

I believe the changes help Kamal users with the migration to a local docker registry.

Key changes:
* Moved Docker Hub to its own section.
* Replaced `DOCKER_REGISTRY_TOKEN` with `KAMAL_REGISTRY_PASSWORD` to be consistent with the `.kamal/secrets` file.
* Replaced the username example to be consistent with the other examples.
* Removed `server: registry.digitalocean.com` from that section. I found that confusing in a Docker Hub section.
* Added a local container registry section with a configuration example. Mostly for users migrating to a local registry.