### PR TITLE
support kamal-proxy --health-check-host

### DIFF
--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -114,10 +114,16 @@ proxy:
   # the deploy timeout, with a 5-second timeout for each request.
   #
   # Once the app is up, the proxy will stop hitting the healthcheck endpoint.
+  #
+  # The `host` option allows setting a custom Host header for health check requests.
+  # This is useful when your application validates the Host header (e.g., Django's
+  # ALLOWED_HOSTS, Rails host authorization). Without this, health checks using
+  # internal IPs may be rejected even when the application is healthy.
   healthcheck:
     interval: 3
     path: /health
     timeout: 3
+    host: example.com
 
   # Buffering
   #

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -78,6 +78,7 @@ class Kamal::Configuration::Proxy
       "health-check-interval": seconds_duration(proxy_config.dig("healthcheck", "interval")),
       "health-check-timeout": seconds_duration(proxy_config.dig("healthcheck", "timeout")),
       "health-check-path": proxy_config.dig("healthcheck", "path"),
+      "health-check-host": proxy_config.dig("healthcheck", "host"),
       "target-timeout": seconds_duration(proxy_config["response_timeout"]),
       "buffer-requests": proxy_config.fetch("buffering", { "requests": true }).fetch("requests", true),
       "buffer-responses": proxy_config.fetch("buffering", { "responses": true }).fetch("responses", true),

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -105,6 +105,35 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
     end
   end
 
+  test "health check host in deploy options" do
+    @deploy[:proxy] = {
+      "host" => "example.com",
+      "healthcheck" => {
+        "path" => "/up",
+        "host" => "example.com"
+      }
+    }
+
+    proxy = config.proxy
+    options = proxy.deploy_options
+    assert_equal "example.com", options[:"health-check-host"]
+    assert_equal "/up", options[:"health-check-path"]
+  end
+
+  test "health check without custom host" do
+    @deploy[:proxy] = {
+      "host" => "example.com",
+      "healthcheck" => {
+        "path" => "/up"
+      }
+    }
+
+    proxy = config.proxy
+    options = proxy.deploy_options
+    assert_nil options[:"health-check-host"]
+    assert_equal "/up", options[:"health-check-path"]
+  end
+
   private
     def config
       Kamal::Configuration.new(@deploy)


### PR DESCRIPTION
Many web applications validate the `Host` header for security (think Django's `ALLOWED_HOSTS`, Rails host authorization, etc.). When kamal-proxy performs health checks using internal IPs like `http://10.0.1.5:3000/up`, the application sees `Host: 10.0.1.5:3000` and rejects it. This causes the proxy to incorrectly mark healthy targets as unhealthy.

For example, if your app only allows `example.com` in its host validation, health checks using the internal IP will fail even though the application is working fine.

## Solution

This PR integrates with basecamp/kamal-proxy#175, which added the `--health-check-host` flag to kamal-proxy. Now you can configure a custom `Host` header for health check requests in your `deploy.yml`:

```yaml
proxy:
  host: example.com
  healthcheck:
    interval: 1
    timeout: 5
    path: "/up"
    host: "example.com"  # Custom Host header for health checks
```

When Kamal deploys your app, health checks will include `Host: example.com` and pass validation.

The option is optional and fully backward compatible. When not specified, the default behavior is unchanged.

## Changes

1. **Configuration** (`lib/kamal/configuration/proxy.rb`): Added `health-check-host` to `deploy_options` to extract and pass the custom host header to kamal-proxy
2. **Documentation** (`lib/kamal/configuration/docs/proxy.yml`): Documented the new `host` option in the healthcheck section with examples and use cases
3. **Tests** (`test/configuration/proxy_test.rb`): Added test cases to verify the option is correctly passed and backward compatibility is maintained

## Testing

- Added unit tests to verify the custom host option is correctly extracted from configuration
- Verified backward compatibility when the option is not specified
- All existing tests continue to pass