### PR TITLE
Fix DNS retry inclusion order

### DIFF
--- a/test/sshkit_dns_retry_test.rb
+++ b/test/sshkit_dns_retry_test.rb
@@ -3,6 +3,13 @@ require "test_helper"
 class SshkitDnsRetryTest < ActiveSupport::TestCase
   setup do
     SSHKit::Backend::Netssh.configure { |config| config.dns_retries = 2 }
+    @previous_output = SSHKit.config.output
+    @log_io = StringIO.new
+    SSHKit.config.output = Logger.new(@log_io)
+  end
+
+  teardown do
+    SSHKit.config.output = @previous_output
   end
 
   test "retries dns errors" do
@@ -29,5 +36,17 @@ class SshkitDnsRetryTest < ActiveSupport::TestCase
     end
 
     assert_equal 1, attempts
+  end
+
+  test "netssh backend retries dns errors when connecting" do
+    host = SSHKit::Host.new("unknown.example.com")
+    backend = SSHKit::Backend::Netssh.new(host)
+
+    SSHKit::Backend::Netssh.stubs(:sleep) # avoid actual backoff wait
+    Net::SSH.expects(:start).twice.raises(SocketError, "getaddrinfo: nodename nor servname provided, or not known").then.returns(:ok)
+
+    assert_equal :ok, backend.send(:connect_ssh, host.hostname, host.username, host.netssh_options)
+
+    assert_includes @log_io.string, "Retrying DNS for #{host.hostname}"
   end
 end


### PR DESCRIPTION
Move `connect_ssh` to a distinct module to clarify prepend ordering.

I had refactored these modules and tests didn't catch the regression! DNS retries not actually hooked in.

References #1707