### PR TITLE
Make environment variables optional for tagged hosts

### DIFF
--- a/lib/kamal/configuration/role.rb
+++ b/lib/kamal/configuration/role.rb
@@ -36,7 +36,7 @@ class Kamal::Configuration::Role
   end
 
   def env_tags(host)
-    tagged_hosts.fetch(host).collect { |tag| config.env_tag(tag) }
+    tagged_hosts.fetch(host).collect { |tag| config.env_tag(tag) }.compact
   end
 
   def cmd

--- a/test/configuration/role_test.rb
+++ b/test/configuration/role_test.rb
@@ -29,6 +29,13 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
     assert_equal [ "1.1.1.3", "1.1.1.4" ], config_with_roles.role(:workers).hosts
   end
 
+  test "missing env tag is ignored" do
+    @deploy_with_roles[:servers]["workers"]["hosts"] = [ { "1.1.1.3" => [ "job" ] } ]
+
+    role = Kamal::Configuration.new(@deploy_with_roles).role(:workers)
+    assert_equal "redis://a/b", role.env("1.1.1.3").clear["REDIS_URL"]
+  end
+
   test "cmd" do
     assert_nil config.role(:web).cmd
     assert_equal "bin/jobs", config_with_roles.role(:workers).cmd


### PR DESCRIPTION
Hey,

When deploying with tagged servers, e.g.:

```
servers:
  job:
    hosts:
      - 10.100.0.4: job
    proxy: false
    cmd: bin/jobs
```

...the deploy would fail at the end with `undefined method 'env' for nil` if `env.tags.job` wasn't set.

This PR fixes that by compacting the `env_tags` in `lib/kamal/configuration/role.rb`, along with a little test.