### PR TITLE
Add KeePassXC Secret Adapter

### DIFF
--- a/lib/kamal/secrets/adapters/keepassxc.rb
+++ b/lib/kamal/secrets/adapters/keepassxc.rb
@@ -8,7 +8,7 @@ class Kamal::Secrets::Adapters::Keepassxc < Kamal::Secrets::Adapters::Base
   private
 
   def check_dependencies!
-    raise RuntimeError, "KeePassXC CLI is not installed." unless cli_installed?
+    raise "KeePassXC CLI is not installed." unless cli_installed?
   end
 
   def login(account)

--- a/lib/kamal/secrets/adapters/keepassxc.rb
+++ b/lib/kamal/secrets/adapters/keepassxc.rb
@@ -44,7 +44,7 @@ class Kamal::Secrets::Adapters::Keepassxc < Kamal::Secrets::Adapters::Base
       if (value = ENV[secret]).present?
         results[secret] = value
       else
-        raise "Secret '#{secret}' is missing in ENV."
+        raise "KeePassXC CLI is not Installed & Secret '#{secret}' is missing in ENV."
       end
     end
   end

--- a/lib/kamal/secrets/adapters/keepassxc.rb
+++ b/lib/kamal/secrets/adapters/keepassxc.rb
@@ -1,0 +1,80 @@
+require "open3"
+
+class Kamal::Secrets::Adapters::Keepassxc < Kamal::Secrets::Adapters::Base
+  # Usage Example:
+  # kamal secrets fetch --adapter keepassxc --account ~/path/to/secrets.kdbx --from entry-title KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY ANY_OTHER_ATTRIBUTE_SAVED_IN_ADVANCE_TAB_OF_AN_ENTRY
+
+  private
+
+  # 1. Login / Authentication
+  def login(account)
+    # In CI, we don't authenticate. Return a dummy session.
+    return "ci-session" if ci_mode?
+
+    if ENV["KEEPASS_PWD"] && !ENV["KEEPASS_PWD"].empty?
+      ENV["KEEPASS_PWD"]
+    else
+      ask_for_password(account)
+    end
+  end
+
+  # 2. Dispatcher
+  def fetch_secrets(secrets, from:, account:, session:)
+    if ci_mode?
+      # CI Mode: Passthrough (Strict check)
+      secrets.each_with_object({}) do |secret, results|
+        value = ENV[secret]
+        raise "Missing ENV secret '#{secret}' in CI mode." if value.nil? || value.empty?
+        results[secret] = value
+      end
+    else
+      # Local Mode: Fetch secrets.
+      if secrets.empty?
+        raise ArgumentError, "No secrets specified. Please list the attribute names you want to fetch."
+      end
+      fetch_specified_secrets(secrets, from: from, account: account, session: session)
+    end
+  end
+
+  # 3. Fetch secrets
+  def fetch_specified_secrets(secrets, from:, account:, session:)
+    secrets.each_with_object({}) do |secret, results|
+      # If asking for "password", use standard field, otherwise use Attribute lookup
+      attr_flag = (secret == "password") ? [] : ["-a", secret]
+
+      results[secret] = run_command("show", account, from, *attr_flag, "-q", "--show-protected", session: session)
+    end
+  end
+
+  # 4. Check Dependencies
+  def check_dependencies!
+    # BYPASS: Don't check for CLI in CI
+    return if ci_mode?
+    raise "KeePassXC CLI is not installed" unless cli_installed?
+  end
+
+  def cli_installed?
+    `keepassxc-cli --version 2> /dev/null`
+    $?.success?
+  end
+
+  # --- Helpers ---
+
+  def ci_mode?
+    ENV["CI"] == "true" || ENV["GITHUB_ACTIONS"] == "true"
+  end
+
+  def ask_for_password(account)
+    require "io/console"
+    File.open("/dev/tty", "r+") do |tty|
+      tty.getpass("Enter KeePassXC Master Password for #{File.basename(account)}: ")
+    end
+  end
+
+  def run_command(*args, session:)
+    cmd = ["keepassxc-cli", *args]
+    stdout, stderr, status = Open3.capture3(*cmd, stdin_data: session)
+    raise "KeePassXC Error: #{stderr.strip}" unless status.success?
+    stdout.strip
+  end
+end

--- a/test/secrets/keepassxc_adapter_test.rb
+++ b/test/secrets/keepassxc_adapter_test.rb
@@ -1,0 +1,95 @@
+require "test_helper"
+
+class KeepassxcAdapterTest < SecretAdapterTestCase
+  setup do
+    @keepassxc = Kamal::Secrets::Adapters::Keepassxc.new
+  end
+
+  test "fetch specific secrets in local mode calling CLI" do
+    with_ci_mode(false) do
+      @keepassxc.stub :ask_for_password, "dummy_master_pass" do
+        @keepassxc.stub :run_command, "secret_value" do
+          secrets = @keepassxc.fetch([ "MY_SECRET" ], account: "/tmp/secrets.kdbx", from: "test-env")
+          assert_equal({ "MY_SECRET" => "secret_value" }, secrets)
+        end
+      end
+    end
+  end
+
+  test "fetch password field uses no -a flag" do
+    with_ci_mode(false) do
+      @keepassxc.stub :ask_for_password, "pass" do
+        verifier = ->(cmd, account, from, *args, session:) {
+          if args.include?("-a")
+            raise "Error: 'password' field should not use -a flag"
+          end
+          "pw_value"
+        }
+
+        @keepassxc.stub :run_command, verifier do
+          secrets = @keepassxc.fetch([ "password" ], account: "/tmp/db.kdbx", from: "entry")
+          assert_equal({ "password" => "pw_value" }, secrets)
+        end
+      end
+    end
+  end
+
+  test "fetch secrets in CI mode reads from ENV" do
+    with_ci_mode(true) do
+      with_env("MY_SECRET" => "env_value") do
+        secrets = @keepassxc.fetch([ "MY_SECRET" ], account: "ignore", from: "ignore")
+        assert_equal({ "MY_SECRET" => "env_value" }, secrets)
+      end
+    end
+  end
+
+  test "fetch secrets in CI mode fails fast if ENV missing" do
+    with_ci_mode(true) do
+      error = assert_raises(RuntimeError) do
+        @keepassxc.fetch([ "MISSING_SECRET" ], account: "ignore", from: "ignore")
+      end
+      assert_match /Missing ENV secret 'MISSING_SECRET' in CI mode/, error.message
+    end
+  end
+
+  test "login returns dummy session in CI mode" do
+    with_ci_mode(true) do
+      assert_equal "ci-session", @keepassxc.send(:login, "account")
+    end
+  end
+
+  test "dependency check is skipped in CI mode" do
+    with_ci_mode(true) do
+      # Should NOT raise even if we force cli_installed? to false
+      @keepassxc.stub :cli_installed?, false do
+        assert_nothing_raised { @keepassxc.send(:check_dependencies!) }
+      end
+    end
+  end
+
+  test "dependency check raises in local mode if CLI missing" do
+    with_ci_mode(false) do
+      @keepassxc.stub :cli_installed?, false do
+        assert_raises(RuntimeError) { @keepassxc.send(:check_dependencies!) }
+      end
+    end
+  end
+
+  private
+    def with_ci_mode(enabled)
+      key = "CI"
+      original = ENV[key]
+      ENV[key] = enabled ? "true" : nil
+      yield
+    ensure
+      ENV[key] = original
+    end
+
+    def with_env(values)
+      original = ENV.to_h
+      values.each { |k, v| ENV[k] = v }
+      yield
+    ensure
+      values.keys.each { |k| ENV[k] = original[k] }
+    end
+end

--- a/test/secrets/keepassxc_adapter_test.rb
+++ b/test/secrets/keepassxc_adapter_test.rb
@@ -5,52 +5,25 @@ class KeepassxcAdapterTest < SecretAdapterTestCase
     @keepassxc = Kamal::Secrets::Adapters::Keepassxc.new
   end
 
-  test "fetch via CLI (Local Mode)" do
+  test "fetch via CLI" do
     # Simulate when CLI is installed
     stub_ticks_with("keepassxc-cli --version 2> /dev/null", succeed: true)
 
     @keepassxc.stub :ask_for_password, "dummy_pass" do
       Open3.stubs(:capture3).with("keepassxc-cli", "show", "/tmp/secrets.kdbx", "test-env", "-a", "MY_SECRET", "-q", "--show-protected", stdin_data: "dummy_pass")
-        .returns(["cli_value", "", mock(success?: true)])
+        .returns([ "cli_value", "", mock(success?: true) ])
 
-      secrets = @keepassxc.fetch(["MY_SECRET"], account: "/tmp/secrets.kdbx", from: "test-env")
-      assert_equal({"MY_SECRET" => "cli_value"}, secrets)
+      secrets = @keepassxc.fetch([ "MY_SECRET" ], account: "/tmp/secrets.kdbx", from: "test-env")
+      assert_equal({ "MY_SECRET" => "cli_value" }, secrets)
     end
   end
 
-  test "fetch via ENV (Fallback/CI Mode)" do
-    # Simulate when CLI is missing
-    stub_ticks_with("keepassxc-cli --version 2> /dev/null", succeed: false)
-
-    with_env("MY_SECRET" => "env_value") do
-      @keepassxc.expects(:ask_for_password).never
-      Open3.expects(:capture3).never
-
-      secrets = @keepassxc.fetch(["MY_SECRET"], account: "ignore", from: "ignore")
-      assert_equal({"MY_SECRET" => "env_value"}, secrets)
-    end
-  end
-
-  test "fetch raises if CLI missing AND Env missing" do
+  test "check_dependencies! raises if CLI is missing" do
     stub_ticks_with("keepassxc-cli --version 2> /dev/null", succeed: false)
 
     error = assert_raises(RuntimeError) do
-      @keepassxc.fetch(["MISSING_SECRET"], account: "ignore", from: "ignore")
+      @keepassxc.send(:check_dependencies!)
     end
-    assert_match(/KeePassXC CLI is not Installed & secret 'MISSING_SECRET' is missing in ENV./, error.message)
-  end
-
-  test "check_dependencies! is no-op (supports fallback)" do
-    assert_nothing_raised { @keepassxc.send(:check_dependencies!) }
-  end
-
-  private
-
-  def with_env(values)
-    original = ENV.to_h
-    values.each { |k, v| ENV[k] = v }
-    yield
-  ensure
-    values.keys.each { |k| ENV[k] = original[k] }
+    assert_match(/KeePassXC CLI is not installed/, error.message)
   end
 end

--- a/test/secrets/keepassxc_adapter_test.rb
+++ b/test/secrets/keepassxc_adapter_test.rb
@@ -37,7 +37,7 @@ class KeepassxcAdapterTest < SecretAdapterTestCase
     error = assert_raises(RuntimeError) do
       @keepassxc.fetch(["MISSING_SECRET"], account: "ignore", from: "ignore")
     end
-    assert_match(/Secret 'MISSING_SECRET' is missing in ENV./, error.message)
+    assert_match(/KeePassXC CLI is not Installed & secret 'MISSING_SECRET' is missing in ENV./, error.message)
   end
 
   test "check_dependencies! is no-op (supports fallback)" do

--- a/test/secrets/keepassxc_adapter_test.rb
+++ b/test/secrets/keepassxc_adapter_test.rb
@@ -5,91 +5,52 @@ class KeepassxcAdapterTest < SecretAdapterTestCase
     @keepassxc = Kamal::Secrets::Adapters::Keepassxc.new
   end
 
-  test "fetch specific secrets in local mode calling CLI" do
-    with_ci_mode(false) do
-      @keepassxc.stub :ask_for_password, "dummy_master_pass" do
-        @keepassxc.stub :run_command, "secret_value" do
-          secrets = @keepassxc.fetch([ "MY_SECRET" ], account: "/tmp/secrets.kdbx", from: "test-env")
-          assert_equal({ "MY_SECRET" => "secret_value" }, secrets)
-        end
-      end
+  test "fetch via CLI (Local Mode)" do
+    # Simulate when CLI is installed
+    stub_ticks_with("keepassxc-cli --version 2> /dev/null", succeed: true)
+
+    @keepassxc.stub :ask_for_password, "dummy_pass" do
+      Open3.stubs(:capture3).with("keepassxc-cli", "show", "/tmp/secrets.kdbx", "test-env", "-a", "MY_SECRET", "-q", "--show-protected", stdin_data: "dummy_pass")
+        .returns(["cli_value", "", mock(success?: true)])
+
+      secrets = @keepassxc.fetch(["MY_SECRET"], account: "/tmp/secrets.kdbx", from: "test-env")
+      assert_equal({"MY_SECRET" => "cli_value"}, secrets)
     end
   end
 
-  test "fetch password field uses no -a flag" do
-    with_ci_mode(false) do
-      @keepassxc.stub :ask_for_password, "pass" do
-        verifier = ->(cmd, account, from, *args, session:) {
-          if args.include?("-a")
-            raise "Error: 'password' field should not use -a flag"
-          end
-          "pw_value"
-        }
+  test "fetch via ENV (Fallback/CI Mode)" do
+    # Simulate when CLI is missing
+    stub_ticks_with("keepassxc-cli --version 2> /dev/null", succeed: false)
 
-        @keepassxc.stub :run_command, verifier do
-          secrets = @keepassxc.fetch([ "password" ], account: "/tmp/db.kdbx", from: "entry")
-          assert_equal({ "password" => "pw_value" }, secrets)
-        end
-      end
+    with_env("MY_SECRET" => "env_value") do
+      @keepassxc.expects(:ask_for_password).never
+      Open3.expects(:capture3).never
+
+      secrets = @keepassxc.fetch(["MY_SECRET"], account: "ignore", from: "ignore")
+      assert_equal({"MY_SECRET" => "env_value"}, secrets)
     end
   end
 
-  test "fetch secrets in CI mode reads from ENV" do
-    with_ci_mode(true) do
-      with_env("MY_SECRET" => "env_value") do
-        secrets = @keepassxc.fetch([ "MY_SECRET" ], account: "ignore", from: "ignore")
-        assert_equal({ "MY_SECRET" => "env_value" }, secrets)
-      end
+  test "fetch raises if CLI missing AND Env missing" do
+    stub_ticks_with("keepassxc-cli --version 2> /dev/null", succeed: false)
+
+    error = assert_raises(RuntimeError) do
+      @keepassxc.fetch(["MISSING_SECRET"], account: "ignore", from: "ignore")
     end
+    assert_match(/Secret 'MISSING_SECRET' is missing in ENV./, error.message)
   end
 
-  test "fetch secrets in CI mode fails fast if ENV missing" do
-    with_ci_mode(true) do
-      error = assert_raises(RuntimeError) do
-        @keepassxc.fetch([ "MISSING_SECRET" ], account: "ignore", from: "ignore")
-      end
-      assert_match /Missing ENV secret 'MISSING_SECRET' in CI mode/, error.message
-    end
-  end
-
-  test "login returns dummy session in CI mode" do
-    with_ci_mode(true) do
-      assert_equal "ci-session", @keepassxc.send(:login, "account")
-    end
-  end
-
-  test "dependency check is skipped in CI mode" do
-    with_ci_mode(true) do
-      # Should NOT raise even if we force cli_installed? to false
-      @keepassxc.stub :cli_installed?, false do
-        assert_nothing_raised { @keepassxc.send(:check_dependencies!) }
-      end
-    end
-  end
-
-  test "dependency check raises in local mode if CLI missing" do
-    with_ci_mode(false) do
-      @keepassxc.stub :cli_installed?, false do
-        assert_raises(RuntimeError) { @keepassxc.send(:check_dependencies!) }
-      end
-    end
+  test "check_dependencies! is no-op (supports fallback)" do
+    assert_nothing_raised { @keepassxc.send(:check_dependencies!) }
   end
 
   private
-    def with_ci_mode(enabled)
-      key = "CI"
-      original = ENV[key]
-      ENV[key] = enabled ? "true" : nil
-      yield
-    ensure
-      ENV[key] = original
-    end
 
-    def with_env(values)
-      original = ENV.to_h
-      values.each { |k, v| ENV[k] = v }
-      yield
-    ensure
-      values.keys.each { |k| ENV[k] = original[k] }
-    end
+  def with_env(values)
+    original = ENV.to_h
+    values.each { |k, v| ENV[k] = v }
+    yield
+  ensure
+    values.keys.each { |k| ENV[k] = original[k] }
+  end
 end


### PR DESCRIPTION
Adds a KeePassXC adapter. Unlike cloud-based managers (1Password), KeePassXC is local-only.

https://keepassxc.org
https://github.com/keepassxreboot/keepassxc

This enables a consistent, local-first, offline friendly secret management setup which is perfect for a solo developer. KeePassXC’s encrypted database (.kdbx) file can live in an iCloud or Google Drive synced folder if you want cloud backups, while still keeping everything local-first by default.

Usage Example

.kamal/secrets

```Bash
SECRETS=$(kamal secrets fetch --adapter keepassxc --account $HOME/Path/To/Secrets.kdbx --from entry-title-here RAILS_MASTER_KEY KAMAL_REGISTRY_PASSWORD ANY_OTHER_ATTRIBUTE_SAVED_IN_ADVANCE_TAB_OF_AN_ENTRY

RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY ${SECRETS})
KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD ${SECRETS})
ANY_OTHER_ATTRIBUTE_SAVED_IN_ADVANCE_TAB_OF_AN_ENTRY=$(kamal secrets extract ANY_OTHER_ATTRIBUTE_SAVED_IN_ADVANCE_TAB_OF_AN_ENTRY ${SECRETS})
```

Happy to submit a PR to update these docs if this is merged.
https://kamal-deploy.org/docs/commands/secrets/
https://github.com/basecamp/kamal-site/blob/main/docs/commands/secrets.md