### PR TITLE
Enhance ERB rendering to trim blank lines in configuration files

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -32,7 +32,9 @@ class Kamal::Configuration
         if file.exist?
           # Newer Psych doesn't load aliases by default
           load_method = YAML.respond_to?(:unsafe_load) ? :unsafe_load : :load
-          YAML.send(load_method, ERB.new(File.read(file)).result).symbolize_keys
+          template = File.read(file)
+          rendered = ERB.new(template, trim_mode: "-").result
+          YAML.send(load_method, rendered).symbolize_keys
         else
           raise "Configuration file not found in #{file}"
         end


### PR DESCRIPTION
Hi,

This pull request update `Kamal::Configuration` so every deploy YAML (including destination-specific files like `deploy.staging.yml`) is rendered via `ERB.new(..., trim_mode: "-")`. Templates can now safely use `-%>` without leaving stray blank lines in the parsed config.

Example snippets:
````yaml
# deploy.yml.erb
service: app
servers:
  - <%= ENV['MAIN_IP'] %>
<% if ENV['EXTRA_IP'].presence -%>
  - <%= ENV['EXTRA_IP'] %>
<% end -%>
````

````yaml
# Without trim_mode: "-" (old behavior)
servers:
  - 1.1.1.1

  - 1.1.1.2

# With trim mode (new behavior)
servers:
  - 1.1.1.1
  - 1.1.1.2
````

Thank you for open-sourcing this project! 🫶

Have a good day,
Tortue Torche