### PR TITLE
Use VFS storage driver locally

### DIFF
--- a/test/integration/docker/deployer/boot.sh
+++ b/test/integration/docker/deployer/boot.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+# Use VFS storage driver locally to avoid overlayfs-on-overlayfs issues
+# Skip on GitHub Actions where the outer Docker is configured differently
+if [ -z "$GITHUB_ACTIONS" ]; then
+  mkdir -p /etc/docker
+  echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
+fi
+
 dockerd --max-concurrent-downloads 1 &
 
 exec sleep infinity


### PR DESCRIPTION
Changes in Docker 29 mean that we can't use the overlayfs storage driver inside Docker as the outer container already uses overlayfs and Linux doesn't support nesting.

Instead we'll use the VFS storage driver for local testing. We don't do this on GitHub Actions - there's we've instead got the outer Docker using vfs already and that seem to run the tests more quickly.