### PR TITLE
Disable the SSH eviction thread in tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,10 @@ ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT) if ENV["
 # Applies to remote commands only.
 SSHKit.config.backend = SSHKit::Backend::Printer
 
+# Disable connection pooling so we don't spawn the eviction thread as
+# there's no clean way to kill it after each test
+SSHKit::Backend::Netssh.pool = SSHKit::Backend::ConnectionPool.new(0)
+
 class SSHKit::Backend::Printer
   def upload!(local, location, **kwargs)
     local = local.string.inspect if local.respond_to?(:string)
@@ -37,10 +41,6 @@ class ActiveSupport::TestCase
   extend Rails::LineFiltering
 
   private
-    setup do
-      SSHKit::Backend::Netssh.pool.close_connections
-    end
-
     def stdouted
       capture(:stdout) { yield }.strip
     end


### PR DESCRIPTION
Sometimes we get errors like this in tests:

```
/home/runner/work/kamal/kamal/vendor/bundle/ruby/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/connection_pool.rb:139:in `block in run_eviction_loop': #<AnyInstance:Object> was instantiated in CliProxyTest#test_upgrade but it is receiving invocations within
another test. This can lead to unintended interactions between tests and hence unexpected test failures. Ensure that every test correctly cleans up any state that it introduces. (Mocha::StubbingError)
    from /home/runner/work/kamal/kamal/vendor/bundle/ruby/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/connection_pool.rb:135:in `loop'
    from /home/runner/work/kamal/kamal/vendor/bundle/ruby/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/connection_pool.rb:135:in `run_eviction_loop'
    from /home/runner/work/kamal/kamal/vendor/bundle/ruby/3.2.0/gems/sshkit-1.24.0/lib/sshkit/backends/connection_pool.rb:51:in `block in initialize'
```

The tests still pass, but lets disable the eviction thread to avoid the error.