### PR TITLE
Accessory file/directory owners + permissions

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -45,13 +45,14 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     with_lock do
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
-          accessory.files.each do |(local, file_config)|
-            remote = file_config[:path]
+          accessory.files.each do |(local, config)|
+            remote = config[:host_path]
             accessory.ensure_local_file_present(local)
 
             execute *accessory.make_directory_for(remote)
             upload! local, remote
-            execute :chmod, "755", remote
+            execute :chmod, config[:mode], remote
+            execute :chown, config[:owner], remote if config[:owner]
           end
         end
       end
@@ -63,8 +64,10 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     with_lock do
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
-          accessory.directories.keys.each do |host_path|
-            execute *accessory.make_directory(host_path)
+          accessory.directories.each do |(local, config)|
+            execute *accessory.make_directory(local)
+            execute :chmod, config[:mode], local if config[:mode]
+            execute :chown, config[:owner], local if config[:owner]
           end
         end
       end

--- a/lib/kamal/configuration/docs/accessory.yml
+++ b/lib/kamal/configuration/docs/accessory.yml
@@ -90,30 +90,54 @@ accessories:
     # Copying files
     #
     # You can specify files to mount into the container.
-    # The format is `local:remote`, where `local` is the path to the file on the local machine
-    # and `remote` is the path to the file in the container.
     #
     # They will be uploaded from the local repo to the host and then mounted.
-    #
     # ERB files will be evaluated before being copied.
     #
-    # You can also specify mount options after a third colon, such as `ro` for read-only
-    # or `z`/`Z` for SELinux labels
+    # You can use the string format: `local:remote` or `local:remote:options`
+    # where the options can be `ro` for read-only or `z`/`Z` for SELinux labels
     files:
       - config/my.cnf.erb:/etc/mysql/my.cnf
       - config/myoptions.cnf:/etc/mysql/myoptions.cnf:ro
       - config/certs:/etc/mysql/certs:ro,Z
+    #
+    # Or you can use the hash format for custom mode and ownership.
+    #
+    # Note: Setting `owner` requires root access:
+    files:
+      - local: config/secret.key
+        remote: /etc/mysql/secret.key
+        mode: "0600"
+        owner: "mysql:mysql"
+      - local: config/ca-cert.pem
+        remote: /etc/mysql/certs/ca-cert.pem
+        mode: "0644"
+        owner: "1000:1000"
+        options: "Z"
 
     # Directories
     #
     # You can specify directories to mount into the container. They will be created on the host
     # before being mounted.
     #
-    # You can also specify mount options after a third colon, such as `ro` for read-only
-    # or `z`/`Z` for SELinux labels:
+    # You can use the string format: `local:remote` or `local:remote:options`
+    # where the options can be `ro` for read-only or `z`/`Z` for SELinux labels
     directories:
       - mysql-logs:/var/log/mysql
       - mysql-data:/var/lib/mysql:z
+    #
+    # Or you can use the hash format for custom mode and ownership.
+    #
+    # Note: Setting `owner` requires root access:
+    directories:
+      - local: mysql-data
+        remote: /var/lib/mysql
+        mode: "0750"
+        owner: "mysql:mysql"
+      - local: mysql-logs
+        remote: /var/log/mysql
+        mode: "0755"
+        options: "z"
 
     # Volumes
     #

--- a/lib/kamal/configuration/validator.rb
+++ b/lib/kamal/configuration/validator.rb
@@ -36,6 +36,8 @@ class Kamal::Configuration::Validator
                 validate_array_of_or_type! value, example_value.first.class
               elsif key.to_s == "config"
                 validate_ssh_config!(value)
+              elsif key.to_s == "files" || key.to_s == "directories"
+                validate_paths!(value)
               else
                 validate_array_of! value, example_value.first.class
               end
@@ -138,6 +140,24 @@ class Kamal::Configuration::Validator
         # Booleans and Strings are allowed
       else
         type_error(TrueClass, FalseClass, String, Array)
+      end
+    end
+
+    def validate_paths!(paths)
+      validate_type! paths, Array
+
+      paths.each_with_index do |path, index|
+        with_context(index) do
+          validate_type! path, String, Hash
+
+          if path.is_a?(Hash)
+            %w[local remote mode owner options].each do |key|
+              with_context(key) do
+                validate_type! path[key], String if path.key?(key)
+              end
+            end
+          end
+        end
       end
     end
 

--- a/test/integration/accessory_test.rb
+++ b/test/integration/accessory_test.rb
@@ -5,6 +5,8 @@ class AccessoryTest < IntegrationTest
     kamal :accessory, :boot, :busybox
     assert_accessory_running :busybox
     assert_accessory_volume_mount_options :busybox
+    assert_accessory_file_mode_and_owner :busybox
+    assert_accessory_directory_mode_and_owner :busybox
 
     kamal :accessory, :stop, :busybox
     assert_accessory_not_running :busybox
@@ -63,6 +65,16 @@ class AccessoryTest < IntegrationTest
     def assert_accessory_volume_mount_options(name)
       mounts = docker_compose("exec vm1 docker inspect custom-busybox --format '{{json .Mounts}}'", capture: true)
       assert_match %r{/data.*"RW":false}, mounts, "Expected read-only mount option (:ro) to be applied"
+    end
+
+    def assert_accessory_file_mode_and_owner(name)
+      file_stat = docker_compose("exec vm1 stat -c '%a %u:%g' /root/custom-busybox/etc/busybox.conf", capture: true)
+      assert_match /640 1000:1000/, file_stat, "Expected file to have 640 mode and 1000:1000 owner"
+    end
+
+    def assert_accessory_directory_mode_and_owner(name)
+      dir_stat = docker_compose("exec vm1 stat -c '%a %u:%g' /root/custom-busybox/data", capture: true)
+      assert_match /750 1000:1000/, dir_stat, "Expected directory to have 750 mode and 1000:1000 owner"
     end
 
     def accessory_details(name)

--- a/test/integration/docker/deployer/app/config/busybox.conf
+++ b/test/integration/docker/deployer/app/config/busybox.conf
@@ -1,0 +1,3 @@
+# Test config file for busybox accessory
+# Used to verify file mode and owner settings
+setting=value

--- a/test/integration/docker/deployer/app/config/deploy.yml
+++ b/test/integration/docker/deployer/app/config/deploy.yml
@@ -41,8 +41,17 @@ accessories:
     cmd: sh -c 'echo "Starting busybox..."; trap exit term; while true; do sleep 1; done'
     roles:
       - web
+    files:
+      - local: config/busybox.conf
+        remote: /etc/busybox.conf
+        mode: "0640"
+        owner: "1000:1000"
     directories:
-      - data:/data:ro
+      - local: data
+        remote: /data
+        mode: "0750"
+        owner: "1000:1000"
+        options: "ro"
   busybox2:
     service: custom-busybox
     image: registry:4443/busybox:1.36.0


### PR DESCRIPTION
Allow the permissions and ownership of accessory files and directories to be specified in the configuration.

Specifying an owner requires the ssh users to have suitable access on the host machine.

Fixes #1376 (sort of). The defaults haven't changed but at least the mode if now configurable