### PR TITLE
Don't shellescape secrets fetch on the command line

### DIFF
--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -12,8 +12,9 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
     end
 
     results = adapter.fetch(secrets, **options.slice(:account, :from).symbolize_keys)
+    json = JSON.dump(results)
 
-    return_or_puts JSON.dump(results).shellescape, inline: options[:inline]
+    return_or_puts options[:inline] ? json.shellescape : json, inline: options[:inline]
   end
 
   desc "extract", "Extract a single secret from the results of a fetch call"

--- a/test/cli/secrets_test.rb
+++ b/test/cli/secrets_test.rb
@@ -3,7 +3,7 @@ require_relative "cli_test_case"
 class CliSecretsTest < CliTestCase
   test "fetch" do
     assert_equal \
-      "\\{\\\"foo\\\":\\\"oof\\\",\\\"bar\\\":\\\"rab\\\",\\\"baz\\\":\\\"zab\\\"\\}",
+      '{"foo":"oof","bar":"rab","baz":"zab"}',
       run_command("fetch", "foo", "bar", "baz", "--account", "myaccount", "--adapter", "test")
   end
 

--- a/test/secrets/aws_secrets_manager_adapter_test.rb
+++ b/test/secrets/aws_secrets_manager_adapter_test.rb
@@ -24,7 +24,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
       JSON
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "unknown1", "unknown2")))
+      JSON.parse(run_command("fetch", "unknown1", "unknown2"))
     end
 
     assert_equal [ "unknown1: Secrets Manager can't find the specified secret.", "unknown2: Secrets Manager can't find the specified secret." ].join(" "), error.message
@@ -62,7 +62,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "secret/KEY1", "secret/KEY2", "secret2/KEY3")))
+    json = JSON.parse(run_command("fetch", "secret/KEY1", "secret/KEY2", "secret2/KEY3"))
 
     expected_json = {
       "secret/KEY1"=>"VALUE1",
@@ -105,7 +105,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "secret", "secret2/KEY1")))
+    json = JSON.parse(run_command("fetch", "secret", "secret2/KEY1"))
 
     expected_json = {
       "secret"=>"a-string-secret",
@@ -137,7 +137,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "secret", "KEY1", "KEY2")))
+    json = JSON.parse(run_command("fetch", "--from", "secret", "KEY1", "KEY2"))
 
     expected_json = {
       "secret/KEY1"=>"VALUE1",
@@ -151,7 +151,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
     stub_ticks_with("aws --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "SECRET1")))
+      JSON.parse(run_command("fetch", "SECRET1"))
     end
     assert_equal "AWS CLI is not installed", error.message
   end
@@ -178,7 +178,7 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "secret", "KEY1", "KEY2", account: nil)))
+    json = JSON.parse(run_command("fetch", "--from", "secret", "KEY1", "KEY2", account: nil))
 
     expected_json = {
       "secret/KEY1"=>"VALUE1",

--- a/test/secrets/bitwarden_adapter_test.rb
+++ b/test/secrets/bitwarden_adapter_test.rb
@@ -8,7 +8,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("bw sync").returns("")
     stub_mypassword
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
+    json = JSON.parse(run_command("fetch", "mypassword"))
 
     expected_json = { "mypassword"=>"secret123" }
 
@@ -23,7 +23,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_noteitem
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "mynote")))
+      JSON.parse(run_command("fetch", "mynote"))
     end
     assert_match(/not a login type item/, error.message)
   end
@@ -35,7 +35,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("bw sync").returns("")
     stub_myitem
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "myitem", "field1", "field2", "field3")))
+    json = JSON.parse(run_command("fetch", "--from", "myitem", "field1", "field2", "field3"))
 
     expected_json = {
       "myitem/field1"=>"secret1", "myitem/field2"=>"blam", "myitem/field3"=>"fewgrwjgk"
@@ -51,7 +51,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("bw sync").returns("")
     stub_noteitem_with_fields
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mynotefields")))
+    json = JSON.parse(run_command("fetch", "mynotefields"))
 
     expected_json = {
       "mynotefields/field1"=>"secret1", "mynotefields/field2"=>"blam", "mynotefields/field3"=>"fewgrwjgk",
@@ -95,7 +95,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     JSON
 
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mypassword", "myitem/field1", "myitem/field2", "myitem2/field3")))
+    json = JSON.parse(run_command("fetch", "mypassword", "myitem/field1", "myitem/field2", "myitem2/field3"))
 
     expected_json = {
       "mypassword"=>"secret123", "myitem/field1"=>"secret1", "myitem/field2"=>"blam", "myitem2/field3"=>"fewgrwjgk"
@@ -120,7 +120,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("bw sync").returns("")
     stub_mypassword
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
+    json = JSON.parse(run_command("fetch", "mypassword"))
 
     expected_json = { "mypassword"=>"secret123" }
 
@@ -147,7 +147,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("bw sync").returns("")
     stub_mypassword
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
+    json = JSON.parse(run_command("fetch", "mypassword"))
 
     expected_json = { "mypassword"=>"secret123" }
 
@@ -174,7 +174,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks.with("BW_SESSION=0987654321 bw sync").returns("")
     stub_mypassword(session: "0987654321")
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
+    json = JSON.parse(run_command("fetch", "mypassword"))
 
     expected_json = { "mypassword"=>"secret123" }
 
@@ -185,7 +185,7 @@ class BitwardenAdapterTest < SecretAdapterTestCase
     stub_ticks_with("bw --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "mynote")))
+      JSON.parse(run_command("fetch", "mynote"))
     end
     assert_equal "Bitwarden CLI is not installed", error.message
   end

--- a/test/secrets/bitwarden_secrets_manager_adapter_test.rb
+++ b/test/secrets/bitwarden_secrets_manager_adapter_test.rb
@@ -6,7 +6,7 @@ class BitwardenSecretsManagerAdapterTest < SecretAdapterTestCase
     stub_login
 
     error = assert_raises RuntimeError do
-      (shellunescape(run_command("fetch")))
+      run_command("fetch")
     end
     assert_equal("You must specify what to retrieve from Bitwarden Secrets Manager", error.message)
   end
@@ -29,7 +29,7 @@ class BitwardenSecretsManagerAdapterTest < SecretAdapterTestCase
       ]
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "all")))
+    json = JSON.parse(run_command("fetch", "all"))
 
     expected_json = {
       "KAMAL_REGISTRY_PASSWORD"=>"some_password",
@@ -57,7 +57,7 @@ class BitwardenSecretsManagerAdapterTest < SecretAdapterTestCase
       ]
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "all", "--from", "82aeb5bd-6958-4a89-8197-eacab758acce")))
+    json = JSON.parse(run_command("fetch", "all", "--from", "82aeb5bd-6958-4a89-8197-eacab758acce"))
 
     expected_json = {
       "KAMAL_REGISTRY_PASSWORD"=>"some_password",
@@ -79,7 +79,7 @@ class BitwardenSecretsManagerAdapterTest < SecretAdapterTestCase
       }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "82aeb5bd-6958-4a89-8197-eacab758acce")))
+    json = JSON.parse(run_command("fetch", "82aeb5bd-6958-4a89-8197-eacab758acce"))
     expected_json = {
       "KAMAL_REGISTRY_PASSWORD"=>"some_password"
     }
@@ -107,7 +107,7 @@ class BitwardenSecretsManagerAdapterTest < SecretAdapterTestCase
       }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "82aeb5bd-6958-4a89-8197-eacab758acce", "6f8cdf27-de2b-4c77-a35d-07df8050e332")))
+    json = JSON.parse(run_command("fetch", "82aeb5bd-6958-4a89-8197-eacab758acce", "6f8cdf27-de2b-4c77-a35d-07df8050e332"))
     expected_json = {
       "KAMAL_REGISTRY_PASSWORD"=>"some_password",
       "MY_OTHER_SECRET"=>"my=wierd\"secret"
@@ -122,7 +122,7 @@ class BitwardenSecretsManagerAdapterTest < SecretAdapterTestCase
     stub_ticks_with("bws secret list", succeed: false).returns("Error:\n0: Received error message from server")
 
     error = assert_raises RuntimeError do
-      (shellunescape(run_command("fetch", "all")))
+      (run_command("fetch", "all"))
     end
     assert_equal("Could not read secrets from Bitwarden Secrets Manager", error.message)
   end
@@ -134,7 +134,7 @@ class BitwardenSecretsManagerAdapterTest < SecretAdapterTestCase
       .returns("Error:\n0: Received error message from server")
 
     error = assert_raises RuntimeError do
-      (shellunescape(run_command("fetch", "82aeb5bd-6958-4a89-8197-eacab758acce")))
+      (run_command("fetch", "82aeb5bd-6958-4a89-8197-eacab758acce"))
     end
     assert_equal("Could not read 82aeb5bd-6958-4a89-8197-eacab758acce from Bitwarden Secrets Manager", error.message)
   end
@@ -151,7 +151,7 @@ class BitwardenSecretsManagerAdapterTest < SecretAdapterTestCase
       }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "82aeb5bd-6958-4a89-8197-eacab758acce")))
+    json = JSON.parse(run_command("fetch", "82aeb5bd-6958-4a89-8197-eacab758acce"))
     expected_json = {
       "SSH_PRIVATE_KEY"=>"some_key\nwith_linebreak"
     }
@@ -164,7 +164,7 @@ class BitwardenSecretsManagerAdapterTest < SecretAdapterTestCase
     stub_ticks_with("bws project list", succeed: false)
 
     error = assert_raises RuntimeError do
-      (shellunescape(run_command("fetch", "all")))
+      (run_command("fetch", "all"))
     end
     assert_equal("Could not authenticate to Bitwarden Secrets Manager. Did you set a valid access token?", error.message)
   end
@@ -173,7 +173,7 @@ class BitwardenSecretsManagerAdapterTest < SecretAdapterTestCase
     stub_ticks_with("bws --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      shellunescape(run_command("fetch"))
+      run_command("fetch")
     end
     assert_equal "Bitwarden Secrets Manager CLI is not installed", error.message
   end

--- a/test/secrets/doppler_adapter_test.rb
+++ b/test/secrets/doppler_adapter_test.rb
@@ -32,7 +32,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "--from", "my-project/prd", "SECRET1", "FSECRET1", "FSECRET2")
+      run_command("fetch", "--from", "my-project/prd", "SECRET1", "FSECRET1", "FSECRET2")
     )
 
     expected_json = {
@@ -73,7 +73,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "SECRET1", "FSECRET1", "FSECRET2")
+      run_command("fetch", "SECRET1", "FSECRET1", "FSECRET2")
     )
 
     expected_json = {
@@ -84,7 +84,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
 
     assert_equal expected_json, json
 
-     ENV.delete("DOPPLER_TOKEN")
+    ENV.delete("DOPPLER_TOKEN")
   end
 
   test "fetch with folder in secret" do
@@ -114,7 +114,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "my-project/prd/SECRET1", "my-project/prd/FSECRET1", "my-project/prd/FSECRET2")
+      run_command("fetch", "my-project/prd/SECRET1", "my-project/prd/FSECRET1", "my-project/prd/FSECRET2")
     )
 
     expected_json = {
@@ -143,7 +143,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
     stub_ticks_with("doppler login -y", succeed: true).returns("")
     stub_ticks.with("doppler secrets get SECRET1 --json -p my-project -c prd").returns(single_item_json)
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "my-project/prd", "SECRET1")))
+    json = JSON.parse(run_command("fetch", "--from", "my-project/prd", "SECRET1"))
 
     expected_json = {
       "SECRET1"=>"secret1"
@@ -156,7 +156,7 @@ class DopplerAdapterTest < SecretAdapterTestCase
     stub_ticks_with("doppler --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "HOST", "PORT")))
+      JSON.parse(run_command("fetch", "HOST", "PORT"))
     end
 
     assert_equal "Doppler CLI is not installed", error.message

--- a/test/secrets/enpass_adapter_test.rb
+++ b/test/secrets/enpass_adapter_test.rb
@@ -5,7 +5,7 @@ class EnpassAdapterTest < SecretAdapterTestCase
     stub_ticks_with("enpass-cli version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "mynote")))
+      JSON.parse(run_command("fetch", "mynote"))
     end
 
     assert_equal "Enpass CLI is not installed", error.message
@@ -20,7 +20,7 @@ class EnpassAdapterTest < SecretAdapterTestCase
       [{"category":"computer","label":"SECRET_1","login":"","password":"my-password-1","title":"FooBar","type":"password"}]
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "FooBar/SECRET_1")))
+    json = JSON.parse(run_command("fetch", "FooBar/SECRET_1"))
 
     expected_json = { "FooBar/SECRET_1" => "my-password-1" }
 
@@ -40,7 +40,7 @@ class EnpassAdapterTest < SecretAdapterTestCase
       ]
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "FooBar/SECRET_1", "FooBar/SECRET_2")))
+    json = JSON.parse(run_command("fetch", "FooBar/SECRET_1", "FooBar/SECRET_2"))
 
     expected_json = { "FooBar/SECRET_1" => "my-password-1", "FooBar/SECRET_2" => "my-password-2" }
 
@@ -61,7 +61,7 @@ class EnpassAdapterTest < SecretAdapterTestCase
       ]
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "FooBar")))
+    json = JSON.parse(run_command("fetch", "FooBar"))
 
     expected_json = { "FooBar/SECRET_1" => "my-password-1", "FooBar/SECRET_2" => "my-password-2", "FooBar" => "my-password-3" }
 

--- a/test/secrets/gcp_secret_manager_adapter_test.rb
+++ b/test/secrets/gcp_secret_manager_adapter_test.rb
@@ -6,7 +6,7 @@ class GcpSecretManagerAdapterTest < SecretAdapterTestCase
     stub_authenticated
     stub_mypassword
 
-    json = JSON.parse(shellunescape(run_command("fetch", "mypassword")))
+    json = JSON.parse(run_command("fetch", "mypassword"))
 
     expected_json = { "default/mypassword"=>"secret123" }
 
@@ -20,7 +20,7 @@ class GcpSecretManagerAdapterTest < SecretAdapterTestCase
     stub_unauthenticated
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "mypassword")))
+      JSON.parse(run_command("fetch", "mypassword"))
     end
 
     assert_match(/could not login to gcloud/, error.message)
@@ -33,7 +33,7 @@ class GcpSecretManagerAdapterTest < SecretAdapterTestCase
     stub_items(1, project: "other-project")
     stub_items(2, project: "other-project")
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "other-project", "item1", "item2", "item3")))
+    json = JSON.parse(run_command("fetch", "--from", "other-project", "item1", "item2", "item3"))
 
     expected_json = {
       "other-project/item1"=>"secret1", "other-project/item2"=>"secret2", "other-project/item3"=>"secret3"
@@ -49,7 +49,7 @@ class GcpSecretManagerAdapterTest < SecretAdapterTestCase
     stub_items(1, project: "project-confidence")
     stub_items(2, project: "manhattan-project")
 
-    json = JSON.parse(shellunescape(run_command("fetch", "some-project/item1", "project-confidence/item2", "manhattan-project/item3")))
+    json = JSON.parse(run_command("fetch", "some-project/item1", "project-confidence/item2", "manhattan-project/item3"))
 
     expected_json = {
       "some-project/item1"=>"secret1", "project-confidence/item2"=>"secret2", "manhattan-project/item3"=>"secret3"
@@ -63,7 +63,7 @@ class GcpSecretManagerAdapterTest < SecretAdapterTestCase
     stub_authenticated
     stub_items(0, project: "some-project", version: "123")
 
-    json = JSON.parse(shellunescape(run_command("fetch", "some-project/item1/123")))
+    json = JSON.parse(run_command("fetch", "some-project/item1/123"))
 
     expected_json = {
       "some-project/item1"=>"secret1"
@@ -77,7 +77,7 @@ class GcpSecretManagerAdapterTest < SecretAdapterTestCase
     stub_authenticated
     stub_items(0, project: "some-project", version: "123", account: "email@example.com")
 
-    json = JSON.parse(shellunescape(run_command("fetch", "some-project/item1/123", account: "email@example.com")))
+    json = JSON.parse(run_command("fetch", "some-project/item1/123", account: "email@example.com"))
 
     expected_json = {
       "some-project/item1"=>"secret1"
@@ -91,7 +91,7 @@ class GcpSecretManagerAdapterTest < SecretAdapterTestCase
     stub_authenticated
     stub_items(0, project: "some-project", version: "123", impersonate_service_account: "service-user@example.com")
 
-    json = JSON.parse(shellunescape(run_command("fetch", "some-project/item1/123", account: "default|service-user@example.com")))
+    json = JSON.parse(run_command("fetch", "some-project/item1/123", account: "default|service-user@example.com"))
 
     expected_json = {
       "some-project/item1"=>"secret1"
@@ -105,7 +105,7 @@ class GcpSecretManagerAdapterTest < SecretAdapterTestCase
     stub_authenticated
     stub_items(0, project: "some-project", version: "123", account: "user@example.com", impersonate_service_account: "service-user@example.com,service-user2@example.com")
 
-    json = JSON.parse(shellunescape(run_command("fetch", "some-project/item1/123", account: "user@example.com|service-user@example.com,service-user2@example.com")))
+    json = JSON.parse(run_command("fetch", "some-project/item1/123", account: "user@example.com|service-user@example.com,service-user2@example.com"))
 
     expected_json = {
       "some-project/item1"=>"secret1"
@@ -119,7 +119,7 @@ class GcpSecretManagerAdapterTest < SecretAdapterTestCase
     stub_authenticated
     stub_items(0, project: "some-project", version: "123", account: "email@example.com", impersonate_service_account: "service-user@example.com")
 
-    json = JSON.parse(shellunescape(run_command("fetch", "some-project/item1/123", account: "email@example.com|service-user@example.com")))
+    json = JSON.parse(run_command("fetch", "some-project/item1/123", account: "email@example.com|service-user@example.com"))
 
     expected_json = {
       "some-project/item1"=>"secret1"
@@ -132,7 +132,7 @@ class GcpSecretManagerAdapterTest < SecretAdapterTestCase
     stub_gcloud_version(succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "item1")))
+      JSON.parse(run_command("fetch", "item1"))
     end
     assert_equal "gcloud CLI is not installed", error.message
   end

--- a/test/secrets/last_pass_adapter_test.rb
+++ b/test/secrets/last_pass_adapter_test.rb
@@ -52,7 +52,7 @@ class LastPassAdapterTest < SecretAdapterTestCase
         ]
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "SECRET1", "FOLDER1/FSECRET1", "FOLDER1/FSECRET2")))
+    json = JSON.parse(run_command("fetch", "SECRET1", "FOLDER1/FSECRET1", "FOLDER1/FSECRET2"))
 
     expected_json = {
       "SECRET1"=>"secret1",
@@ -98,7 +98,7 @@ class LastPassAdapterTest < SecretAdapterTestCase
         ]
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "FOLDER1", "FSECRET1", "FSECRET2")))
+    json = JSON.parse(run_command("fetch", "--from", "FOLDER1", "FSECRET1", "FSECRET2"))
 
     expected_json = {
       "FOLDER1/FSECRET1"=>"fsecret1",
@@ -115,7 +115,7 @@ class LastPassAdapterTest < SecretAdapterTestCase
     stub_ticks_with("lpass login email@example.com", succeed: true).returns("")
     stub_ticks.with("lpass show SECRET1 --json").returns(single_item_json)
 
-    json = JSON.parse(shellunescape(run_command("fetch", "SECRET1")))
+    json = JSON.parse(run_command("fetch", "SECRET1"))
 
     expected_json = {
       "SECRET1"=>"secret1"
@@ -128,7 +128,7 @@ class LastPassAdapterTest < SecretAdapterTestCase
     stub_ticks_with("lpass --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "SECRET1", "FOLDER1/FSECRET1", "FOLDER1/FSECRET2")))
+      JSON.parse(run_command("fetch", "SECRET1", "FOLDER1/FSECRET1", "FOLDER1/FSECRET2"))
     end
     assert_equal "LastPass CLI is not installed", error.message
   end

--- a/test/secrets/one_password_adapter_test.rb
+++ b/test/secrets/one_password_adapter_test.rb
@@ -45,7 +45,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
         ]
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3")))
+    json = JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1",
@@ -105,7 +105,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault", "myitem/section/SECRET1", "myitem/section/SECRET2", "myitem2/section2/SECRET3")))
+    json = JSON.parse(run_command("fetch", "--from", "op://myvault", "myitem/section/SECRET1", "myitem/section/SECRET2", "myitem2/section2/SECRET3"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1",
@@ -163,7 +163,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault/myitem")))
+    json = JSON.parse(run_command("fetch", "--from", "op://myvault/myitem"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1",
@@ -183,7 +183,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
       .with("op item get myitem --vault \"myvault\" --format \"json\" --account \"myaccount\" --fields \"label=section.SECRET1\"")
       .returns(single_item_json)
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1")))
+    json = JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1"
@@ -202,7 +202,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
       .with("op item get myitem --vault \"myvault\" --format \"json\" --account \"myaccount\" --session \"1234567890\" --fields \"label=section.SECRET1\"")
       .returns(single_item_json)
 
-    json = JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1")))
+    json = JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1"
@@ -215,7 +215,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     stub_ticks_with("op --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3")))
+      JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3"))
     end
     assert_equal "1Password CLI is not installed", error.message
   end

--- a/test/secrets/passbolt_adapter_test.rb
+++ b/test/secrets/passbolt_adapter_test.rb
@@ -50,7 +50,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "SECRET1", "FSECRET1", "FSECRET2")
+      run_command("fetch", "SECRET1", "FSECRET1", "FSECRET2")
     )
 
     expected_json = {
@@ -121,7 +121,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "--from", "my-project", "SECRET1", "FSECRET1", "FSECRET2")
+      run_command("fetch", "--from", "my-project", "SECRET1", "FSECRET1", "FSECRET2")
     )
 
     expected_json = {
@@ -192,7 +192,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "my-project/SECRET1", "my-project/FSECRET1", "my-project/FSECRET2")
+      run_command("fetch", "my-project/SECRET1", "my-project/FSECRET1", "my-project/FSECRET2")
     )
 
     expected_json = {
@@ -270,7 +270,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "my-project/SECRET1", "my-project/FSECRET1", "other-project/FSECRET2")
+      run_command("fetch", "my-project/SECRET1", "my-project/FSECRET1", "other-project/FSECRET2")
     )
 
     expected_json = {
@@ -355,7 +355,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "--from", "my-project/subfolder", "SECRET1", "FSECRET1", "FSECRET2")
+      run_command("fetch", "--from", "my-project/subfolder", "SECRET1", "FSECRET1", "FSECRET2")
     )
 
     expected_json = {
@@ -440,7 +440,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
       JSON
 
     json = JSON.parse(
-      shellunescape run_command("fetch", "my-project/subfolder/SECRET1", "my-project/subfolder/FSECRET1", "my-project/subfolder/FSECRET2")
+      run_command("fetch", "my-project/subfolder/SECRET1", "my-project/subfolder/FSECRET1", "my-project/subfolder/FSECRET2")
     )
 
     expected_json = {
@@ -456,7 +456,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
     stub_ticks_with("passbolt --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(shellunescape(run_command("fetch", "HOST", "PORT")))
+      JSON.parse(run_command("fetch", "HOST", "PORT"))
     end
 
     assert_equal "Passbolt CLI is not installed", error.message
@@ -472,7 +472,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
     stub_ticks.with("passbolt list resources --filter '(Name == \"SECRET1\" && FolderParentID == \"abc\\\\ def-123\")' --folder abc\\ def-123 --json")
       .returns('[{"id":"dd32963c","folder_parent_id":"abc def-123","name":"SECRET1","username":"","uri":"","password":"secret1","description":"","created_timestamp":"2025-02-21T06:04:23Z","modified_timestamp":"2025-02-21T06:04:23Z"}]')
 
-    json = JSON.parse(shellunescape(run_command("fetch", "my-project/SECRET1")))
+    json = JSON.parse(run_command("fetch", "my-project/SECRET1"))
 
     assert_equal({ "SECRET1"=>"secret1" }, json)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -136,8 +136,4 @@ class SecretAdapterTestCase < ActiveSupport::TestCase
       stub_ticks.with { |c| c == command && (succeed ? `true` : `false`) }
       Kamal::Secrets::Adapters::Base.any_instance.stubs(:`)
     end
-
-    def shellunescape(string)
-      "\"#{string}\"".undump.gsub(/\\([{}])/, "\\1")
-    end
 end


### PR DESCRIPTION
Output the raw JSON on the command line. This means that `kamal fetch` /`kamal extract` will now work correctly when run manually in a shell.

Fixes: #1007