### PR TITLE
Don't escape Docker env file values

### DIFF
--- a/lib/kamal/env_file.rb
+++ b/lib/kamal/env_file.rb
@@ -23,22 +23,13 @@ class Kamal::EnvFile
 
   private
     def docker_env_file_line(key, value)
-      "#{key}=#{escape_docker_env_file_value(value)}\n"
-    end
+      value = value.to_s
 
-    # Escape a value to make it safe to dump in a docker file.
-    def escape_docker_env_file_value(value)
-      # keep non-ascii(UTF-8) characters as it is
-      value.to_s.scan(/[\x00-\x7F]+|[^\x00-\x7F]+/).map do |part|
-        part.ascii_only? ? escape_docker_env_file_ascii_value(part) : part
-      end.join
-    end
+      # Docker env files don't support escape sequences, so newlines and null
+      # bytes cannot be represented. Raise an error rather than silently corrupt.
+      raise ArgumentError, "Env file values cannot contain newlines" if value.include?("\n")
+      raise ArgumentError, "Env file values cannot contain null bytes" if value.include?("\0")
 
-    def escape_docker_env_file_ascii_value(value)
-      # Doublequotes are treated literally in docker env files
-      # so remove leading and trailing ones and unescape any others
-      value.to_s.dump[1..-2]
-        .gsub(/\\"/, "\"")
-        .gsub(/\\#/, "#")
+      "#{key}=#{value}\n"
     end
 end

--- a/test/env_file_test.rb
+++ b/test/env_file_test.rb
@@ -57,21 +57,21 @@ class EnvFileTest < ActiveSupport::TestCase
       "foo" => "hello\\nthere"
     }
 
-    assert_equal "foo=hello\\\\nthere\n", \
+    # Literal backslash-n should be preserved, not double-escaped
+    assert_equal "foo=hello\\nthere\n", \
       Kamal::EnvFile.new(env).to_s
   ensure
     ENV.delete "PASSWORD"
   end
 
-  test "to_s newline" do
+  test "to_s newline raises" do
     env = {
       "foo" => "hello\nthere"
     }
 
-    assert_equal "foo=hello\\nthere\n", \
+    assert_raises ArgumentError do
       Kamal::EnvFile.new(env).to_s
-  ensure
-    ENV.delete "PASSWORD"
+    end
   end
 
   test "stringIO conversion" do


### PR DESCRIPTION
Docker env files normally pass the output of `key=value` pairs verbatim, so they don't need escaping.

But they also don't support literal newlines or null bytes.

Right now we escape the values, so that we can send the values through, but then you need to unescape them in your code.

It would be preferrable to send the values as is and raise if they contain a literal \n or \0. That way there's no unexpected escaping and the user is made aware of unsupported values.

As a workaround for the two unsupported values, you could base64 encode and then decode again in the docker entrypoint script.

This change will need to wait for a major version bump though as there are likely users depending on the current escaping behavior and silently changing it could break things.

Fixes: #1412 