### PR TITLE
Boot in parallel for roles on the same host

### DIFF
--- a/lib/kamal/configuration/boot.rb
+++ b/lib/kamal/configuration/boot.rb
@@ -22,4 +22,8 @@ class Kamal::Configuration::Boot
   def wait
     boot_config["wait"]
   end
+
+  def parallel_roles
+    boot_config["parallel_roles"]
+  end
 end

--- a/lib/kamal/configuration/docs/boot.yml
+++ b/lib/kamal/configuration/docs/boot.yml
@@ -4,16 +4,18 @@
 #
 # Kamal’s default is to boot new containers on all hosts in parallel. However, you can control this with the boot configuration.
 
-# Fixed group sizes
-#
-# Here, we boot 2 hosts at a time with a 10-second gap between each group:
 boot:
-  limit: 2
+
+  # The number or percentage of hosts to boot at a time.
+  # This can be an integer (e.g., 3) or a percentage string (e.g., 25%).
+  limit: 25%
+
+  # The number of seconds to wait between booting each group of hosts.
   wait: 10
 
-# Percentage of hosts
-#
-# Here, we boot 25% of the hosts at a time with a 2-second gap between each group:
-boot:
-  limit: 25%
-  wait: 2
+  # Whether to boot roles in parallel on a host.
+  #
+  # If a host has multiple roles, control whether they are booted in parallel or sequentially on that host.
+  #
+  # Defaults to false.
+  parallel_roles: true

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -53,6 +53,24 @@ class CliAppTest < CliTestCase
     end
   end
 
+  test "boot without parallel roles" do
+    # Without parallel_roles: on() called with all hosts, roles sequential per host
+    Kamal::Cli::App.any_instance.expects(:on).with("1.1.1.1").with_block_given.twice
+    Kamal::Cli::App.any_instance.expects(:on).with([ "1.1.1.1", "1.1.1.2", "1.1.1.3" ]).with_block_given.times(4)
+
+    run_command("boot", config: :without_parallel_roles, host: nil)
+  end
+
+  test "boot with parallel roles" do
+    # With parallel_roles: each role gets its own on() call
+    Kamal::Cli::App.any_instance.expects(:on).with("1.1.1.1").with_block_given.twice
+    Kamal::Cli::App.any_instance.expects(:on).with([ "1.1.1.1", "1.1.1.2", "1.1.1.3" ]).with_block_given.times(3)
+    Kamal::Cli::App.any_instance.expects(:on).with([ "1.1.1.1", "1.1.1.2" ]).with_block_given
+    Kamal::Cli::App.any_instance.expects(:on).with([ "1.1.1.1", "1.1.1.3" ]).with_block_given
+
+    run_command("boot", config: :with_parallel_roles, host: nil)
+  end
+
   test "boot errors don't leave lock in place" do
     Kamal::Cli::App.any_instance.expects(:using_version).raises(RuntimeError)
 

--- a/test/configuration/boot_test.rb
+++ b/test/configuration/boot_test.rb
@@ -1,54 +1,49 @@
 require "test_helper"
 
 class ConfigurationBootTest < ActiveSupport::TestCase
-  test "no group strategy" do
-    deploy = {
-      service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" }, builder: { "arch" => "amd64" },
-      servers: { "web" => [ "1.1.1.1", "1.1.1.2" ], "workers" => [ "1.1.1.3", "1.1.1.4" ] }
-    }
-
-    config = Kamal::Configuration.new(deploy)
+  test "no boot config" do
+    config = config_with_boot(nil)
 
     assert_nil config.boot.limit
     assert_nil config.boot.wait
+    assert_nil config.boot.parallel_roles
   end
 
   test "specific limit group strategy" do
-    deploy = {
-      service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" }, builder: { "arch" => "amd64" },
-      servers: { "web" => [ "1.1.1.1", "1.1.1.2" ], "workers" => [ "1.1.1.3", "1.1.1.4" ] },
-      boot: { "limit" => 3, "wait" => 2 }
-    }
-
-    config = Kamal::Configuration.new(deploy)
+    config = config_with_boot("limit" => 3, "wait" => 2)
 
     assert_equal 3, config.boot.limit
     assert_equal 2, config.boot.wait
   end
 
   test "percentage-based group strategy" do
-    deploy = {
-      service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" }, builder: { "arch" => "amd64" },
-      servers: { "web" => [ "1.1.1.1", "1.1.1.2" ], "workers" => [ "1.1.1.3", "1.1.1.4" ] },
-      boot: { "limit" => "50%", "wait" => 2 }
-    }
-
-    config = Kamal::Configuration.new(deploy)
+    config = config_with_boot("limit" => "50%", "wait" => 2)
 
     assert_equal 2, config.boot.limit
     assert_equal 2, config.boot.wait
   end
 
   test "percentage-based group strategy limit is at least 1" do
-    deploy = {
-      service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" }, builder: { "arch" => "amd64" },
-      servers: { "web" => [ "1.1.1.1", "1.1.1.2" ], "workers" => [ "1.1.1.3", "1.1.1.4" ] },
-      boot: { "limit" => "1%", "wait" => 2 }
-    }
-
-    config = Kamal::Configuration.new(deploy)
+    config = config_with_boot("limit" => "1%", "wait" => 2)
 
     assert_equal 1, config.boot.limit
     assert_equal 2, config.boot.wait
   end
+
+  test "parallel_roles" do
+    config = config_with_boot("parallel_roles" => true)
+
+    assert_equal true, config.boot.parallel_roles
+  end
+
+  private
+    def config_with_boot(boot)
+      deploy = {
+        service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" }, builder: { "arch" => "amd64" },
+        servers: { "web" => [ "1.1.1.1", "1.1.1.2" ], "workers" => [ "1.1.1.3", "1.1.1.4" ] },
+        boot: boot
+      }.compact
+
+      Kamal::Configuration.new(deploy)
+    end
 end

--- a/test/fixtures/deploy_with_parallel_roles.yml
+++ b/test/fixtures/deploy_with_parallel_roles.yml
@@ -1,0 +1,18 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+    - "1.1.1.2"
+  workers:
+    - "1.1.1.1"
+    - "1.1.1.3"
+builder:
+  arch: amd64
+
+registry:
+  username: user
+  password: pw
+
+boot:
+  parallel_roles: true

--- a/test/fixtures/deploy_without_parallel_roles.yml
+++ b/test/fixtures/deploy_without_parallel_roles.yml
@@ -1,0 +1,15 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+    - "1.1.1.2"
+  workers:
+    - "1.1.1.1"
+    - "1.1.1.3"
+builder:
+  arch: amd64
+
+registry:
+  username: user
+  password: pw

--- a/test/integration/app_test.rb
+++ b/test/integration/app_test.rb
@@ -60,6 +60,59 @@ class AppTest < IntegrationTest
     assert_app_directory_removed
   end
 
+  test "parallel roles" do
+    @app = "app_with_parallel_roles"
+
+    version = latest_app_version
+
+    kamal :deploy
+
+    assert_app_is_up version: version
+    assert_container_running host: :vm1, name: "app_with_parallel_roles-web-#{version}"
+    assert_container_running host: :vm1, name: "app_with_parallel_roles-workers-#{version}"
+    assert_container_running host: :vm2, name: "app_with_parallel_roles-web-#{version}"
+
+    kamal :app, :stop
+
+    assert_app_not_found
+
+    kamal :app, :start
+
+    wait_for_app_to_be_up
+
+    logs = kamal :app, :logs, capture: true
+    assert_match /role=web.* on vm1/, logs
+    assert_match /role=web.* on vm2/, logs
+    assert_match /role=workers.* on vm1/, logs
+
+    # Images runs once per host (not per role)
+    images = kamal :app, :images, capture: true
+    assert_match "App Host: vm1", images
+    assert_match "App Host: vm2", images
+    assert_equal 2, images.scan(/App Host:/).count
+
+    # Containers runs once per host (not per role)
+    containers = kamal :app, :containers, capture: true
+    assert_match "App Host: vm1", containers
+    assert_match "App Host: vm2", containers
+    assert_match "app_with_parallel_roles-web", containers
+    assert_match "app_with_parallel_roles-workers", containers
+    assert_equal 2, containers.scan(/App Host:/).count
+
+    # Exec runs per role per host: web on vm1, web on vm2, workers on vm1
+    exec_output = kamal :app, :exec, :hostname, capture: true
+    assert_match /app_with_parallel_roles-web-exec-.* on vm1/, exec_output
+    assert_match /app_with_parallel_roles-web-exec-.* on vm2/, exec_output
+    assert_match /app_with_parallel_roles-workers-exec-.* on vm1/, exec_output
+    assert_equal 3, exec_output.scan(/App Host:/).count
+
+    kamal :app, :maintenance
+    assert_app_in_maintenance
+
+    kamal :app, :live
+    assert_app_is_up
+  end
+
   test "custom error pages" do
     @app = "app_with_roles"
 

--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -28,7 +28,8 @@ RUN rm -rf /root/.ssh && \
     cd /app_with_custom_certificate && git init && git add . && git commit -am "Initial version" && \
     cd /app_with_roles && git init && git add . && git commit -am "Initial version" && \
     cd /app_with_traefik && git init && git add . && git commit -am "Initial version" && \
-    cd /app_with_proxied_accessory && git init && git add . && git commit -am "Initial version"
+    cd /app_with_proxied_accessory && git init && git add . && git commit -am "Initial version" && \
+    cd /app_with_parallel_roles && git init && git add . && git commit -am "Initial version"
 
 HEALTHCHECK --interval=1s CMD pgrep sleep
 

--- a/test/integration/docker/deployer/app_with_parallel_roles/Dockerfile
+++ b/test/integration/docker/deployer/app_with_parallel_roles/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry:4443/nginx:1-alpine-slim
+
+COPY default.conf /etc/nginx/conf.d/default.conf
+
+ARG COMMIT_SHA
+RUN echo $COMMIT_SHA > /usr/share/nginx/html/version && \
+    mkdir -p /usr/share/nginx/html/versions && \
+    echo "version" > /usr/share/nginx/html/versions/$COMMIT_SHA && \
+    echo "hidden" > /usr/share/nginx/html/versions/.hidden && \
+    echo "Up!" > /usr/share/nginx/html/up

--- a/test/integration/docker/deployer/app_with_parallel_roles/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_parallel_roles/config/deploy.yml
@@ -1,0 +1,35 @@
+service: app_with_parallel_roles
+image: app_with_parallel_roles
+servers:
+  web:
+    hosts:
+      - vm1
+      - vm2
+  workers:
+    hosts:
+      - vm1
+    cmd: sleep infinity
+deploy_timeout: 2
+drain_timeout: 2
+readiness_delay: 0
+boot:
+  parallel_roles: true
+proxy:
+  host: localhost
+  ssl: false
+  healthcheck:
+    interval: 1
+    timeout: 1
+    path: "/up"
+  response_timeout: 2
+  run:
+    registry: registry:4443
+registry:
+  server: registry:4443
+  username: root
+  password: root
+builder:
+  driver: docker
+  arch: <%= Kamal::Utils.docker_arch %>
+  args:
+    COMMIT_SHA: <%= `git rev-parse HEAD` %>

--- a/test/integration/docker/deployer/app_with_parallel_roles/default.conf
+++ b/test/integration/docker/deployer/app_with_parallel_roles/default.conf
@@ -1,0 +1,17 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/test/integration/docker/deployer/app_with_parallel_roles/error_pages/503.html
+++ b/test/integration/docker/deployer/app_with_parallel_roles/error_pages/503.html
@@ -1,0 +1,8 @@
+<html>
+  <head>
+    <title>503 Service Interrupted</title>
+  </head>
+  <body>
+    <p>Custom Maintenance Page: {{ .Message }}</p>
+  </body>
+</html>


### PR DESCRIPTION
If you have multiple roles on the same host, we'll boot them sequentially on that host. This may be important to avoid overloading the server but it's actually just there as a consequence of SSHKit's `on()` method only connecting once per host.

To allow roles to boot in parallel on the same host, add a new option:
```yaml
boot
  parallel_roles: true
```

This is implenented by adding a new `on_roles` method that uses a separate thread for each role.

It defaults to `false` though as underpowered servers may struggle with booting new containers in parallel.