### PR TITLE
Quote filter names in docker commands

### DIFF
--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -15,7 +15,7 @@ module Kamal::Commands
     end
 
     def container_id_for(container_name:, only_running: false)
-      docker :container, :ls, *("--all" unless only_running), "--filter", "name=^#{container_name}$", "--quiet"
+      docker :container, :ls, *("--all" unless only_running), "--filter", "'name=^#{container_name}$'", "--quiet"
     end
 
     def make_directory_for(remote_file)

--- a/lib/kamal/commands/proxy.rb
+++ b/lib/kamal/commands/proxy.rb
@@ -37,7 +37,7 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
   end
 
   def info
-    docker :ps, "--filter", "name=^#{container_name}$"
+    docker :ps, "--filter", "'name=^#{container_name}$'"
   end
 
   def version

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -99,7 +99,7 @@ class CliProxyTest < CliTestCase
 
   test "details" do
     run_command("details").tap do |output|
-      assert_match "docker ps --filter name=^kamal-proxy$", output
+      assert_match "docker ps --filter 'name=^kamal-proxy$'", output
     end
   end
 
@@ -179,7 +179,7 @@ class CliProxyTest < CliTestCase
       .returns(Kamal::Configuration::Proxy::Run::MINIMUM_VERSION)
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
-      .with(:docker, :container, :ls, "--all", "--filter", "name=^app-workers-latest$", "--quiet", "|", :xargs, :docker, :inspect, "--format", "'{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'")
+      .with(:docker, :container, :ls, "--all", "--filter", "'name=^app-workers-latest$'", "--quiet", "|", :xargs, :docker, :inspect, "--format", "'{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'")
       .returns("running").at_least_once # workers health check
 
     run_command("upgrade", "-y").tap do |output|
@@ -199,7 +199,7 @@ class CliProxyTest < CliTestCase
       assert_match "Uploading \"\\n\" to .kamal/apps/app/env/roles/web.env", output
       assert_match %r{docker run --detach --restart unless-stopped --name app-web-latest --network kamal --hostname 1.1.1.1-.* --env KAMAL_CONTAINER_NAME="app-web-latest" --env KAMAL_VERSION="latest" --env KAMAL_HOST="1.1.1.1" --env-file .kamal/apps/app/env/roles/web.env --log-opt max-size="10m" --label service="app" --label role="web" --label destination dhh/app:latest}, output
       assert_match "docker exec kamal-proxy kamal-proxy deploy app-web --target=\"12345678:80\" --deploy-timeout=\"6s\" --drain-timeout=\"30s\" --buffer-requests --buffer-responses --log-request-header=\"Cache-Control\" --log-request-header=\"Last-Modified\" --log-request-header=\"User-Agent\"", output
-      assert_match "docker container ls --all --filter name=^app-web-12345678$ --quiet | xargs docker stop", output
+      assert_match "docker container ls --all --filter 'name=^app-web-12345678$' --quiet | xargs docker stop", output
       assert_match "docker tag dhh/app:latest dhh/app:latest", output
       assert_match "/usr/bin/env mkdir -p .kamal", output
       assert_match "docker ps -q -a --filter label=service=app --filter status=created --filter status=exited --filter status=dead | tail -n +6 | while read container_id; do docker rm $container_id; done", output
@@ -218,7 +218,7 @@ class CliProxyTest < CliTestCase
       .returns(Kamal::Configuration::Proxy::Run::MINIMUM_VERSION)
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
-      .with(:docker, :container, :ls, "--all", "--filter", "name=^app-workers-latest$", "--quiet", "|", :xargs, :docker, :inspect, "--format", "'{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'")
+      .with(:docker, :container, :ls, "--all", "--filter", "'name=^app-workers-latest$'", "--quiet", "|", :xargs, :docker, :inspect, "--format", "'{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'")
       .returns("running").at_least_once # workers health check
 
     run_command("upgrade", "--rolling", "-y",).tap do |output|

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -103,7 +103,7 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "stop with version" do
     assert_equal \
-      "docker container ls --all --filter name=^app-web-123$ --quiet | xargs docker stop",
+      "docker container ls --all --filter 'name=^app-web-123$' --quiet | xargs docker stop",
       new_command.stop(version: "123").join(" ")
   end
 
@@ -379,7 +379,7 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "container_id_for" do
     assert_equal \
-      "docker container ls --all --filter name=^app-999$ --quiet",
+      "docker container ls --all --filter 'name=^app-999$' --quiet",
       new_command.container_id_for(container_name: "app-999").join(" ")
   end
 
@@ -420,14 +420,14 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "remove_container" do
     assert_equal \
-      "docker container ls --all --filter name=^app-web-999$ --quiet | xargs docker container rm",
+      "docker container ls --all --filter 'name=^app-web-999$' --quiet | xargs docker container rm",
       new_command.remove_container(version: "999").join(" ")
   end
 
   test "remove_container with destination" do
     @destination = "staging"
     assert_equal \
-      "docker container ls --all --filter name=^app-web-staging-999$ --quiet | xargs docker container rm",
+      "docker container ls --all --filter 'name=^app-web-staging-999$' --quiet | xargs docker container rm",
       new_command.remove_container(version: "999").join(" ")
   end
 

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -41,7 +41,7 @@ class CommandsProxyTest < ActiveSupport::TestCase
 
   test "proxy info" do
     assert_equal \
-      "docker ps --filter name=^kamal-proxy$",
+      "docker ps --filter 'name=^kamal-proxy$'",
       new_command.info.join(" ")
   end
 


### PR DESCRIPTION
Fixes an error on the Fish shell where it treats the '$' as part of a variable.

Fixes https://github.com/basecamp/kamal/issues/1691