### PR TITLE
feat(secrets): add proton pass secrets adapter

### DIFF
--- a/lib/kamal/secrets/adapters.rb
+++ b/lib/kamal/secrets/adapters.rb
@@ -5,6 +5,7 @@ module Kamal::Secrets::Adapters
     name = "last_pass" if name.downcase == "lastpass"
     name = "gcp_secret_manager" if name.downcase == "gcp"
     name = "bitwarden_secrets_manager" if name.downcase == "bitwarden-sm"
+    name = "proton_pass" if name.downcase == "proton-pass"
     adapter_class(name)
   end
 

--- a/lib/kamal/secrets/adapters/proton_pass.rb
+++ b/lib/kamal/secrets/adapters/proton_pass.rb
@@ -1,0 +1,43 @@
+class Kamal::Secrets::Adapters::ProtonPass < Kamal::Secrets::Adapters::Base
+  def requires_account?
+    false
+  end
+
+  private
+    def login(account)
+      unless loggedin?
+        system("pass-cli login")
+        raise RuntimeError, "Failed to login to Proton Pass" unless $?.success?
+      end
+    end
+
+    def loggedin?
+      `pass-cli info 2> /dev/null`
+      $?.success?
+    end
+
+    def fetch_secrets(secrets, from:, account:, session:)
+      prefixed_secrets(secrets, from: from).to_h do |secret|
+        path = generate_secret_path(secret)
+        output = `pass-cli item view #{path.shellescape} --output json 2>&1`.strip
+        raise RuntimeError, "Could not read #{path} from Proton Pass" unless $?.success?
+
+        [ secret, output ]
+      end
+    end
+
+    def generate_secret_path(secret)
+      parts = secret.split("/")
+      normalized = parts.length == 2 ? "#{secret}/password" : secret
+      "pass://#{normalized}"
+    end
+
+    def check_dependencies!
+      raise RuntimeError, "Proton Pass CLI is not installed" unless cli_installed?
+    end
+
+    def cli_installed?
+      `pass-cli --version 2> /dev/null`
+      $?.success?
+    end
+end

--- a/test/secrets/proton_pass_adapter_test.rb
+++ b/test/secrets/proton_pass_adapter_test.rb
@@ -1,0 +1,97 @@
+require "test_helper"
+
+class ProtonPassAdapterTest < SecretAdapterTestCase
+  test "fetch without CLI installed" do
+    stub_ticks_with("pass-cli --version 2> /dev/null", succeed: false)
+
+    error = assert_raises RuntimeError do
+      JSON.parse(run_command("fetch", "REGISTRY_PASSWORD"))
+    end
+
+    assert_equal "Proton Pass CLI is not installed", error.message
+  end
+
+  test "fetch single password field" do
+    stub_ticks_with("pass-cli --version 2> /dev/null", succeed: true)
+    stub_ticks_with("pass-cli info 2> /dev/null", succeed: true)
+
+    stub_ticks
+      .with("pass-cli item view pass://MyVault/MyItem/password --output json 2>&1")
+      .returns("secret123\n")
+
+    json = JSON.parse(run_command("fetch", "--from", "MyVault", "MyItem"))
+
+    expected_json = { "MyVault/MyItem" => "secret123" }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch specific field" do
+    stub_ticks_with("pass-cli --version 2> /dev/null", succeed: true)
+    stub_ticks_with("pass-cli info 2> /dev/null", succeed: true)
+
+    stub_ticks
+      .with("pass-cli item view pass://MyVault/MyItem/username --output json 2>&1")
+      .returns("myuser\n")
+
+    json = JSON.parse(run_command("fetch", "--from", "MyVault", "MyItem/username"))
+
+    expected_json = { "MyVault/MyItem/username" => "myuser" }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch multiple fields" do
+    stub_ticks_with("pass-cli --version 2> /dev/null", succeed: true)
+    stub_ticks_with("pass-cli info 2> /dev/null", succeed: true)
+
+    stub_ticks
+      .with("pass-cli item view pass://MyVault/MyItem/password --output json 2>&1")
+      .returns("secret123\n")
+
+    stub_ticks
+      .with("pass-cli item view pass://MyVault/MyItem/username --output json 2>&1")
+      .returns("myuser\n")
+
+    json = JSON.parse(run_command("fetch", "--from", "MyVault", "MyItem", "MyItem/username"))
+
+    expected_json = {
+      "MyVault/MyItem" => "secret123",
+      "MyVault/MyItem/username" => "myuser"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch from multiple vaults" do
+    stub_ticks_with("pass-cli --version 2> /dev/null", succeed: true)
+    stub_ticks_with("pass-cli info 2> /dev/null", succeed: true)
+
+    stub_ticks
+      .with("pass-cli item view pass://Vault1/Item1/password --output json 2>&1")
+      .returns("secret1\n")
+
+    stub_ticks
+      .with("pass-cli item view pass://Vault2/Item2/username --output json 2>&1")
+      .returns("user2\n")
+
+    json = JSON.parse(run_command("fetch", "Vault1/Item1", "Vault2/Item2/username"))
+
+    expected_json = {
+      "Vault1/Item1" => "secret1",
+      "Vault2/Item2/username" => "user2"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  private
+    def run_command(*command)
+      stdouted do
+        Kamal::Cli::Secrets.start \
+          [ *command,
+            "-c", "test/fixtures/deploy_with_accessories.yml",
+            "--adapter", "proton_pass" ]
+      end
+    end
+end


### PR DESCRIPTION
Proton Pass organizes secrets into vaults and items. The default attribute of each item is "password". Other attributes can be accessed by specifying them (e.g. MyItem/MyAttribute). The --from option specifies the vault path (e.g. --from MyVault)

The Proton Pass adapter does not use the --account option.

Site documentation PR: https://github.com/basecamp/kamal-site/pull/191