### PR TITLE
Add namespace option to builder configuration to prevent credential conflicts

### DIFF
--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -7,7 +7,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   delegate \
     :args, :secrets, :dockerfile, :target, :arches, :local_arches, :remote_arches, :remote,
     :pack?, :pack_builder, :pack_buildpacks,
-    :cache_from, :cache_to, :ssh, :provenance, :sbom, :driver, :docker_driver?,
+    :cache_from, :cache_to, :ssh, :provenance, :sbom, :driver, :docker_driver?, :namespace,
     to: :builder_config
 
   def clean
@@ -139,5 +139,9 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
 
     def platform_options(arches)
       argumentize "--platform", arches.map { |arch| "linux/#{arch}" }.join(",") if arches.any?
+    end
+
+    def namespaced_builder_name(base_name)
+      [ namespace, base_name ].compact.join("-")
     end
 end

--- a/lib/kamal/commands/builder/cloud.rb
+++ b/lib/kamal/commands/builder/cloud.rb
@@ -11,7 +11,7 @@ class Kamal::Commands::Builder::Cloud < Kamal::Commands::Builder::Base
 
   private
     def builder_name
-      driver.gsub(/[ \/]/, "-")
+      namespaced_builder_name(driver.gsub(/[ \/]/, "-"))
     end
 
     def inspect_buildx

--- a/lib/kamal/commands/builder/hybrid.rb
+++ b/lib/kamal/commands/builder/hybrid.rb
@@ -8,7 +8,7 @@ class Kamal::Commands::Builder::Hybrid < Kamal::Commands::Builder::Remote
 
   private
     def builder_name
-      "kamal-hybrid-#{driver}-#{remote_builder_name_suffix}"
+      namespaced_builder_name("kamal-hybrid-#{driver}-#{remote_builder_name_suffix}")
     end
 
     def create_local_buildx

--- a/lib/kamal/commands/builder/local.rb
+++ b/lib/kamal/commands/builder/local.rb
@@ -11,10 +11,11 @@ class Kamal::Commands::Builder::Local < Kamal::Commands::Builder::Base
 
   private
     def builder_name
-      if registry_config.local?
+      base_name = if registry_config.local?
         "kamal-local-registry-#{driver}"
       else
         "kamal-local-#{driver}"
       end
+      namespaced_builder_name(base_name)
     end
 end

--- a/lib/kamal/commands/builder/remote.rb
+++ b/lib/kamal/commands/builder/remote.rb
@@ -34,7 +34,7 @@ class Kamal::Commands::Builder::Remote < Kamal::Commands::Builder::Base
 
   private
     def builder_name
-      "kamal-remote-#{remote_builder_name_suffix}"
+      namespaced_builder_name("kamal-remote-#{remote_builder_name_suffix}")
     end
 
     def remote_context_name

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -89,6 +89,10 @@ class Kamal::Configuration::Builder
     builder_config.fetch("driver", "docker-container")
   end
 
+  def namespace
+    builder_config["namespace"]
+  end
+
   def pack_builder
     builder_config["pack"]["builder"] if pack?
   end

--- a/lib/kamal/configuration/docs/builder.yml
+++ b/lib/kamal/configuration/docs/builder.yml
@@ -119,6 +119,12 @@ builder:
   # If you want to use Docker Build Cloud (https://www.docker.com/products/build-cloud/), you can set the driver to:
   driver: cloud org-name/builder-name
 
+  # Namespace
+  #
+  # A namespace to prefix the builder name. This is useful when you have multiple
+  # projects using Kamal on the same machine to avoid builder name collisions:
+  namespace: my-project
+
   # Provenance
   #
   # It is used to configure provenance attestations for the build result.

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -103,6 +103,38 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "cloud builder with namespace" do
+    builder = new_builder_command(builder: { "arch" => [ "#{local_arch}" ], "driver" => "cloud docker-org-name/builder-name", "namespace" => "my-project" })
+    assert_equal "cloud", builder.name
+    assert_equal \
+      "docker buildx build --output=type=registry --platform linux/#{local_arch} --builder my-project-cloud-docker-org-name-builder-name -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
+      builder.push.join(" ")
+  end
+
+  test "local builder with namespace" do
+    builder = new_builder_command(builder: { "arch" => [ "amd64" ], "namespace" => "my-project" })
+    assert_equal "local", builder.name
+    assert_equal \
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder my-project-kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
+      builder.push.join(" ")
+  end
+
+  test "remote builder with namespace" do
+    builder = new_builder_command(builder: { "arch" => [ "#{remote_arch}" ], "remote" => "ssh://app@host", "namespace" => "my-project" })
+    assert_equal "remote", builder.name
+    assert_equal \
+      "docker buildx build --output=type=registry --platform linux/#{remote_arch} --builder my-project-kamal-remote-ssh---app-host -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
+      builder.push.join(" ")
+  end
+
+  test "hybrid builder with namespace" do
+    builder = new_builder_command(builder: { "arch" => [ "amd64", "arm64" ], "remote" => "ssh://app@127.0.0.1", "namespace" => "my-project" })
+    assert_equal "hybrid", builder.name
+    assert_equal \
+      "docker buildx build --output=type=registry --platform linux/amd64,linux/arm64 --builder my-project-kamal-hybrid-docker-container-ssh---app-127-0-0-1 -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
+      builder.push.join(" ")
+  end
+
   test "build args" do
     builder = new_builder_command(builder: { "args" => { "a" => 1, "b" => 2 } })
     assert_equal \


### PR DESCRIPTION
Context
=====

When users change Docker Hub (or another registry) accounts in `deploy.yml` after a successful deploy, kamal deploy fails with authorization errors. This occurs because
Docker `buildx` builders cache registry credentials, and when the builder name remains unchanged (e.g., "kamal-local-docker-container"), Docker reuses the existing builder with credentials from the previous account.

The `buildx` builder attempts to push using the new account credentials but still references cached layers from the old account, resulting in `"insufficient_scope: authorization failed"` errors. Users must manually run `kamal build remove` to clear the old builder before deploying with a new account.

Solution
========

We introduce a new **optional** `namespace` configuration option under the builder section that allows users to prefix builder names with a custom namespace. This enables users to isolate builders when switching Docker Hub accounts or when running multiple services on the same deployment host, preventing credential conflicts.

This approach was chosen over automatically including the service name in builder names because:

1. **Backward compatibility**: Existing deployments continue to work without any changes. The namespace option is opt-in, so there are no breaking changes for current users.
2. **Flexibility**: Users can choose their own namespace strategy. Some may want to namespace by project, by team, by environment, or by Docker Hub account. Automatically using the service name would be too rigid and might not match user needs.
3. **Explicit control**: Making it a configuration option makes the intent clear and gives users control over when and how to namespace their builders. Automatic service name inclusion could cause confusion if users don't understand why their builder names changed.
4. **Opt-in migration**: Users experiencing the credential conflict issue can add the namespace option to their deploy.yml and run `kamal build remove` to migrate, without affecting other users who aren't experiencing the problem.

Usage
=====

```yaml
builder:
  arch: amd64
  namespace: my-project
```

Fixes: #1383