### PR TITLE
Pass accessory volume through as is

### DIFF
--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -98,7 +98,7 @@ class Kamal::Configuration::Accessory
   end
 
   def volume_args
-    (specific_volumes + path_volumes(files) + path_volumes(directories)).flat_map(&:docker_args)
+    argumentize("--volume", specific_volumes) + (path_volumes(files) + path_volumes(directories)).flat_map(&:docker_args)
   end
 
   def option_args
@@ -170,13 +170,7 @@ class Kamal::Configuration::Accessory
     end
 
     def specific_volumes
-      (accessory_config["volumes"] || []).collect do |volume_string|
-        host_path, container_path, options = volume_string.split(":", 3)
-        Kamal::Configuration::Volume.new \
-          host_path: host_path,
-          container_path: container_path,
-          options: options
-      end
+      accessory_config["volumes"] || []
     end
 
     def path_volumes(paths)

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -162,6 +162,12 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "--volume", "/var/lib/redis:/data" ], @config.accessory(:redis).volume_args
   end
 
+  test "volume args with docker named volume" do
+    @deploy[:accessories]["redis"]["volumes"] = [ "redis_data:/data" ]
+    config = Kamal::Configuration.new(@deploy)
+    assert_equal [ "--volume", "redis_data:/data" ], config.accessory(:redis).volume_args
+  end
+
   test "dynamic file expansion" do
     @deploy[:accessories]["mysql"]["env"]["secret"] << "ENV_VAR:SECRET_VAR"
     @deploy[:accessories]["mysql"]["files"] << "test/fixtures/files/structure.sql.erb:/docker-entrypoint-initdb.d/structure.sql"


### PR DESCRIPTION
In 83ca5079, relative accessory volume were changed to be prefixed with $PWD. The reverts the regression.