### PR TITLE
Add support ssh-config to run-over-ssh

### DIFF
--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -11,7 +11,7 @@ module Kamal::Commands
     end
 
     def run_over_ssh(*command, host:)
-      "ssh#{ssh_proxy_args}#{ssh_keys_args} -t #{config.ssh.user}@#{host} -p #{config.ssh.port} '#{command.join(" ").gsub("'", "'\\\\''")}'"
+      "ssh#{ssh_config_args}#{ssh_proxy_args}#{ssh_keys_args} -t #{config.ssh.user}@#{host} -p #{config.ssh.port} '#{command.join(" ").gsub("'", "'\\\\''")}'"
     end
 
     def container_id_for(container_name:, only_running: false)
@@ -98,6 +98,19 @@ module Kamal::Commands
 
       def tags(**details)
         Kamal::Tags.from_config(config, **details)
+      end
+
+      def ssh_config_args
+        case config.ssh.config
+        when Array
+          config.ssh.config.map { |file| " -F #{file}" }.join
+        when String
+          " -F #{config.ssh.config}"
+        when true
+          "" # Use default SSH config
+        when false
+          " -F /dev/null" # Ignore SSH config
+        end
       end
 
       def ssh_proxy_args


### PR DESCRIPTION
Support the app to reference ssh.config settings when running "kamal app logs --follow" etc.

issue: #1755