### PR TITLE
Add healthcheck port configuration option

### DIFF
--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -114,10 +114,16 @@ proxy:
   # the deploy timeout, with a 5-second timeout for each request.
   #
   # Once the app is up, the proxy will stop hitting the healthcheck endpoint.
+  #
+  # By default, the healthcheck is performed on the same port as the target.
+  # If your healthcheck endpoint is exposed on a different port than your main
+  # application, you can specify it with the port option. This is useful when
+  # your app exposes health endpoints on a dedicated port.
   healthcheck:
     interval: 3
     path: /health
     timeout: 3
+    port: 3001  # Optional: use a different port for healthchecks
 
   # Buffering
   #

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -21,6 +21,10 @@ class Kamal::Configuration::Proxy
     proxy_config.fetch("app_port", 80)
   end
 
+  def healthcheck_port
+    proxy_config.dig("healthcheck", "port")
+  end
+
   def ssl?
     proxy_config.fetch("ssl", false)
   end
@@ -78,6 +82,7 @@ class Kamal::Configuration::Proxy
       "health-check-interval": seconds_duration(proxy_config.dig("healthcheck", "interval")),
       "health-check-timeout": seconds_duration(proxy_config.dig("healthcheck", "timeout")),
       "health-check-path": proxy_config.dig("healthcheck", "path"),
+      "health-check-port": healthcheck_port,
       "target-timeout": seconds_duration(proxy_config["response_timeout"]),
       "buffer-requests": proxy_config.fetch("buffering", { "requests": true }).fetch("requests", true),
       "buffer-responses": proxy_config.fetch("buffering", { "responses": true }).fetch("responses", true),

--- a/lib/kamal/configuration/validator/proxy.rb
+++ b/lib/kamal/configuration/validator/proxy.rb
@@ -32,6 +32,12 @@ class Kamal::Configuration::Validator::Proxy < Kamal::Configuration::Validator
           end
         end
       end
+
+      if healthcheck_port = config.dig("healthcheck", "port")
+        unless healthcheck_port.is_a?(Integer) && healthcheck_port > 0 && healthcheck_port <= 65535
+          error "healthcheck/port must be a valid port number (1-65535)"
+        end
+      end
     end
   end
 

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -321,6 +321,22 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "monitoring.example.com" ], @config.accessory(:monitoring).proxy.hosts
   end
 
+  test "proxy with custom healthcheck port" do
+    @deploy[:accessories]["monitoring"]["proxy"]["healthcheck"] = { "port" => 8080 }
+    config = Kamal::Configuration.new(@deploy)
+
+    assert_equal 8080, config.accessory(:monitoring).proxy.healthcheck_port
+    options = config.accessory(:monitoring).proxy.deploy_options
+    assert_equal 8080, options[:"health-check-port"]
+  end
+
+  test "proxy healthcheck port not set by default" do
+    @deploy[:accessories]["monitoring"]["proxy"]["app_port"] = 4321
+    config = Kamal::Configuration.new(@deploy)
+
+    assert_nil config.accessory(:monitoring).proxy.healthcheck_port
+  end
+
   test "can't set restart in options" do
     @deploy[:accessories]["mysql"]["options"] = { "restart" => "always" }
 


### PR DESCRIPTION
Allow healthchecks to use a different port than the main application port by adding a configurable `port` option under `proxy.healthcheck.port`.

When not specified, the healthcheck port is not set and kamal-proxy will use its default behavior. The port can be set to any valid port number (1-65535) and is passed to kamal-proxy via the --health-check-port parameter.

This is useful when applications expose health endpoints on a dedicated port separate from the main application port.