### PR TITLE
Add volume removal when removing accessories

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -223,10 +223,10 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     end
   end
 
-  desc "remove [NAME]", "Remove accessory container, image and data directory from host (use NAME=all to remove all accessories)"
+  desc "remove [NAME]", "Remove accessory container, image, data directory and volumes from host (use NAME=all to remove all accessories)"
   option :confirmed, aliases: "-y", type: :boolean, default: false, desc: "Proceed without confirmation question"
   def remove(name)
-    confirming "This will remove all containers, images and data directories for #{name}. Are you sure?" do
+    confirming "This will remove all containers, images, data directories and volumes for #{name}. Are you sure?" do
       with_lock do
         if name == "all"
           KAMAL.accessory_names.each { |accessory_name| remove_accessory(accessory_name) }
@@ -267,6 +267,20 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
           execute *accessory.remove_service_directory
+        end
+      end
+    end
+  end
+
+  desc "remove_volumes [NAME]", "Remove accessory Docker volumes from host", hide: true
+  def remove_volumes(name)
+    with_lock do
+      with_accessory(name) do |accessory, hosts|
+        if accessory.volume_names.any?
+          on(hosts) do
+            execute *KAMAL.auditor.record("Removed #{name} accessory volumes"), verbosity: :debug
+            execute *accessory.remove_volumes
+          end
         end
       end
     end
@@ -318,6 +332,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
       remove_container(name)
       remove_image(name)
       remove_service_directory(name)
+      remove_volumes(name)
     end
 
     def prepare(name)

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -5,6 +5,7 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
   delegate :service_name, :image, :hosts, :port, :files, :directories, :cmd,
            :network_args, :publish_args, :env_args, :volume_args, :label_args, :option_args,
            :secrets_io, :secrets_path, :env_directory, :proxy, :running_proxy?, :registry,
+           :volume_names,
            to: :accessory_config
 
   def initialize(config, name:)
@@ -104,6 +105,10 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
 
   def remove_image
     docker :image, :rm, "--force", image
+  end
+
+  def remove_volumes
+    docker :volume, :rm, *volume_names
   end
 
   def ensure_env_directory

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -113,6 +113,13 @@ class Kamal::Configuration::Accessory
     accessory_config["cmd"]
   end
 
+  def volume_names
+    specific_volumes.filter_map do |volume|
+      name = volume.split(":").first
+      name unless Pathname.new(name).absolute?  # Skip bind mounts (absolute paths)
+    end
+  end
+
   def running_proxy?
     accessory_config["proxy"].present?
   end

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -182,6 +182,21 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
       new_command(:mysql).remove_image.join(" ")
   end
 
+  test "remove volumes" do
+    @config[:accessories]["mysql"]["volumes"] = [ "mysql_data:/var/lib/mysql", "mysql_logs:/var/log/mysql" ]
+
+    assert_equal \
+      "docker volume rm mysql_data mysql_logs",
+      new_command(:mysql).remove_volumes.join(" ")
+  end
+
+  test "remove volumes excludes bind mounts" do
+    # redis already has /var/lib/redis:/data which is a bind mount
+    assert_equal \
+      "docker volume rm",
+      new_command(:redis).remove_volumes.join(" ")
+  end
+
   test "deploy" do
     assert_equal \
       "docker exec kamal-proxy kamal-proxy deploy custom-busybox --target=\"172.1.0.2:80\" --host=\"busybox.example.com\" --deploy-timeout=\"30s\" --drain-timeout=\"30s\" --buffer-requests --buffer-responses --log-request-header=\"Cache-Control\" --log-request-header=\"Last-Modified\" --log-request-header=\"User-Agent\"",

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -168,6 +168,24 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "--volume", "redis_data:/data" ], config.accessory(:redis).volume_args
   end
 
+  test "volume_names returns named volumes only" do
+    @deploy[:accessories]["redis"]["volumes"] = [
+      "redis_data:/data",
+      "/host/path:/container/path",
+      "another_volume:/mnt/vol:ro"
+    ]
+    config = Kamal::Configuration.new(@deploy)
+    assert_equal [ "redis_data", "another_volume" ], config.accessory(:redis).volume_names
+  end
+
+  test "volume_names returns empty array when no volumes" do
+    assert_equal [], @config.accessory(:mysql).volume_names
+  end
+
+  test "volume_names excludes bind mounts with absolute paths" do
+    assert_equal [], @config.accessory(:redis).volume_names
+  end
+
   test "dynamic file expansion" do
     @deploy[:accessories]["mysql"]["env"]["secret"] << "ENV_VAR:SECRET_VAR"
     @deploy[:accessories]["mysql"]["files"] << "test/fixtures/files/structure.sql.erb:/docker-entrypoint-initdb.d/structure.sql"


### PR DESCRIPTION
## Summary

When running `kamal accessory remove`, directories created via the `directories:` configuration are deleted from the host, but Docker volumes specified via the `volumes:` configuration are not removed. This creates an inconsistency in behavior.

Arguably, deleting host-mounted directories is more drastic than deleting Docker-managed volumes, yet only the former happens automatically. This PR adds volume deletion to match the directory deletion behavior, making `kamal accessory remove` fully clean up all accessory-related storage.

## Example Output

Before this change, `kamal accessory remove postgres-backup -y` would output:

```
INFO Running docker container stop generate-postgres-backup on 192.168.1.86
INFO Running docker container prune --force --filter label=service=generate-postgres-backup on 192.168.1.86
INFO Running docker image rm --force timescale/timescaledb:latest-pg18 on 192.168.1.86
INFO Running /usr/bin/env rm -rf generate-postgres-backup on 192.168.1.86
```

After this change, an additional step removes Docker volumes:

```
INFO Running docker container stop generate-postgres-backup on 192.168.1.86
INFO Running docker container prune --force --filter label=service=generate-postgres-backup on 192.168.1.86
INFO Running docker image rm --force timescale/timescaledb:latest-pg18 on 192.168.1.86
INFO Running /usr/bin/env rm -rf generate-postgres-backup on 192.168.1.86
INFO Running docker volume rm generate-postgres-backups on 192.168.1.86  # <-- NEW
```

## Behavior

Given an accessory configured with:

```yaml
accessories:
  mysql:
    image: mysql:8.0
    host: 1.1.1.1
    volumes:
      - mysql-data:/var/lib/mysql        # Named volume - will be removed
      - /host/path:/container/path       # Bind mount - ignored (not a Docker volume)
    directories:
      - data:/var/lib/data               # Already removed by existing code
```

After this change, `kamal accessory remove mysql` will:

1. Stop the container (existing)
2. Remove the container (existing)
3. Remove the image (existing)
4. Remove the service directory (existing)
5. **Remove Docker volumes** (`docker volume rm mysql-data`) - NEW

Only named Docker volumes are removed. Bind mounts (paths starting with `/`) are correctly excluded since they're not Docker volumes.

## Changes

- Add `volume_names` method to `Configuration::Accessory` that extracts Docker volume names from the `volumes:` config (excluding bind mounts which use absolute paths starting with `/`)
- Add `remove_volumes` command to `Commands::Accessory` that runs `docker volume rm` for the accessory's named volumes
- Add `remove_volumes` CLI method and call it in `remove_accessory`
- Update the `remove` command description and confirmation message to mention volumes
- Add tests for the new functionality
