### PR TITLE
docs: Lightly improve the documentation of metrics_port

### DIFF
--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -153,9 +153,13 @@ proxy:
   # These options are used when booting the proxy container.
   #
   run:
-    http_port: 8080                # HTTP port to use (default 80)
-    https_port: 8443               # HTTPS port to use (default 443)
-    metrics_port: 9090             # Port for Prometheus metrics
+    http_port: 8080                # HTTP port to use (default: 80)
+    https_port: 8443               # HTTPS port to use (default: 443)
+    metrics_port: 9090             # Where to find prometheus metrics in your application
+                                   #
+                                   # The proxy will make available on 127.0.0.1:(port)/metrics
+                                   # any metrics you are serving on application:(port)/metrics.
+                                   # (default: nil)
     debug: true                    # Debug logging (default: false)
     log_max_size: "30m"            # Maximum log file size (default: "10m")
     publish: false                 # Publish ports to the host (default: true)


### PR DESCRIPTION
At the moment the documentation doesn't really say anything, but I think the important bit (That this proxies application level metrics and isn't just "metrics about kamal proxy will be served here") isn't mentioned at all anywhere.

This confused me and also seems to have confused a couple other people in github discussions!