### PR TITLE
Allow configurable verbosity for hooks output

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -6,6 +6,8 @@ require "erb"
 require "net/ssh/proxy/jump"
 
 class Kamal::Configuration
+  HOOKS_OUTPUT_LEVELS = [ :quiet, :verbose ].freeze
+
   delegate :service, :labels, :hooks_path, to: :raw_config, allow_nil: true
   delegate :argumentize, :optionize, to: Kamal::Utils
 
@@ -78,6 +80,7 @@ class Kamal::Configuration
     ensure_unique_hosts_for_ssl_roles
     ensure_local_registry_remote_builder_has_ssh_url
     ensure_no_conflicting_proxy_runs
+    ensure_valid_hooks_output!
   end
 
   def version=(version)
@@ -279,6 +282,15 @@ class Kamal::Configuration
     env_tags.detect { |t| t.name == name.to_s }
   end
 
+  def hooks_output_for(hook)
+    case raw_config.hooks_output
+    when Symbol, String
+      raw_config.hooks_output.to_sym
+    when Hash
+      raw_config.hooks_output[hook]&.to_sym
+    end
+  end
+
   def to_h
     {
       roles: role_names,
@@ -407,6 +419,21 @@ class Kamal::Configuration
 
     def role_names
       raw_config.servers.is_a?(Array) ? [ "web" ] : raw_config.servers.keys.sort
+    end
+
+    def ensure_valid_hooks_output!
+      case raw_config.hooks_output
+      when Symbol, String
+        validate_hooks_output_level!(raw_config.hooks_output.to_sym)
+      when Hash
+        raw_config.hooks_output.each { |hook, level| validate_hooks_output_level!(level.to_sym, hook) }
+      end
+    end
+
+    def validate_hooks_output_level!(level, hook = nil)
+      return if HOOKS_OUTPUT_LEVELS.include?(level)
+      context = hook ? " for hook '#{hook}'" : ""
+      raise Kamal::ConfigurationError, "Invalid hooks_output '#{level}'#{context}, must be one of: #{HOOKS_OUTPUT_LEVELS.join(', ')}"
     end
 
     def git_version

--- a/lib/kamal/configuration/docs/configuration.yml
+++ b/lib/kamal/configuration/docs/configuration.yml
@@ -85,6 +85,26 @@ asset_path: /path/to/assets
 # See https://kamal-deploy.org/docs/hooks for more information:
 hooks_path: /user_home/kamal/hooks
 
+# Hook output
+#
+# Hook output visibility. Can be set globally or per-hook.
+# CLI flags (`-v`, `-q`) override these settings.
+#
+# - `:quiet` - hook output is hidden
+# - `:verbose` - hook output is shown
+#
+# With no setting, hook output follows CLI verbosity flags.
+#
+# Note: Failed hooks always show output in the error message regardless of setting.
+#
+# Global setting for all hooks:
+hooks_output: :verbose
+
+# Or per-hook settings:
+hooks_output:
+  pre-deploy: :verbose
+  pre-build: :quiet
+
 # Secrets path
 #
 # Path to secrets, defaults to `.kamal/secrets`.

--- a/lib/kamal/configuration/validator.rb
+++ b/lib/kamal/configuration/validator.rb
@@ -29,6 +29,8 @@ class Kamal::Configuration::Validator
               end
             elsif key.to_s == "ssl"
                 validate_type! value, TrueClass, FalseClass, Hash
+            elsif key.to_s == "hooks_output"
+                validate_hooks_output!(value)
             elsif key == "hosts"
               validate_servers! value
             elsif example_value.is_a?(Array)
@@ -158,6 +160,19 @@ class Kamal::Configuration::Validator
             end
           end
         end
+      end
+    end
+
+    def validate_hooks_output!(value)
+      # hooks_output can be either a symbol/string (global) or a hash (per-hook)
+      if value.is_a?(Hash)
+        value.each do |hook, level|
+          with_context(hook) do
+            validate_type! level, String, Symbol
+          end
+        end
+      else
+        validate_type! value, String, Symbol
       end
     end
 

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -289,7 +289,7 @@ class CliMainTest < CliTestCase
       assert_hook_ran "pre-connect", output
       assert_match /Build and push app image/, output
       assert_hook_ran "pre-deploy", output
-      assert_match /Running the pre-deploy hook.../, output
+      assert_match /Running \/usr\/bin\/env .kamal\/hooks\/pre-deploy /, output
       assert_hook_ran "post-deploy", output
     end
   end

--- a/test/cli/server_test.rb
+++ b/test/cli/server_test.rb
@@ -61,7 +61,6 @@ class CliServerTest < CliTestCase
     run_command("bootstrap").tap do |output|
       ("1.1.1.1".."1.1.1.4").map do |host|
         assert_match "Missing Docker on #{host}. Installing…", output
-        assert_match "Running the docker-setup hook", output
       end
     end
   end

--- a/test/integration/docker/deployer/app/.kamal/hooks/post-deploy
+++ b/test/integration/docker/deployer/app/.kamal/hooks/post-deploy
@@ -1,3 +1,3 @@
 #!/bin/sh
-echo "Deployed!"
+echo "Finished deploy!"
 mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/post-deploy

--- a/test/integration/docker/deployer/app/config/deploy.yml
+++ b/test/integration/docker/deployer/app/config/deploy.yml
@@ -21,6 +21,9 @@ env:
       secret:
         - SECRET_TAG
 asset_path: /usr/share/nginx/html/versions:ro
+hooks_output:
+  pre-deploy: :verbose
+  pre-build: :quiet
 deploy_timeout: 2
 drain_timeout: 2
 readiness_delay: 0

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -6,9 +6,10 @@ class MainTest < IntegrationTest
 
     assert_app_is_down
 
-    kamal :deploy
+    deploy_output = kamal :deploy, capture: true
     assert_app_is_up version: first_version
     assert_hooks_ran "pre-connect", "pre-build", "pre-deploy", "pre-app-boot", "post-app-boot", "post-deploy"
+    assert_hook_output deploy_output
 
     assert_envs version: first_version
 
@@ -229,5 +230,17 @@ class MainTest < IntegrationTest
       assert_match /KAMAL_RECORDED_AT=\d\d\d\d-\d\d-\d\dT\d\d:\d\d:\d\dZ/, output
       assert_match "KAMAL_HOSTS=vm1,vm2", output
       assert_match "KAMAL_ROLES=web", output
+    end
+
+    def assert_hook_output(output)
+      # pre-deploy hook (hooks_output: :verbose) shows everything
+      assert_match(/Running.*pre-deploy/, output)
+      assert_match(/Deployed!/, output)
+      # pre-build hook (hooks_output: :quiet) hides everything
+      assert_no_match(/Running.*pre-build/, output)
+      assert_no_match(/About to build and push/, output)
+      # post-deploy hook (no hooks_output setting) shows Running but hides output
+      assert_match(/Running.*post-deploy/, output)
+      assert_no_match(/Finished deploy!/, output)
     end
 end


### PR DESCRIPTION
You can set a global or per-hook verbosity level for hook output.

Global:

```yaml
hooks_output: :verbose
```

Per hook:

```yaml
hooks_output:
  pre-deploy: :verbose
  pre-build: :quiet
```

Verbose shows the hook output, quiet hides it entirely (i.e no "Running the X hook..." message + "Finished..." messages).

Default is the standard SSHKit info setting which is just the Running/Finished messages.

The hooks_output setting is overridden by the CLI verbosity flags (-v and -q) if set.

Fixes: https://github.com/basecamp/kamal/issues/1243