### PR TITLE
Fix integration tests on hosts using nftables

### DIFF
--- a/test/integration/docker/deployer/boot.sh
+++ b/test/integration/docker/deployer/boot.sh
@@ -7,6 +7,11 @@ if [ -z "$GITHUB_ACTIONS" ]; then
   echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
 fi
 
+# On hosts using nftables, Docker can't create netfilter rules from inside a container.
+# iptables-legacy uses an older kernel interface that doesn't have this limitation.
+update-alternatives --set iptables /usr/sbin/iptables-legacy 2>/dev/null || true
+update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true
+
 dockerd --max-concurrent-downloads 1 &
 
 exec sleep infinity

--- a/test/integration/docker/vm/boot.sh
+++ b/test/integration/docker/vm/boot.sh
@@ -4,6 +4,11 @@ while [ ! -f /root/.ssh/authorized_keys ]; do echo "Waiting for ssh keys"; sleep
 
 service ssh restart
 
+# On hosts using nftables, Docker can't create netfilter rules from inside a container.
+# iptables-legacy uses an older kernel interface that doesn't have this limitation.
+update-alternatives --set iptables /usr/sbin/iptables-legacy 2>/dev/null || true
+update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true
+
 dockerd --max-concurrent-downloads 1 &
 
 exec sleep infinity


### PR DESCRIPTION
On hosts using nftables (the default on modern Linux distributions), Docker can't create netfilter rules from inside a container. This caused dockerd to fail to start in the test containers with:

  iptables v1.8.11 (nf_tables): CHAIN_ADD failed (No such file or directory)

iptables-legacy uses an older kernel interface that doesn't have this limitation.