### PR TITLE
feat(secrets): add phase.dev secrets adapter

### DIFF
--- a/lib/kamal/secrets/adapters/phase.rb
+++ b/lib/kamal/secrets/adapters/phase.rb
@@ -1,0 +1,113 @@
+class Kamal::Secrets::Adapters::Phase < Kamal::Secrets::Adapters::Base
+  def requires_account?
+    true  # Account is used for app name
+  end
+
+  private
+    def login(account)
+      # Check if already authenticated
+      unless authenticated?
+        # Interactive auth required
+        `phase auth`.tap do
+          raise RuntimeError, "Failed to authenticate with Phase. Run 'phase auth' to login" unless $?.success?
+        end
+      end
+      nil
+    end
+
+    def authenticated?
+      `phase users whoami 2> /dev/null`
+      $?.success?
+    end
+
+    def fetch_secrets(secrets, from:, account:, session:)
+      # Parse 'from' parameter to extract environment and path
+      # Format can be: "production" or "production/path/to/secrets"
+      env, path = parse_from(from)
+
+      if secrets.empty?
+        fetch_all_secrets(env: env, path: path, app: account)
+      else
+        fetch_specified_secrets(secrets, env: env, path: path, app: account)
+      end
+    end
+
+    def fetch_all_secrets(env:, path:, app:)
+      args = build_command_args("secrets", "export", env: env, path: path, app: app)
+      args += ["--format", "json"]
+
+      cmd = args.join(" ")
+      output = `#{cmd}`
+      raise RuntimeError, "Failed to fetch secrets from Phase. Ensure app '#{app}' exists and you have access" unless $?.success?
+
+      # Parse JSON output from phase secrets export
+      secrets_data = JSON.parse(output)
+
+      # Transform to expected format
+      {}.tap do |results|
+        secrets_data.each do |key, value|
+          # Build full path for the key
+          full_key = build_result_key(key, env: env, path: path)
+          results[full_key] = value
+        end
+      end
+    rescue JSON::ParserError => e
+      raise RuntimeError, "Failed to parse Phase CLI output: #{e.message}"
+    end
+
+    def fetch_specified_secrets(secrets, env:, path:, app:)
+      {}.tap do |results|
+        secrets.each do |secret_key|
+          args = build_command_args("secrets", "get", secret_key, env: env, path: path, app: app)
+          cmd = args.join(" ")
+
+          output = `#{cmd}`
+          raise RuntimeError, "Could not read '#{secret_key}' from Phase app '#{app}'" unless $?.success?
+
+          # Parse JSON output from phase secrets get
+          secret_data = JSON.parse(output)
+
+          # Build full path for the result key
+          full_key = build_result_key(secret_key, env: env, path: path)
+          results[full_key] = secret_data["value"]
+        end
+      end
+    rescue JSON::ParserError => e
+      raise RuntimeError, "Failed to parse Phase CLI output for secret: #{e.message}"
+    end
+
+    def parse_from(from)
+      return ["development", "/"] if from.blank?
+
+      parts = from.split("/", 2)
+      env = parts[0]
+      path = parts[1] ? "/#{parts[1]}" : "/"
+
+      [env, path]
+    end
+
+    def build_result_key(secret_key, env:, path:)
+      # Build hierarchical key: environment/path/secret_key
+      components = [env]
+      components << path.delete_prefix("/") if path != "/"
+      components << secret_key
+      components.join("/")
+    end
+
+    def build_command_args(*command_parts, env:, path:, app:)
+      args = ["phase"] + command_parts
+      args += ["--env", env.shellescape] if env
+      args += ["--app", app.shellescape] if app
+      args += ["--path", path.shellescape] if path && path != "/"
+      args
+    end
+
+    def check_dependencies!
+      raise RuntimeError, "Phase CLI is not installed. Install it from https://docs.phase.dev/cli/install" unless cli_installed?
+    end
+
+    def cli_installed?
+      `phase --version 2> /dev/null`
+      $?.success?
+    end
+end

--- a/test/secrets/phase_adapter_test.rb
+++ b/test/secrets/phase_adapter_test.rb
@@ -1,0 +1,114 @@
+require "test_helper"
+
+class PhaseAdapterTest < SecretAdapterTestCase
+  test "fetch without CLI installed" do
+    stub_ticks_with("phase --version 2> /dev/null", succeed: false)
+
+    error = assert_raises RuntimeError do
+      run_command("fetch", "SECRET1")
+    end
+    assert_equal "Phase CLI is not installed. Install it from https://docs.phase.dev/cli/install", error.message
+  end
+
+  test "fetch without authentication" do
+    stub_ticks.with("phase --version 2> /dev/null")
+    stub_ticks_with("phase users whoami 2> /dev/null", succeed: false)
+    stub_ticks_with("phase auth", succeed: false)
+
+    error = assert_raises RuntimeError do
+      run_command("fetch", "SECRET1")
+    end
+    assert_equal "Failed to authenticate with Phase. Run 'phase auth' to login", error.message
+  end
+
+  test "fetch specified secrets" do
+    stub_ticks.with("phase --version 2> /dev/null")
+    stub_authenticated
+    stub_ticks
+      .with("phase secrets get DB_PASSWORD --env production --app my-app --path /backend")
+      .returns(<<~JSON)
+        {
+          "value": "supersecret123"
+        }
+      JSON
+    stub_ticks
+      .with("phase secrets get API_KEY --env production --app my-app --path /backend")
+      .returns(<<~JSON)
+        {
+          "value": "api-key-456"
+        }
+      JSON
+
+    json = JSON.parse(run_command("fetch", "--from", "production/backend", "DB_PASSWORD", "API_KEY"))
+
+    expected_json = {
+      "production/backend/DB_PASSWORD" => "supersecret123",
+      "production/backend/API_KEY" => "api-key-456"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch all secrets" do
+    stub_ticks.with("phase --version 2> /dev/null")
+    stub_authenticated
+    stub_ticks
+      .with("phase secrets export --env production --app my-app --path /backend --format json")
+      .returns(<<~JSON)
+        {
+          "DB_PASSWORD": "supersecret123",
+          "API_KEY": "api-key-456",
+          "REDIS_URL": "redis://localhost:6379"
+        }
+      JSON
+
+    json = JSON.parse(run_command("fetch", "--from", "production/backend"))
+
+    expected_json = {
+      "production/backend/DB_PASSWORD" => "supersecret123",
+      "production/backend/API_KEY" => "api-key-456",
+      "production/backend/REDIS_URL" => "redis://localhost:6379"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch with nonexistent secret" do
+    stub_ticks.with("phase --version 2> /dev/null")
+    stub_authenticated
+    stub_ticks_with("phase secrets get NONEXISTENT --env production --app my-app", succeed: false)
+
+    error = assert_raises RuntimeError do
+      run_command("fetch", "--from", "production", "NONEXISTENT")
+    end
+    assert_equal "Could not read 'NONEXISTENT' from Phase app 'my-app'", error.message
+  end
+
+  test "fetch all with invalid app" do
+    stub_ticks.with("phase --version 2> /dev/null")
+    stub_authenticated
+    stub_ticks_with("phase secrets export --env production --app invalid-app --format json", succeed: false)
+      .returns("")
+
+    error = assert_raises RuntimeError do
+      run_command("fetch", "--from", "production", account: "invalid-app")
+    end
+    assert_equal "Failed to fetch secrets from Phase. Ensure app 'invalid-app' exists and you have access", error.message
+  end
+
+  private
+    def stub_authenticated
+      stub_ticks.with("phase users whoami 2> /dev/null")
+    end
+
+    def run_command(*command, account: "my-app")
+      stdouted do
+        args = [
+          *command,
+          "--adapter", "phase"
+        ]
+        args += [ "--account", account ] if account
+        Kamal::Cli::Secrets.start(args)
+      end
+    end
+end


### PR DESCRIPTION
This PR adds a secrets adapter for `phase.dev`. It's a simple secrets manager with a generous free plan, it's OSS and supports E2EE for all secrets

Docs: https://github.com/basecamp/kamal-site/pull/194