### PR TITLE
Add interactive rollback command

### DIFF
--- a/lib/kamal/commands/app.rb
+++ b/lib/kamal/commands/app.rb
@@ -73,6 +73,10 @@ class Kamal::Commands::App < Kamal::Commands::Base
       extract_version_from_name
   end
 
+  def list_versions_with_ages
+    docker(:ps, "--all", *container_filter_args, "--format", '"{{.Names}}\t{{.CreatedAt}}"')
+  end
+
   def ensure_env_directory
     make_directory role.env_directory
   end

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -439,6 +439,19 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command.list_versions("--latest", statuses: [ :running, :restarting ]).join(" ")
   end
 
+  test "list_versions_with_ages" do
+    assert_equal \
+      "docker ps --all --filter label=service=app --filter label=destination= --filter label=role=web --format \"{{.Names}}\\t{{.CreatedAt}}\"",
+      new_command.list_versions_with_ages.join(" ")
+  end
+
+  test "list_versions_with_ages with destination" do
+    @destination = "staging"
+    assert_equal \
+      "docker ps --all --filter label=service=app --filter label=destination=staging --filter label=role=web --format \"{{.Names}}\\t{{.CreatedAt}}\"",
+      new_command.list_versions_with_ages.join(" ")
+  end
+
   test "list_containers" do
     assert_equal \
       "docker container ls --all --filter label=service=app --filter label=destination= --filter label=role=web",


### PR DESCRIPTION
Based on @dhh’s suggestion (https://github.com/basecamp/kamal/discussions/621#discussioncomment-13035653), this PR improves the kamal rollback UX, specially for the “oh no, roll back now” moments.

### What changed

When running kamal rollback without a version argument, Kamal now shows an interactive picker of recent deployments with relative timestamps:

```
  Rollback to deployment from:

    1) 15 minutes ago (8b71ff79378b)
    2) 28 minutes ago (2b97f624d657)
    3) about an hour ago (faed64ff269f)

  Pick: [1]
```

* Defaults to the most recent deployment ([1]) for a fast, safe “just do it” rollback.
* Non-interactive rollback remains unchanged: passing a version argument or using --version continues to work exactly as before.

### Why

This reduces the cognitive load (and likelihood of mistakes) when rolling back under pressure by making the “recent known-good” options easy to identify and select.