### PR TITLE
Load secrets for pre-connect

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -173,7 +173,7 @@ module Kamal::Cli
 
       def pre_connect_if_required
         if !KAMAL.connected?
-          run_hook "pre-connect" unless options[:skip_hooks]
+          run_hook "pre-connect", secrets: true unless options[:skip_hooks]
           KAMAL.connected = true
         end
       end


### PR DESCRIPTION
This PR enables secrets for the `pre-connect` hook which is useful when you're connecting to something that needs an API key or an additional detail that's stored in secrets.

I noticed when looking at the `run_hook` calls that only `pre-deploy` and `post-deploy` currently load secrets, which was a bit confusing. I was thinking the initial core four hooks(pre-connect, pre-build, pre-deploy, post-deploy) would load secrets for you. 

There's nothing mentioned in the hook docs around loading secrets, it looks like loading those was added with the secrets upgrade(https://github.com/basecamp/kamal/pull/924). 