### PR TITLE
Add KeepassXC secrets adapter for kamal secrets

### DIFF
--- a/lib/kamal/cli/templates/secrets
+++ b/lib/kamal/cli/templates/secrets
@@ -11,8 +11,12 @@
 
 # Option 3: Read secrets via kamal secrets helpers
 # These will handle logging in and fetching the secrets in as few calls as possible
-# There are adapters for 1Password, LastPass + Bitwarden
+# There are adapters for 1Password, LastPass, Bitwarden, and KeepassXC
 #
 # SECRETS=$(kamal secrets fetch --adapter 1password --account my-account --from MyVault/MyItem KAMAL_REGISTRY_PASSWORD RAILS_MASTER_KEY)
+# KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD $SECRETS)
+# RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY $SECRETS)
+#
+# SECRETS=$(kamal secrets fetch --adapter keepassxc --from /path/to/vault.kdbx app/KAMAL_REGISTRY_PASSWORD app/RAILS_MASTER_KEY)
 # KAMAL_REGISTRY_PASSWORD=$(kamal secrets extract KAMAL_REGISTRY_PASSWORD $SECRETS)
 # RAILS_MASTER_KEY=$(kamal secrets extract RAILS_MASTER_KEY $SECRETS)

--- a/lib/kamal/secrets/adapters.rb
+++ b/lib/kamal/secrets/adapters.rb
@@ -5,6 +5,7 @@ module Kamal::Secrets::Adapters
     name = "last_pass" if name.downcase == "lastpass"
     name = "gcp_secret_manager" if name.downcase == "gcp"
     name = "bitwarden_secrets_manager" if name.downcase == "bitwarden-sm"
+    name = "keepassxc" if [ "keepass-xc", "keepass_xc", "keepass" ].include?(name.downcase)
     adapter_class(name)
   end
 

--- a/lib/kamal/secrets/adapters/keepassxc.rb
+++ b/lib/kamal/secrets/adapters/keepassxc.rb
@@ -1,0 +1,69 @@
+##
+# KeepassXC is an offline password manager that stores secrets in a local `.kdbx` database.
+#
+# Usage
+#
+# Fetch one password from an entry path:
+# `kamal secrets fetch --adapter keepassxc --from /path/to/vault.kdbx app/KAMAL_REGISTRY_PASSWORD`
+#
+# You can provide the database password through `KEEPASSXC_PASSWORD` for non-interactive runs.
+class Kamal::Secrets::Adapters::Keepassxc < Kamal::Secrets::Adapters::Base
+  PASSWORD_ATTRIBUTE = "Password"
+
+  def requires_account?
+    false
+  end
+
+  private
+    def login(*)
+      nil
+    end
+
+    def fetch_secrets(secrets, from:, **)
+      raise RuntimeError, "Missing database path from '--from=/path/to/database.kdbx' option" if from.blank?
+
+      prefixed_secrets(secrets, from: nil).to_h do |secret|
+        [ secret, fetch_secret(from, secret) ]
+      end
+    end
+
+    def fetch_secret(database_path, entry_path)
+      output = keepassxc_show(database_path, entry_path)
+      lines = output.to_s.lines.map(&:strip).reject(&:blank?)
+      password_line = lines.find { |line| line.match?(/\A#{PASSWORD_ATTRIBUTE}\s*:/i) }
+      value = password_line ? password_line.sub(/\A#{PASSWORD_ATTRIBUTE}\s*:\s*/i, "") : lines.last.to_s
+      value.strip
+    end
+
+    def keepassxc_show(database_path, entry_path)
+      command = [
+        "keepassxc-cli", "show", "--show-protected", "--attributes", PASSWORD_ATTRIBUTE,
+        *(password_stdin_flag), database_path.shellescape, entry_path.shellescape
+      ].join(" ")
+
+      `#{password_prefix}#{command}`.tap do
+        raise RuntimeError, "Could not read #{entry_path} from KeepassXC" unless $?.success?
+      end
+    end
+
+    def password_prefix
+      if ENV["KEEPASSXC_PASSWORD"].present?
+        "printf %s\\\\n #{ENV["KEEPASSXC_PASSWORD"].shellescape} | "
+      else
+        ""
+      end
+    end
+
+    def password_stdin_flag
+      ENV["KEEPASSXC_PASSWORD"].present? ? [ "--pw-stdin" ] : []
+    end
+
+    def check_dependencies!
+      raise RuntimeError, "KeepassXC CLI is not installed" unless cli_installed?
+    end
+
+    def cli_installed?
+      `keepassxc-cli --version 2> /dev/null`
+      $?.success?
+    end
+end

--- a/test/secrets/keepassxc_adapter_test.rb
+++ b/test/secrets/keepassxc_adapter_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+class KeepassxcAdapterTest < SecretAdapterTestCase
+  test "fetch one entry password" do
+    stub_ticks_with("keepassxc-cli --version 2> /dev/null", succeed: true)
+    stub_ticks
+      .with("keepassxc-cli show --show-protected --attributes Password vault-path app/KAMAL_REGISTRY_PASSWORD")
+      .returns("super-secret\n")
+
+    json = JSON.parse(run_command("fetch", "app/KAMAL_REGISTRY_PASSWORD"))
+
+    assert_equal({ "app/KAMAL_REGISTRY_PASSWORD" => "super-secret" }, json)
+  end
+
+  test "fetch parses labeled output" do
+    stub_ticks_with("keepassxc-cli --version 2> /dev/null", succeed: true)
+    stub_ticks
+      .with("keepassxc-cli show --show-protected --attributes Password vault-path app/DB_PASSWORD")
+      .returns("Password: db-secret\n")
+
+    json = JSON.parse(run_command("fetch", "app/DB_PASSWORD"))
+
+    assert_equal({ "app/DB_PASSWORD" => "db-secret" }, json)
+  end
+
+  test "fetch uses KEEPASSXC_PASSWORD when available" do
+    begin
+      ENV["KEEPASSXC_PASSWORD"] = "db-pass"
+
+      stub_ticks_with("keepassxc-cli --version 2> /dev/null", succeed: true)
+      command = "printf %s\\\\n db-pass | " \
+        "keepassxc-cli show --show-protected --attributes Password --pw-stdin " \
+        "vault-path app/RAILS_MASTER_KEY"
+      stub_ticks
+        .with(command)
+        .returns("rails-secret\n")
+
+      json = JSON.parse(run_command("fetch", "app/RAILS_MASTER_KEY"))
+
+      assert_equal({ "app/RAILS_MASTER_KEY" => "rails-secret" }, json)
+    ensure
+      ENV.delete("KEEPASSXC_PASSWORD")
+    end
+  end
+
+  test "fetch without --from" do
+    stub_ticks_with("keepassxc-cli --version 2> /dev/null", succeed: true)
+
+    error = assert_raises RuntimeError do
+      run_command_without_from("fetch", "app/KAMAL_REGISTRY_PASSWORD")
+    end
+
+    assert_equal "Missing database path from '--from=/path/to/database.kdbx' option", error.message
+  end
+
+  test "fetch without CLI installed" do
+    stub_ticks_with("keepassxc-cli --version 2> /dev/null", succeed: false)
+
+    error = assert_raises RuntimeError do
+      run_command("fetch", "app/KAMAL_REGISTRY_PASSWORD")
+    end
+
+    assert_equal "KeepassXC CLI is not installed", error.message
+  end
+
+  private
+    def run_command(*command)
+      stdouted do
+        Kamal::Cli::Secrets.start \
+          [ *command,
+            "-c", "test/fixtures/deploy_with_accessories.yml",
+            "--adapter", "keepassxc",
+            "--from", "vault-path" ]
+      end
+    end
+
+    def run_command_without_from(*command)
+      stdouted do
+        Kamal::Cli::Secrets.start \
+          [ *command,
+            "-c", "test/fixtures/deploy_with_accessories.yml",
+            "--adapter", "keepassxc" ]
+      end
+    end
+end


### PR DESCRIPTION
Introduce a KeepassXC adapter for , add adapter aliases, include adapter tests, and document KeepassXC usage in the secrets template.