### PR TITLE
Adds kamal accessory tunnel command for forwarding ports to accessories

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -143,6 +143,27 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     end
   end
 
+  desc "tunnel [NAME]", "Creates a ssh port forwarding tunnel to the accessory"
+  option :ports, type: :array, desc: "List of available ports to bind"
+  def tunnel(name)
+    with_accessory(name) do |accessory, hosts|
+      internal_accessory_host = ""
+      internal_accessory_ports = ""
+      available_ports = options[:ports].to_a.map { |port| Integer(port, exception: false) }.compact
+
+      on(hosts) do
+        internal_accessory_ports = capture_with_info(*accessory.internal_ports).split(" ")
+        internal_accessory_host = capture_with_info(*accessory.internal_host)
+      end
+
+      say "Starting port forwarding tunnel for #{name} accessory...", :magenta
+      run_locally do
+        info accessory.forward_ports(internal_accessory_host, internal_accessory_ports, available_ports: available_ports)
+        exec accessory.forward_ports(internal_accessory_host, internal_accessory_ports, available_ports: available_ports)
+      end
+    end
+  end
+
   desc "exec [NAME] [CMD...]", "Execute a custom command on servers within the accessory container (use --help to show options)"
   option :interactive, aliases: "-i", type: :boolean, default: false, desc: "Execute command over ssh for an interactive shell (use for console/bash)"
   option :reuse, type: :boolean, default: false, desc: "Reuse currently running container instead of starting a new one"

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -2,7 +2,7 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
   include Proxy
 
   attr_reader :accessory_config
-  delegate :service_name, :image, :hosts, :port, :files, :directories, :cmd,
+  delegate :service_name, :image, :hosts, :port, :files, :directories, :cmd, :network,
            :network_args, :publish_args, :env_args, :volume_args, :label_args, :option_args,
            :secrets_io, :secrets_path, :env_directory, :proxy, :running_proxy?, :registry,
            to: :accessory_config
@@ -39,6 +39,31 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
 
   def info(all: false, quiet: false)
     docker :ps, *("-a" if all), *("-q" if quiet), *service_filter
+  end
+
+  def internal_host
+    docker :inspect, service_name, "--format", "'{{.NetworkSettings.Networks.#{network}.IPAddress}}'"
+  end
+
+  def internal_ports
+    pipe(
+      docker(:inspect, service_name, "--format", "'{{range $k, $v := .NetworkSettings.Ports}}{{$k}} {{end}}'"),
+      grep("'/tcp'"),
+      sed("'s#/tcp##g'")
+    )
+  end
+
+  def forward_ports(internal_host, internal_ports, available_ports: [])
+    local_ports = available_ports.dup
+
+    forward_args = internal_ports.map do |internal_port|
+      local_port = local_ports.shift
+      local_port ||= internal_port
+
+      "-L #{local_port}:#{internal_host}:#{internal_port}"
+    end
+
+    run_over_ssh("", extra_ssh_args: " -o ExitOnForwardFailure=yes -N #{forward_args.join(" ")}")
   end
 
   def logs(timestamps: true, since: nil, lines: nil, grep: nil, grep_options: nil)
@@ -81,8 +106,8 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
     run_over_ssh execute_in_new_container(*command, interactive: true)
   end
 
-  def run_over_ssh(command)
-    super command, host: hosts.first
+  def run_over_ssh(command, extra_ssh_args: "")
+    super command, extra_ssh_args: extra_ssh_args, host: hosts.first
   end
 
   def ensure_local_file_present(local_file)

--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -10,8 +10,8 @@ module Kamal::Commands
       @config = config
     end
 
-    def run_over_ssh(*command, host:)
-      "ssh#{ssh_config_args}#{ssh_proxy_args}#{ssh_keys_args} -t #{config.ssh.user}@#{host} -p #{config.ssh.port} '#{command.join(" ").gsub("'", "'\\\\''")}'"
+    def run_over_ssh(*command, extra_ssh_args: "", host:)
+      "ssh#{ssh_config_args}#{ssh_proxy_args}#{ssh_keys_args}#{extra_ssh_args} -t #{config.ssh.user}@#{host} -p #{config.ssh.port} '#{command.join(" ").gsub("'", "'\\\\''")}'"
     end
 
     def container_id_for(container_name:, only_running: false)
@@ -94,6 +94,10 @@ module Kamal::Commands
 
       def grep(*args)
         args.compact.unshift :grep
+      end
+
+      def sed(*args)
+        args.compact.unshift :sed
       end
 
       def tags(**details)

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -41,6 +41,10 @@ class Kamal::Configuration::Accessory
     end
   end
 
+  def network
+    accessory_config["network"] || DEFAULT_NETWORK
+  end
+
   def network_args
     argumentize "--network", network
   end
@@ -256,10 +260,6 @@ class Kamal::Configuration::Accessory
           end
         end
       end
-    end
-
-    def network
-      accessory_config["network"] || DEFAULT_NETWORK
     end
 
     def ensure_valid_roles

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -117,6 +117,36 @@ class CliAccessoryTest < CliTestCase
     end
   end
 
+  test "tunnel" do
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+      .with(:docker, :inspect, "app-mysql", "--format", "'{{range $k, $v := .NetworkSettings.Ports}}{{$k}} {{end}}'", "|", :grep, "'/tcp'", "|", :sed, "'s#/tcp##g'")
+      .returns("3001")
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+      .with(:docker, :inspect, "app-mysql", "--format",  "'{{.NetworkSettings.Networks.kamal.IPAddress}}'")
+      .returns("1.1.2.1")
+    SSHKit::Backend::Abstract.any_instance.expects(:exec)
+      .with("ssh -o ExitOnForwardFailure=yes -N -L 3001:1.1.2.1:3001 -t root@1.1.1.3 -p 22 ''")
+
+    run_command("tunnel", "mysql").tap do |output|
+      assert_match "Starting port forwarding tunnel for mysql accessory...", output
+    end
+  end
+
+  test "tunnel with available ports" do
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+      .with(:docker, :inspect, "app-mysql", "--format", "'{{range $k, $v := .NetworkSettings.Ports}}{{$k}} {{end}}'", "|", :grep, "'/tcp'", "|", :sed, "'s#/tcp##g'")
+      .returns("3001 3002")
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+      .with(:docker, :inspect, "app-mysql", "--format",  "'{{.NetworkSettings.Networks.kamal.IPAddress}}'")
+      .returns("1.1.2.1")
+    SSHKit::Backend::Abstract.any_instance.expects(:exec)
+      .with("ssh -o ExitOnForwardFailure=yes -N -L 5001:1.1.2.1:3001 -L 5002:1.1.2.1:3002 -t root@1.1.1.3 -p 22 ''")
+
+    run_command("tunnel", "mysql", "--ports", "5001", "5002").tap do |output|
+      assert_match "Starting port forwarding tunnel for mysql accessory...", output
+    end
+  end
+
   test "exec" do
     run_command("exec", "mysql", "mysql -v").tap do |output|
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED]", output

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -107,6 +107,30 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
       new_command(:mysql).info.join(" ")
   end
 
+  test "internal host" do
+    assert_equal \
+      "docker inspect app-mysql --format '{{.NetworkSettings.Networks.kamal.IPAddress}}'",
+      new_command(:mysql).internal_host.join(" ")
+  end
+
+  test "internal ports" do
+    assert_equal \
+      "docker inspect app-mysql --format '{{range $k, $v := .NetworkSettings.Ports}}{{$k}} {{end}}' | grep '/tcp' | sed 's#/tcp##g'",
+      new_command(:mysql).internal_ports.join(" ")
+  end
+
+  test "forward ports" do
+    assert_equal \
+      "ssh -o ExitOnForwardFailure=yes -N -L 3001:1.1.2.1:3001 -t root@1.1.1.5 -p 22 ''",
+      new_command(:mysql).forward_ports("1.1.2.1", [ "3001" ])
+  end
+
+  test "forward ports with available ports specified" do
+    assert_equal \
+      "ssh -o ExitOnForwardFailure=yes -N -L 5001:1.1.2.1:3001 -L 3002:1.1.2.1:3002 -t root@1.1.1.5 -p 22 ''",
+      new_command(:mysql).forward_ports("1.1.2.1", [ "3001", "3002" ], available_ports: [ "5001" ])
+  end
+
   test "execute in new container" do
     assert_equal \
       "docker run --rm --network kamal --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0 mysql -u root",


### PR DESCRIPTION
# Problem
Having a setup where accessories are not exposing their ports, connecting to them via an ip and port from outside of the host can be annoying. Considering the default network setup, a maintaner of the application would have to fetch informations about the internal host&ports of the accessories, which as far as I understand are not stable, in order to create a ssh tunnel to the accessories.

A proposed solution is to have an accessory command which fetches the docker network host&ports and composes a ssh port forwarding command to provide a quick tunnel to the accessories.

# Description
This pull requests adds a `kamal accessory tunnel [ACCESSORY_NAME]` which fetches information about the host and all tcp ports exposed by the docker container housing the accessory and executes a ssh port forwarding command.

It also provides a `--ports=one two three` option that is treated by the command as preferential ports to use, in case the accessories ports are already bound on the users machine. 