### PR TITLE
Prepend .kamal/bin to PATH during hook execution

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -154,6 +154,7 @@ module Kamal::Cli
           end
 
           with_env KAMAL.hook.env(**details, **extra_details) do
+            prepend_kamal_bin_to_path
             KAMAL.with_verbosity(hook_verbosity) do
               run_locally do
                 execute *KAMAL.hook.run(hook)
@@ -213,7 +214,6 @@ module Kamal::Cli
       def with_env(env)
         current_env = ENV.to_h.dup
         ENV.update(env)
-        prepend_kamal_bin_to_path
         yield
       ensure
         ENV.clear

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -785,7 +785,7 @@ class CliMainTest < CliTestCase
     end
   end
 
-  test ".kamal/bin is prepended to PATH during hook execution" do
+  test ".kamal/bin is prepended to PATH by prepend_kamal_bin_to_path" do
     Dir.mktmpdir do |tmpdir|
       Dir.chdir(tmpdir) do
         FileUtils.mkdir_p(".kamal/bin")
@@ -794,12 +794,11 @@ class CliMainTest < CliTestCase
         original_path = ENV["PATH"]
         kamal_bin = File.expand_path(".kamal/bin")
 
-        cli.send(:with_env, { "FOO" => "bar" }) do
-          assert ENV["PATH"].start_with?("#{kamal_bin}#{File::PATH_SEPARATOR}"),
-            "Expected PATH to start with #{kamal_bin}, got: #{ENV["PATH"]}"
-        end
+        cli.send(:prepend_kamal_bin_to_path)
+        assert ENV["PATH"].start_with?("#{kamal_bin}#{File::PATH_SEPARATOR}"),
+          "Expected PATH to start with #{kamal_bin}, got: #{ENV["PATH"]}"
 
-        assert_equal original_path, ENV["PATH"], "PATH should be restored after with_env"
+        ENV["PATH"] = original_path
       end
     end
   end
@@ -810,9 +809,24 @@ class CliMainTest < CliTestCase
         cli = Kamal::Cli::Base.allocate
         original_path = ENV["PATH"]
 
+        cli.send(:prepend_kamal_bin_to_path)
+        assert_equal original_path, ENV["PATH"],
+          "PATH should be unchanged when .kamal/bin does not exist"
+      end
+    end
+  end
+
+  test "with_env does not prepend .kamal/bin to PATH" do
+    Dir.mktmpdir do |tmpdir|
+      Dir.chdir(tmpdir) do
+        FileUtils.mkdir_p(".kamal/bin")
+
+        cli = Kamal::Cli::Base.allocate
+        original_path = ENV["PATH"]
+
         cli.send(:with_env, { "FOO" => "bar" }) do
           assert_equal original_path, ENV["PATH"],
-            "PATH should be unchanged when .kamal/bin does not exist"
+            "with_env should not modify PATH"
         end
       end
     end


### PR DESCRIPTION
## Summary

- Hooks can now call executables in `.kamal/bin` without qualification
- `.kamal/bin` is prepended to `$PATH` inside `with_env`, which wraps every hook execution
- PATH is restored after each hook via the existing `ensure` block
- Same pattern as npm prepending `node_modules/.bin` for scripts

Stacked on #1784 (external commands).

## Example

```bash
# .kamal/hooks/post-configure can now call:
claims release beta3

# instead of:
.kamal/bin/claims release beta3
```

## Test plan

- [x] `.kamal/bin` is prepended to PATH when directory exists
- [x] PATH is unchanged when `.kamal/bin` is absent
- [x] PATH is restored after `with_env` returns