### PR TITLE
Allow aliases to include the destination

### DIFF
--- a/lib/kamal/cli/alias/command.rb
+++ b/lib/kamal/cli/alias/command.rb
@@ -1,8 +1,8 @@
 class Kamal::Cli::Alias::Command < Thor::DynamicCommand
   def run(instance, args = [])
-    if (_alias = KAMAL.config.aliases[name])
+    if (command = KAMAL.resolve_alias(name))
       KAMAL.reset
-      Kamal::Cli::Main.start(Shellwords.split(_alias.command) + ARGV[1..-1])
+      Kamal::Cli::Main.start(Shellwords.split(command) + ARGV[1..-1])
     else
       super
     end

--- a/lib/kamal/commander.rb
+++ b/lib/kamal/commander.rb
@@ -121,6 +121,15 @@ class Kamal::Commander
     config.aliases[name]
   end
 
+  def resolve_alias(name)
+    if @config
+      @config.aliases[name]&.command
+    else
+      raw_config = Kamal::Configuration.load_raw_config(**@config_kwargs.to_h.slice(:config_file, :destination))
+      raw_config[:aliases]&.dig(name)
+    end
+  end
+
   def with_verbosity(level)
     old_level = self.verbosity
 

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -20,9 +20,13 @@ class Kamal::Configuration
     def create_from(config_file:, destination: nil, version: nil)
       ENV["KAMAL_DESTINATION"] = destination
 
-      raw_config = load_config_files(config_file, *destination_config_file(config_file, destination))
+      raw_config = load_raw_config(config_file: config_file, destination: destination)
 
       new raw_config, destination: destination, version: version
+    end
+
+    def load_raw_config(config_file:, destination: nil)
+      load_config_files(config_file, *destination_config_file(config_file, destination))
     end
 
     private

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -605,6 +605,18 @@ class CliMainTest < CliTestCase
     end
   end
 
+  test "run an alias with require_destination" do
+    invoke_options = { "config_file" => "test/fixtures/deploy_for_required_dest.yml", "version" => "999", "skip_hooks" => false, "destination" => "world" }
+
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:boot", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:boot", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:prune:all", [], invoke_options)
+
+    run_command("world_deploy", config_file: "deploy_for_required_dest")
+  end
+
   test "run on primary via alias" do
     run_command("primary_details", config_file: "deploy_with_aliases").tap do |output|
       assert_match "App Host: 1.1.1.1", output

--- a/test/fixtures/deploy_for_required_dest.yml
+++ b/test/fixtures/deploy_for_required_dest.yml
@@ -7,3 +7,5 @@ registry:
 builder:
   arch: amd64
 require_destination: true
+aliases:
+  world_deploy: deploy -d world

--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -29,7 +29,8 @@ RUN rm -rf /root/.ssh && \
     cd /app_with_roles && git init && git add . && git commit -am "Initial version" && \
     cd /app_with_traefik && git init && git add . && git commit -am "Initial version" && \
     cd /app_with_proxied_accessory && git init && git add . && git commit -am "Initial version" && \
-    cd /app_with_parallel_roles && git init && git add . && git commit -am "Initial version"
+    cd /app_with_parallel_roles && git init && git add . && git commit -am "Initial version" && \
+    cd /app_with_destinations && git init && git add . && git commit -am "Initial version"
 
 HEALTHCHECK --interval=1s CMD pgrep sleep
 

--- a/test/integration/docker/deployer/app_with_destinations/Dockerfile
+++ b/test/integration/docker/deployer/app_with_destinations/Dockerfile
@@ -1,0 +1,10 @@
+FROM registry:4443/nginx:1-alpine-slim
+
+COPY default.conf /etc/nginx/conf.d/default.conf
+
+ARG COMMIT_SHA
+RUN echo $COMMIT_SHA > /usr/share/nginx/html/version && \
+    mkdir -p /usr/share/nginx/html/versions && \
+    echo "version" > /usr/share/nginx/html/versions/$COMMIT_SHA && \
+    echo "hidden" > /usr/share/nginx/html/versions/.hidden && \
+    echo "Up!" > /usr/share/nginx/html/up

--- a/test/integration/docker/deployer/app_with_destinations/config/deploy.production.yml
+++ b/test/integration/docker/deployer/app_with_destinations/config/deploy.production.yml
@@ -1,0 +1,3 @@
+servers:
+  - vm2
+  - vm3

--- a/test/integration/docker/deployer/app_with_destinations/config/deploy.staging.yml
+++ b/test/integration/docker/deployer/app_with_destinations/config/deploy.staging.yml
@@ -1,0 +1,2 @@
+servers:
+  - vm1

--- a/test/integration/docker/deployer/app_with_destinations/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_destinations/config/deploy.yml
@@ -1,0 +1,31 @@
+service: app_with_destinations
+image: app_with_destinations
+require_destination: true
+deploy_timeout: 2
+drain_timeout: 2
+readiness_delay: 0
+proxy:
+  run:
+    registry: registry:4443
+  host: localhost
+  ssl: false
+  healthcheck:
+    interval: 1
+    timeout: 1
+    path: "/up"
+  response_timeout: 2
+  forward_headers: true
+registry:
+  server: registry:4443
+  username: root
+  password: root
+builder:
+  driver: docker
+  arch: <%= Kamal::Utils.docker_arch %>
+  args:
+    COMMIT_SHA: <%= `git rev-parse HEAD` %>
+aliases:
+  staging_deploy: deploy -d staging
+  production_deploy: deploy -d production
+  staging_config: config -d staging
+  production_config: config -d production

--- a/test/integration/docker/deployer/app_with_destinations/default.conf
+++ b/test/integration/docker/deployer/app_with_destinations/default.conf
@@ -1,0 +1,17 @@
+server {
+    listen       80;
+    listen  [::]:80;
+    server_name  localhost;
+
+    location / {
+        root   /usr/share/nginx/html;
+        index  index.html index.htm;
+    }
+
+    # redirect server error pages to the static page /50x.html
+    #
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+}

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -99,6 +99,19 @@ class MainTest < IntegrationTest
     assert_match "GNU/Linux", output
   end
 
+  test "deploy with destinations" do
+    @app = "app_with_destinations"
+
+    kamal :staging_deploy
+    assert_app_is_up
+
+    config = YAML.load(kamal(:staging_config, capture: true))
+    assert_equal [ "vm1" ], config[:hosts]
+
+    config = YAML.load(kamal(:production_config, capture: true))
+    assert_equal [ "vm2", "vm3" ], config[:hosts]
+  end
+
   test "setup and remove" do
     kamal :proxy, :boot_config, "set",
       "--publish=false",


### PR DESCRIPTION
Preprocess the configuration to load the aliases. This allows us to have an alias that sets the destination (previously the destination was required before the config was loaded).

Allows things like:

```yaml
aliases:
  world_deploy: deploy -d world
```