### PR TITLE
Add default value for `secrets_path` parameter

### DIFF
--- a/lib/kamal/secrets.rb
+++ b/lib/kamal/secrets.rb
@@ -3,7 +3,7 @@ require "dotenv"
 class Kamal::Secrets
   Kamal::Secrets::Dotenv::InlineCommandSubstitution.install!
 
-  def initialize(destination: nil, secrets_path:)
+  def initialize(destination: nil, secrets_path: ".kamal/secrets")
     @destination = destination
     @secrets_path = secrets_path
     @mutex = Mutex.new

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -111,6 +111,12 @@ class SecretsTest < ActiveSupport::TestCase
     end
   end
 
+  test "default secrets_path" do
+    with_test_secrets("secrets" => "SECRET=ABC") do
+      assert_equal "ABC", Kamal::Secrets.new["SECRET"]
+    end
+  end
+
   test "custom secrets_path error message" do
     Dir.mktmpdir do |tmpdir|
       Dir.chdir(tmpdir) do


### PR DESCRIPTION
In my deploy.yml files, I often use `Kamal::Secrets` to fetch IP's like this:

```yml
cron:
  hosts:
    - <%= Kamal::Secrets.new["IP_PRODUCTION_UTILITY_1"] %>
    - <%= Kamal::Secrets.new["IP_PRODUCTION_UTILITY_2"] %>
```


After v2.9.0 the above call would throw the error `missing keyword: :secrets_path`.    
This PR adds a default value of `.kamal/secrets` to the `secrets_path` parameter, matching the existing default in `Kamal::Configuration`.