### PR TITLE
Secure accessory port bindings to localhost by default

### DIFF
--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -1,7 +1,10 @@
+require "ipaddr"
+
 class Kamal::Configuration::Accessory
   include Kamal::Configuration::Validation
 
   DEFAULT_NETWORK = "kamal"
+  LOCALHOST = "127.0.0.1"
 
   delegate :argumentize, :optionize, to: Kamal::Utils
 
@@ -17,6 +20,7 @@ class Kamal::Configuration::Accessory
       with: Kamal::Configuration::Validator::Accessory
 
     ensure_valid_roles
+    ensure_valid_port
 
     @env = initialize_env
     @proxy = initialize_proxy if running_proxy?
@@ -36,9 +40,7 @@ class Kamal::Configuration::Accessory
   end
 
   def port
-    if port = accessory_config["port"]&.to_s
-      port.include?(":") ? port : "#{port}:#{port}"
-    end
+    normalize_port(accessory_config["port"]&.to_s)
   end
 
   def network_args
@@ -119,6 +121,39 @@ class Kamal::Configuration::Accessory
 
   private
     attr_reader :config, :accessory_config
+
+    def normalize_port(port_config)
+      return unless port_config
+
+      binding, protocol = port_config.split("/", 2)
+
+      normalized_binding =
+        if binding.start_with?("[")
+          # IPv6: [::1]:host:container
+          ip = binding[/\A\[([^\]]+)\]/, 1]
+          validate_port_ip!(ip, port_config)
+          binding
+        elsif binding.count(":") >= 2
+          # IPv4: ip:host:container
+          ip = binding.split(":").first
+          validate_port_ip!(ip, port_config)
+          binding
+        elsif binding.count(":") == 1
+          # host:container — no IP given, default to localhost
+          "#{LOCALHOST}:#{binding}"
+        else
+          # container port only — expand to host:container and default to localhost
+          "#{LOCALHOST}:#{binding}:#{binding}"
+        end
+
+      protocol ? "#{normalized_binding}/#{protocol}" : normalized_binding
+    end
+
+    def validate_port_ip!(ip, port_config)
+      IPAddr.new(ip)
+    rescue IPAddr::InvalidAddressError
+      raise Kamal::ConfigurationError, "accessories/#{name}: invalid port configuration \"#{port_config}\""
+    end
 
     def initialize_env
       Kamal::Configuration::Env.new \
@@ -260,6 +295,10 @@ class Kamal::Configuration::Accessory
 
     def network
       accessory_config["network"] || DEFAULT_NETWORK
+    end
+
+    def ensure_valid_port
+      port
     end
 
     def ensure_valid_roles

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -139,8 +139,14 @@ class Kamal::Configuration::Accessory
           validate_port_ip!(ip, port_config)
           binding
         elsif binding.count(":") == 1
-          # host:container — no IP given, default to localhost
-          "#{LOCALHOST}:#{binding}"
+          host, container = binding.split(":", 2)
+          if valid_ip?(host)
+            # ip:port — expand to ip:port:port
+            "#{host}:#{container}:#{container}"
+          else
+            # host:container — no IP given, default to localhost
+            "#{LOCALHOST}:#{host}:#{container}"
+          end
         else
           # container port only — expand to host:container and default to localhost
           "#{LOCALHOST}:#{binding}:#{binding}"
@@ -149,9 +155,16 @@ class Kamal::Configuration::Accessory
       protocol ? "#{normalized_binding}/#{protocol}" : normalized_binding
     end
 
+    def valid_ip?(str)
+      IPAddr.new(str)
+      true
+    rescue IPAddr::InvalidAddressError, TypeError, ArgumentError
+      false
+    end
+
     def validate_port_ip!(ip, port_config)
       IPAddr.new(ip)
-    rescue IPAddr::InvalidAddressError
+    rescue IPAddr::InvalidAddressError, TypeError, ArgumentError
       raise Kamal::ConfigurationError, "accessories/#{name}: invalid port configuration \"#{port_config}\""
     end
 

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -245,7 +245,7 @@ class CliAccessoryTest < CliTestCase
       assert_match "Upgrading all accessories on 1.1.1.3,1.1.1.1,1.1.1.2...", output
       assert_match "docker network create kamal on 1.1.1.3", output
       assert_match "docker container stop app-mysql on 1.1.1.3", output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
       assert_match "Upgraded all accessories on 1.1.1.3,1.1.1.1,1.1.1.2...", output
     end
   end
@@ -255,7 +255,7 @@ class CliAccessoryTest < CliTestCase
       assert_match "Upgrading all accessories on 1.1.1.3...", output
       assert_match "docker network create kamal on 1.1.1.3", output
       assert_match "docker container stop app-mysql on 1.1.1.3", output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
       assert_match "Upgraded all accessories on 1.1.1.3", output
     end
   end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -15,7 +15,7 @@ class CliAccessoryTest < CliTestCase
 
     run_command("boot", "mysql").tap do |output|
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.3", output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
     end
   end
 
@@ -35,9 +35,9 @@ class CliAccessoryTest < CliTestCase
       assert_match /docker network create kamal.*on 1.1.1.1/, output
       assert_match /docker network create kamal.*on 1.1.1.2/, output
       assert_match /docker network create kamal.*on 1.1.1.3/, output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
       assert_match "docker run --name custom-box --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --env KAMAL_HOST=\"1.1.1.3\" --env-file .kamal/apps/app/env/accessories/busybox.env --label service=\"custom-box\" other.registry/busybox:latest on 1.1.1.3", output
     end
   end
@@ -223,7 +223,7 @@ class CliAccessoryTest < CliTestCase
     run_command("boot", "redis", "--hosts", "1.1.1.1").tap do |output|
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.1", output
       assert_no_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.2", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
       assert_no_match /docker run --name app-redis .* on 1.1.1.2/, output
     end
   end
@@ -235,7 +235,7 @@ class CliAccessoryTest < CliTestCase
     run_command("boot", "redis", "--hosts", "1.1.1.1,1.1.1.3").tap do |output|
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.1", output
       assert_no_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.3", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
       assert_no_match /docker run --name app-redis .* on 1.1.1.3/, output
     end
   end
@@ -245,7 +245,7 @@ class CliAccessoryTest < CliTestCase
       assert_match "Upgrading all accessories on 1.1.1.3,1.1.1.1,1.1.1.2...", output
       assert_match "docker network create kamal on 1.1.1.3", output
       assert_match "docker container stop app-mysql on 1.1.1.3", output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
       assert_match "Upgraded all accessories on 1.1.1.3,1.1.1.1,1.1.1.2...", output
     end
   end
@@ -255,15 +255,15 @@ class CliAccessoryTest < CliTestCase
       assert_match "Upgrading all accessories on 1.1.1.3...", output
       assert_match "docker network create kamal on 1.1.1.3", output
       assert_match "docker container stop app-mysql on 1.1.1.3", output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
       assert_match "Upgraded all accessories on 1.1.1.3", output
     end
   end
 
   test "boot with web role filter" do
     run_command("boot", "redis", "-r", "web").tap do |output|
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
     end
   end
 

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -61,11 +61,11 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
 
   test "run" do
     assert_equal \
-      "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
+      "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
       new_command(:mysql).run.join(" ")
 
     assert_equal \
-      "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env SOMETHING=\"else\" --env-file .kamal/apps/app/env/accessories/redis.env --volume /var/lib/redis:/data --label service=\"app-redis\" --label cache=\"true\" redis:latest",
+      "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env SOMETHING=\"else\" --env-file .kamal/apps/app/env/accessories/redis.env --volume /var/lib/redis:/data --label service=\"app-redis\" --label cache=\"true\" redis:latest",
       new_command(:redis).run.join(" ")
 
     assert_equal \
@@ -85,7 +85,7 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
     @config[:accessories]["mysql"]["network"] = "custom"
 
     assert_equal \
-      "docker run --name app-mysql --detach --restart unless-stopped --network custom --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
+      "docker run --name app-mysql --detach --restart unless-stopped --network custom --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
       new_command(:mysql).run.join(" ")
   end
 

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -156,6 +156,26 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_raises(Kamal::ConfigurationError) { Kamal::Configuration.new(@deploy).accessory(:mysql).port }
   end
 
+  test "port with ip:port expands to ip:port:port" do
+    @deploy[:accessories]["mysql"]["port"] = "127.0.0.1:3306"
+    assert_equal "127.0.0.1:3306:3306", Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "port with ip:port and protocol expands to ip:port:port/protocol" do
+    @deploy[:accessories]["mysql"]["port"] = "127.0.0.1:3306/tcp"
+    assert_equal "127.0.0.1:3306:3306/tcp", Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "port with IPv6 any address is preserved" do
+    @deploy[:accessories]["mysql"]["port"] = "[::]::3306"
+    assert_equal "[::]::3306", Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "port with malformed IPv6 bracket raises an error" do
+    @deploy[:accessories]["mysql"]["port"] = "[::1:3306:3306"
+    assert_raises(Kamal::ConfigurationError) { Kamal::Configuration.new(@deploy).accessory(:mysql).port }
+  end
+
   test "host" do
     assert_equal [ "1.1.1.5" ], @config.accessory(:mysql).hosts
     assert_equal [ "1.1.1.6", "1.1.1.7" ], @config.accessory(:redis).hosts

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -107,8 +107,53 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
   end
 
   test "port" do
-    assert_equal "3306:3306", @config.accessory(:mysql).port
-    assert_equal "6379:6379", @config.accessory(:redis).port
+    assert_equal "127.0.0.1:3306:3306", @config.accessory(:mysql).port
+    assert_equal "127.0.0.1:6379:6379", @config.accessory(:redis).port
+  end
+
+  test "port with no port config" do
+    @deploy[:accessories]["mysql"].delete("port")
+    assert_nil Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "port with container port only defaults to localhost" do
+    @deploy[:accessories]["mysql"]["port"] = "3306"
+    assert_equal "127.0.0.1:3306:3306", Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "port with host:container defaults to localhost" do
+    @deploy[:accessories]["mysql"]["port"] = "13306:3306"
+    assert_equal "127.0.0.1:13306:3306", Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "port with explicit IPv4 is preserved" do
+    @deploy[:accessories]["mysql"]["port"] = "0.0.0.0:3306:3306"
+    assert_equal "0.0.0.0:3306:3306", Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "port with explicit IPv6 is preserved" do
+    @deploy[:accessories]["mysql"]["port"] = "[::1]:3306:3306"
+    assert_equal "[::1]:3306:3306", Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "port with protocol suffix is preserved" do
+    @deploy[:accessories]["mysql"]["port"] = "3306:3306/udp"
+    assert_equal "127.0.0.1:3306:3306/udp", Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "port with explicit IP and protocol suffix is preserved" do
+    @deploy[:accessories]["mysql"]["port"] = "192.168.1.1:3306:3306/tcp"
+    assert_equal "192.168.1.1:3306:3306/tcp", Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "port with invalid IPv4 raises an error" do
+    @deploy[:accessories]["mysql"]["port"] = "999.999.999.999:3306:3306"
+    assert_raises(Kamal::ConfigurationError) { Kamal::Configuration.new(@deploy).accessory(:mysql).port }
+  end
+
+  test "port with invalid IPv6 raises an error" do
+    @deploy[:accessories]["mysql"]["port"] = "[not::valid::ip]:3306:3306"
+    assert_raises(Kamal::ConfigurationError) { Kamal::Configuration.new(@deploy).accessory(:mysql).port }
   end
 
   test "host" do

--- a/test/integration/docker/deployer/app_with_traefik/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_traefik/config/deploy.yml
@@ -29,7 +29,7 @@ accessories:
   traefik:
     service: traefik
     image: traefik:v2.10
-    port: 80
+    port: "0.0.0.0:80:80"
     cmd: "--providers.docker"
     options:
       volume:


### PR DESCRIPTION
Fixes https://github.com/basecamp/kamal/issues/1790.

This PR adds some opinionated validation of the accessory port configuration.

Accessory port mappings without an explicit host IP now bind to `127.0.0.1` by default, preventing unintentional exposure of services (e.g. databases) on public-facing interfaces. Explicit IPs are now validated and an error is raised for invalid values.

References:
- https://docs.docker.com/engine/network/port-publishing/