### PR TITLE
Add native OpenTelemetry support for deploy logs

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -4,7 +4,7 @@ require "concurrent/array"
 class Kamal::Cli::Accessory < Kamal::Cli::Base
   desc "boot [NAME]", "Boot new accessory service on host (use NAME=all to boot all accessories)"
   def boot(name, prepare: true)
-    with_lock do
+    modify(lock: true) do
       if name == "all"
         KAMAL.accessory_names.each { |accessory_name| boot(accessory_name) }
       else
@@ -42,7 +42,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
   desc "upload [NAME]", "Upload accessory files to host", hide: true
   def upload(name)
-    with_lock do
+    modify(lock: true) do
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
           accessory.files.each do |(local, config)|
@@ -61,7 +61,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
   desc "directories [NAME]", "Create accessory directories on host", hide: true
   def directories(name)
-    with_lock do
+    modify(lock: true) do
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
           accessory.directories.each do |(local, config)|
@@ -76,7 +76,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
   desc "reboot [NAME]", "Reboot existing accessory on host (stop container, remove container, start new container; use NAME=all to boot all accessories)"
   def reboot(name)
-    with_lock do
+    modify(lock: true) do
       if name == "all"
         KAMAL.accessory_names.each { |accessory_name| reboot(accessory_name) }
       else
@@ -91,7 +91,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
   desc "start [NAME]", "Start existing accessory container on host"
   def start(name)
-    with_lock do
+    modify(lock: true) do
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
           execute *KAMAL.auditor.record("Started #{name} accessory"), verbosity: :debug
@@ -107,7 +107,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
   desc "stop [NAME]", "Stop existing accessory container on host"
   def stop(name)
-    with_lock do
+    modify(lock: true) do
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
           execute *KAMAL.auditor.record("Stopped #{name} accessory"), verbosity: :debug
@@ -124,7 +124,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
   desc "restart [NAME]", "Restart existing accessory container on host"
   def restart(name)
-    with_lock do
+    modify(lock: true) do
       stop(name)
       start(name)
     end
@@ -213,7 +213,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
   desc "pull_image [NAME]", "Pull accessory image on host", hide: true
   def pull_image(name)
-    with_lock do
+    modify(lock: true) do
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
           execute *KAMAL.auditor.record("Pull #{name} accessory image"), verbosity: :debug
@@ -227,7 +227,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   option :confirmed, aliases: "-y", type: :boolean, default: false, desc: "Proceed without confirmation question"
   def remove(name)
     confirming "This will remove all containers, images and data directories for #{name}. Are you sure?" do
-      with_lock do
+      modify(lock: true) do
         if name == "all"
           KAMAL.accessory_names.each { |accessory_name| remove_accessory(accessory_name) }
         else
@@ -239,7 +239,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
   desc "remove_container [NAME]", "Remove accessory container from host", hide: true
   def remove_container(name)
-    with_lock do
+    modify(lock: true) do
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
           execute *KAMAL.auditor.record("Remove #{name} accessory container"), verbosity: :debug
@@ -251,7 +251,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
   desc "remove_image [NAME]", "Remove accessory image from host", hide: true
   def remove_image(name)
-    with_lock do
+    modify(lock: true) do
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
           execute *KAMAL.auditor.record("Removed #{name} accessory image"), verbosity: :debug
@@ -263,7 +263,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
 
   desc "remove_service_directory [NAME]", "Remove accessory directory used for uploaded files and data directories from host", hide: true
   def remove_service_directory(name)
-    with_lock do
+    modify(lock: true) do
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
           execute *accessory.remove_service_directory
@@ -277,7 +277,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   option :confirmed, aliases: "-y", type: :boolean, default: false, desc: "Proceed without confirmation question"
   def upgrade(name)
     confirming "This will restart all accessories" do
-      with_lock do
+      modify(lock: true) do
         host_groups = options[:rolling] ? KAMAL.accessory_hosts : [ KAMAL.accessory_hosts ]
         host_groups.each do |hosts|
           host_list = Array(hosts).join(",")

--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -1,7 +1,7 @@
 class Kamal::Cli::App < Kamal::Cli::Base
   desc "boot", "Boot app on servers (or reboot app if already running)"
   def boot
-    with_lock do
+    modify(lock: true) do
       say "Get most recent version available as an image...", :magenta unless options[:version]
       using_version(version_or_latest) do |version|
         say "Start container with version #{version} (or reboot if already running)...", :magenta
@@ -42,7 +42,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
   desc "start", "Start existing app container on servers"
   def start
-    with_lock do
+    modify(lock: true) do
       on_roles(KAMAL.roles, hosts: KAMAL.app_hosts, parallel: KAMAL.config.boot.parallel_roles) do |host, role|
         app = KAMAL.app(role: role, host: host)
         execute *KAMAL.auditor.record("Started app version #{KAMAL.config.version}"), verbosity: :debug
@@ -61,7 +61,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
   desc "stop", "Stop app container on servers"
   def stop
-    with_lock do
+    modify(lock: true) do
       on_roles(KAMAL.roles, hosts: KAMAL.app_hosts, parallel: KAMAL.config.boot.parallel_roles) do |host, role|
         app = KAMAL.app(role: role, host: host)
         execute *KAMAL.auditor.record("Stopped app", role: role), verbosity: :debug
@@ -233,7 +233,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
   desc "remove", "Remove app containers and images from servers"
   def remove
-    with_lock do
+    modify(lock: true) do
       stop
       remove_containers
       remove_images
@@ -243,7 +243,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
   desc "live", "Set the app to live mode"
   def live
-    with_lock do
+    modify(lock: true) do
       on_roles(KAMAL.roles, hosts: KAMAL.proxy_hosts) do |host, role|
         execute *KAMAL.app(role: role, host: host).live if role.running_proxy?
       end
@@ -256,7 +256,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
   def maintenance
     maintenance_options = { drain_timeout: options[:drain_timeout] || KAMAL.config.drain_timeout, message: options[:message] }
 
-    with_lock do
+    modify(lock: true) do
       on_roles(KAMAL.roles, hosts: KAMAL.proxy_hosts) do |host, role|
         execute *KAMAL.app(role: role, host: host).maintenance(**maintenance_options) if role.running_proxy?
       end
@@ -265,7 +265,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
   desc "remove_container [VERSION]", "Remove app container with given version from servers", hide: true
   def remove_container(version)
-    with_lock do
+    modify(lock: true) do
       on_roles(KAMAL.roles, hosts: KAMAL.app_hosts) do |host, role|
         execute *KAMAL.auditor.record("Removed app container with version #{version}", role: role), verbosity: :debug
         execute *KAMAL.app(role: role, host: host).remove_container(version: version)
@@ -275,7 +275,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
   desc "remove_containers", "Remove all app containers from servers", hide: true
   def remove_containers
-    with_lock do
+    modify(lock: true) do
       on_roles(KAMAL.roles, hosts: KAMAL.app_hosts) do |host, role|
         execute *KAMAL.auditor.record("Removed all app containers", role: role), verbosity: :debug
         execute *KAMAL.app(role: role, host: host).remove_containers
@@ -285,7 +285,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
   desc "remove_images", "Remove all app images from servers", hide: true
   def remove_images
-    with_lock do
+    modify(lock: true) do
       on(hosts_removing_all_roles) do
         execute *KAMAL.auditor.record("Removed all app images"), verbosity: :debug
         execute *KAMAL.app.remove_images
@@ -295,7 +295,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
   desc "remove_app_directories", "Remove the app directories from servers", hide: true
   def remove_app_directories
-    with_lock do
+    modify(lock: true) do
       on(hosts_removing_all_roles) do |host|
         execute *KAMAL.server.remove_app_directory, raise_on_non_zero_exit: false
         execute *KAMAL.auditor.record("Removed #{KAMAL.config.app_directory}"), verbosity: :debug
@@ -347,7 +347,7 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
     def with_lock_if_stopping
       if options[:stop]
-        with_lock { yield }
+        modify(lock: true) { yield }
       else
         yield
       end

--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -72,6 +72,17 @@ module Kamal::Cli
         puts "  Finished all in #{sprintf("%.1f seconds", runtime)}"
       end
 
+      def modify(lock: false)
+        KAMAL.modify(command: command, subcommand: subcommand) do
+          lock ? with_lock { yield } : yield
+        end
+      end
+
+      def say(message = "", *)
+        super
+        KAMAL.log(message.to_s)
+      end
+
       def with_lock
         if KAMAL.holding_lock?
           yield

--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -4,7 +4,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
   option :no_cache, type: :boolean, default: false, desc: "Build without using Docker's build cache"
   def setup
     print_runtime do
-      with_lock do
+      modify(lock: true) do
         invoke_options = deploy_options
 
         say "Ensure Docker is installed...", :magenta
@@ -19,88 +19,94 @@ class Kamal::Cli::Main < Kamal::Cli::Base
   option :skip_push, aliases: "-P", type: :boolean, default: false, desc: "Skip image build and push"
   option :no_cache, type: :boolean, default: false, desc: "Build without using Docker's build cache"
   def deploy(boot_accessories: false)
-    runtime = print_runtime do
-      invoke_options = deploy_options
+    modify do
+      runtime = print_runtime do
+        invoke_options = deploy_options
 
-      if options[:skip_push]
-        say "Pull app image...", :magenta
-        invoke "kamal:cli:build:pull", [], invoke_options
-      else
-        say "Build and push app image...", :magenta
-        invoke "kamal:cli:build:deliver", [], invoke_options
+        if options[:skip_push]
+          say "Pull app image...", :magenta
+          invoke "kamal:cli:build:pull", [], invoke_options
+        else
+          say "Build and push app image...", :magenta
+          invoke "kamal:cli:build:deliver", [], invoke_options
+        end
+
+        modify(lock: true) do
+          run_hook "pre-deploy", secrets: true
+
+          say "Ensure kamal-proxy is running...", :magenta
+          invoke "kamal:cli:proxy:boot", [], invoke_options
+
+          invoke "kamal:cli:accessory:boot", [ "all" ], invoke_options if boot_accessories
+
+          say "Detect stale containers...", :magenta
+          invoke "kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true)
+
+          invoke "kamal:cli:app:boot", [], invoke_options
+
+          say "Prune old containers and images...", :magenta
+          invoke "kamal:cli:prune:all", [], invoke_options
+        end
       end
 
-      with_lock do
-        run_hook "pre-deploy", secrets: true
-
-        say "Ensure kamal-proxy is running...", :magenta
-        invoke "kamal:cli:proxy:boot", [], invoke_options
-
-        invoke "kamal:cli:accessory:boot", [ "all" ], invoke_options if boot_accessories
-
-        say "Detect stale containers...", :magenta
-        invoke "kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true)
-
-        invoke "kamal:cli:app:boot", [], invoke_options
-
-        say "Prune old containers and images...", :magenta
-        invoke "kamal:cli:prune:all", [], invoke_options
-      end
+      run_hook "post-deploy", secrets: true, runtime: runtime.round.to_s
     end
-
-    run_hook "post-deploy", secrets: true, runtime: runtime.round.to_s
   end
 
   desc "redeploy", "Deploy app to servers without bootstrapping servers, starting kamal-proxy and pruning"
   option :skip_push, aliases: "-P", type: :boolean, default: false, desc: "Skip image build and push"
   option :no_cache, type: :boolean, default: false, desc: "Build without using Docker's build cache"
   def redeploy
-    runtime = print_runtime do
-      invoke_options = deploy_options
+    modify do
+      runtime = print_runtime do
+        invoke_options = deploy_options
 
-      if options[:skip_push]
-        say "Pull app image...", :magenta
-        invoke "kamal:cli:build:pull", [], invoke_options
-      else
-        say "Build and push app image...", :magenta
-        invoke "kamal:cli:build:deliver", [], invoke_options
+        if options[:skip_push]
+          say "Pull app image...", :magenta
+          invoke "kamal:cli:build:pull", [], invoke_options
+        else
+          say "Build and push app image...", :magenta
+          invoke "kamal:cli:build:deliver", [], invoke_options
+        end
+
+        modify(lock: true) do
+          run_hook "pre-deploy", secrets: true
+
+          say "Detect stale containers...", :magenta
+          invoke "kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true)
+
+          invoke "kamal:cli:app:boot", [], invoke_options
+        end
       end
 
-      with_lock do
-        run_hook "pre-deploy", secrets: true
-
-        say "Detect stale containers...", :magenta
-        invoke "kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true)
-
-        invoke "kamal:cli:app:boot", [], invoke_options
-      end
+      run_hook "post-deploy", secrets: true, runtime: runtime.round.to_s
     end
-
-    run_hook "post-deploy", secrets: true, runtime: runtime.round.to_s
   end
 
   desc "rollback [VERSION]", "Rollback app to VERSION"
   def rollback(version)
     rolled_back = false
-    runtime = print_runtime do
-      with_lock do
-        invoke_options = deploy_options
 
-        KAMAL.config.version = version
-        old_version = nil
+    modify do
+      runtime = print_runtime do
+        modify(lock: true) do
+          invoke_options = deploy_options
 
-        if container_available?(version)
-          run_hook "pre-deploy", secrets: true
+          KAMAL.config.version = version
 
-          invoke "kamal:cli:app:boot", [], invoke_options.merge(version: version)
-          rolled_back = true
-        else
-          say "The app version '#{version}' is not available as a container (use 'kamal app containers' for available versions)", :red
+          if container_available?(version)
+            run_hook "pre-deploy", secrets: true
+
+            invoke "kamal:cli:app:boot", [], invoke_options.merge(version: version)
+            rolled_back = true
+          else
+            say "The app version '#{version}' is not available as a container (use 'kamal app containers' for available versions)", :red
+          end
         end
       end
-    end
 
-    run_hook "post-deploy", secrets: true, runtime: runtime.round.to_s if rolled_back
+      run_hook "post-deploy", secrets: true, runtime: runtime.round.to_s if rolled_back
+    end
   end
 
   desc "details", "Show details about all containers"
@@ -182,7 +188,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
   option :confirmed, aliases: "-y", type: :boolean, default: false, desc: "Proceed without confirmation question"
   def remove
     confirming "This will remove all containers and images. Are you sure?" do
-      with_lock do
+      modify(lock: true) do
         invoke "kamal:cli:app:remove", [], options.without(:confirmed)
         invoke "kamal:cli:proxy:remove", [], options.without(:confirmed)
         invoke "kamal:cli:accessory:remove", [ "all" ], options
@@ -196,7 +202,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
   option :rolling, type: :boolean, default: false, desc: "Upgrade one host at a time"
   def upgrade
     confirming "This will replace Traefik with kamal-proxy and restart all accessories" do
-      with_lock do
+      modify(lock: true) do
         if options[:rolling]
           KAMAL.hosts.each do |host|
             KAMAL.with_specific_hosts(host) do

--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -1,7 +1,7 @@
 class Kamal::Cli::Proxy < Kamal::Cli::Base
   desc "boot", "Boot proxy on servers"
   def boot
-    with_lock do
+    modify(lock: true) do
       on(KAMAL.hosts) do |host|
         execute *KAMAL.docker.create_network
       rescue SSHKit::Command::Failed => e
@@ -108,7 +108,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
   option :confirmed, aliases: "-y", type: :boolean, default: false, desc: "Proceed without confirmation question"
   def reboot
     confirming "This will cause a brief outage on each host. Are you sure?" do
-      with_lock do
+      modify(lock: true) do
         host_groups = options[:rolling] ? KAMAL.proxy_hosts : [ KAMAL.proxy_hosts ]
         host_groups.each do |hosts|
           host_list = Array(hosts).join(",")
@@ -174,7 +174,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
 
   desc "start", "Start existing proxy container on servers"
   def start
-    with_lock do
+    modify(lock: true) do
       on(KAMAL.proxy_hosts) do |host|
         execute *KAMAL.auditor.record("Started proxy"), verbosity: :debug
         execute *KAMAL.proxy(host).start
@@ -184,7 +184,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
 
   desc "stop", "Stop existing proxy container on servers"
   def stop
-    with_lock do
+    modify(lock: true) do
       on(KAMAL.proxy_hosts) do |host|
         execute *KAMAL.auditor.record("Stopped proxy"), verbosity: :debug
         execute *KAMAL.proxy(host).stop, raise_on_non_zero_exit: false
@@ -194,7 +194,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
 
   desc "restart", "Restart existing proxy container on servers"
   def restart
-    with_lock do
+    modify(lock: true) do
       stop
       start
     end
@@ -236,7 +236,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
   desc "remove", "Remove proxy container and image from servers"
   option :force, type: :boolean, default: false, desc: "Force removing proxy when apps are still installed"
   def remove
-    with_lock do
+    modify(lock: true) do
       if removal_allowed?(options[:force])
         stop
         remove_container
@@ -248,7 +248,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
 
   desc "remove_container", "Remove proxy container from servers", hide: true
   def remove_container
-    with_lock do
+    modify(lock: true) do
       on(KAMAL.proxy_hosts) do
         execute *KAMAL.auditor.record("Removed proxy container"), verbosity: :debug
         execute *KAMAL.proxy(host).remove_container
@@ -258,7 +258,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
 
   desc "remove_image", "Remove proxy image from servers", hide: true
   def remove_image
-    with_lock do
+    modify(lock: true) do
       on(KAMAL.proxy_hosts) do
         execute *KAMAL.auditor.record("Removed proxy image"), verbosity: :debug
         execute *KAMAL.proxy(host).remove_image
@@ -268,7 +268,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
 
   desc "remove_proxy_directory", "Remove the proxy directory from servers", hide: true
   def remove_proxy_directory
-    with_lock do
+    modify(lock: true) do
       on(KAMAL.proxy_hosts) do
         execute *KAMAL.proxy(host).remove_proxy_directory, raise_on_non_zero_exit: false
       end

--- a/lib/kamal/cli/prune.rb
+++ b/lib/kamal/cli/prune.rb
@@ -1,7 +1,7 @@
 class Kamal::Cli::Prune < Kamal::Cli::Base
   desc "all", "Prune unused images and stopped containers"
   def all
-    with_lock do
+    modify(lock: true) do
       containers
       images
     end
@@ -9,7 +9,7 @@ class Kamal::Cli::Prune < Kamal::Cli::Base
 
   desc "images", "Prune unused images"
   def images
-    with_lock do
+    modify(lock: true) do
       on(KAMAL.hosts) do
         execute *KAMAL.auditor.record("Pruned images"), verbosity: :debug
         execute *KAMAL.prune.dangling_images
@@ -24,7 +24,7 @@ class Kamal::Cli::Prune < Kamal::Cli::Base
     retain = options.fetch(:retain, KAMAL.config.retain_containers)
     raise "retain must be at least 1" if retain < 1
 
-    with_lock do
+    modify(lock: true) do
       on(KAMAL.hosts) do
         execute *KAMAL.auditor.record("Pruned containers"), verbosity: :debug
         execute *KAMAL.prune.app_containers(retain: retain)

--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -27,7 +27,7 @@ class Kamal::Cli::Server < Kamal::Cli::Base
 
   desc "bootstrap", "Set up Docker to run Kamal apps"
   def bootstrap
-    with_lock do
+    modify(lock: true) do
       missing = []
 
       on(KAMAL.hosts) do |host|

--- a/lib/kamal/commander.rb
+++ b/lib/kamal/commander.rb
@@ -1,9 +1,11 @@
 require "active_support/core_ext/enumerable"
 require "active_support/core_ext/module/delegation"
 require "active_support/core_ext/object/blank"
+require "active_support/broadcast_logger"
+require "active_support/notifications"
 
 class Kamal::Commander
-  attr_accessor :verbosity, :holding_lock, :connected
+  attr_accessor :verbosity, :holding_lock, :connected, :logging
   attr_reader :specific_roles, :specific_hosts
   delegate :hosts, :roles, :primary_host, :primary_role, :roles_on, :app_hosts, :proxy_hosts, :accessory_hosts, to: :specifics
 
@@ -15,8 +17,11 @@ class Kamal::Commander
     self.verbosity = :info
     self.holding_lock = ENV["KAMAL_LOCK"] == "true"
     self.connected = false
+    self.logging = false
+    @modify_depth = 0
     @specifics = @specific_roles = @specific_hosts = nil
     @config = @config_kwargs = nil
+    @output_logger = nil
     @commands = {}
   end
 
@@ -142,6 +147,22 @@ class Kamal::Commander
     SSHKit.config.output_verbosity = old_level
   end
 
+  def modify(command:, subcommand:)
+    @logging = true
+    if modify_started
+      ActiveSupport::Notifications.instrument("modify.kamal",
+        command: command, subcommand: subcommand, destination: config.destination, hosts: hosts) { yield }
+    else
+      yield
+    end
+  ensure
+    output_logger.close if modify_finished
+  end
+
+  def log(line)
+    output_logger << "#{line}\n" if logging
+  end
+
   def holding_lock?
     self.holding_lock
   end
@@ -151,6 +172,20 @@ class Kamal::Commander
   end
 
   private
+    def output_logger
+      @output_logger ||= ActiveSupport::BroadcastLogger.new
+    end
+
+    def modify_started
+      @modify_depth += 1
+      @modify_depth == 1
+    end
+
+    def modify_finished
+      @modify_depth -= 1
+      @modify_depth == 0
+    end
+
     # Lazy setup of SSHKit
     def configure_sshkit_with(config)
       SSHKit::Backend::Netssh.pool.idle_timeout = config.sshkit.pool_idle_timeout
@@ -161,6 +196,21 @@ class Kamal::Commander
       end
       SSHKit.config.command_map[:docker] = "docker" # No need to use /usr/bin/env, just clogs up the logs
       SSHKit.config.output_verbosity = verbosity
+
+      configure_output_with(config)
+    end
+
+    def configure_output_with(config)
+      return unless config.output.enabled?
+
+      config.output.loggers.each { |logger| output_logger.broadcast_to(logger) }
+
+      SSHKit.config.output = Kamal::Output::Formatter.new($stdout, output_logger)
+
+      at_exit { @output_logger&.close }
+    rescue => e
+      $stderr.puts "Output logger setup failed: #{e.class}: #{e.message}"
+      $stderr.puts e.backtrace.join("\n") if ENV["VERBOSE"]
     end
 
     def specifics

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -12,7 +12,7 @@ class Kamal::Configuration
   delegate :argumentize, :optionize, to: Kamal::Utils
 
   attr_reader :destination, :raw_config, :secrets
-  attr_reader :accessories, :aliases, :boot, :builder, :env, :logging, :proxy, :proxy_boot, :servers, :ssh, :sshkit, :registry
+  attr_reader :accessories, :aliases, :boot, :builder, :env, :logging, :output, :proxy, :proxy_boot, :servers, :ssh, :sshkit, :registry
 
   include Validation
 
@@ -71,6 +71,7 @@ class Kamal::Configuration
     @env = Env.new(config: @raw_config.env || {}, secrets: secrets)
 
     @logging = Logging.new(logging_config: @raw_config.logging)
+    @output = Output.new(config: self)
     @proxy = Proxy.new(config: self, proxy_config: @raw_config.proxy, secrets: secrets)
     @proxy_boot = Proxy::Boot.new(config: self)
     @ssh = Ssh.new(config: self)

--- a/lib/kamal/configuration/docs/configuration.yml
+++ b/lib/kamal/configuration/docs/configuration.yml
@@ -206,6 +206,12 @@ boot:
 logging:
   ...
 
+# Output
+#
+# Configure output loggers (OTel, file), see kamal docs output:
+output:
+  ...
+
 # Aliases
 #
 # Alias configuration, see kamal docs alias:

--- a/lib/kamal/configuration/docs/output.yml
+++ b/lib/kamal/configuration/docs/output.yml
@@ -1,0 +1,25 @@
+# Output
+#
+# Configure where Kamal sends command output logs.
+
+# Output options
+#
+# The options are specified under the output key in the configuration file.
+output:
+
+  # OTel
+  #
+  # Ship deploy logs to an OpenTelemetry-compatible endpoint via OTLP HTTP.
+  #
+  # Logs are sent as OTLP log records with resource attributes derived from
+  # Kamal's deploy tags (service, version, performer, destination, etc.)
+  otel:
+    endpoint: http://otel-gateway:4318
+
+  # File
+  #
+  # Write deploy logs to a file on the local machine.
+  #
+  # One log file is created per deploy, named with the timestamp and command.
+  file:
+    path: /var/log/kamal/

--- a/lib/kamal/configuration/output.rb
+++ b/lib/kamal/configuration/output.rb
@@ -1,0 +1,34 @@
+class Kamal::Configuration::Output
+  include Kamal::Configuration::Validation
+
+  LOGGER_TYPES = {
+    "otel" => "Kamal::Output::OtelLogger",
+    "file" => "Kamal::Output::FileLogger"
+  }
+
+  attr_reader :output_config, :loggers
+
+  def initialize(config:)
+    @config = config
+    @output_config = config.raw_config.output || {}
+    validate! @output_config unless @output_config.empty?
+    @loggers = build_loggers
+  end
+
+  def enabled?
+    output_config.present?
+  end
+
+  def to_h
+    output_config
+  end
+
+  private
+    def build_loggers
+      output_config.filter_map do |key, settings|
+        if (klass_name = LOGGER_TYPES[key])
+          klass_name.constantize.build(settings: settings || {}, config: @config)
+        end
+      end
+    end
+end

--- a/lib/kamal/otel_shipper.rb
+++ b/lib/kamal/otel_shipper.rb
@@ -1,0 +1,176 @@
+require "active_support/core_ext/numeric/time"
+require "net/http"
+require "json"
+require "securerandom"
+require "uri"
+
+class Kamal::OtelShipper
+  BATCH_SIZE = 100
+  FLUSH_INTERVAL = 5.seconds
+
+  OTEL_ATTRIBUTE_KEYS = {
+    service: "service.namespace",
+    version: "kamal.deploy_version",
+    performer: "kamal.performer",
+    destination: "deployment.environment.name"
+  }
+
+  SEVERITIES = {
+    debug: { severityNumber: 5,  severityText: "DEBUG" },
+    info:  { severityNumber: 9,  severityText: "INFO" },
+    warn:  { severityNumber: 13, severityText: "WARN" },
+    error: { severityNumber: 17, severityText: "ERROR" },
+    fatal: { severityNumber: 21, severityText: "FATAL" }
+  }
+
+  LOGGER_SEVERITIES = {
+    Logger::DEBUG => :debug,
+    Logger::INFO  => :info,
+    Logger::WARN  => :warn,
+    Logger::ERROR => :error,
+    Logger::FATAL => :fatal
+  }
+
+  attr_reader :run_id
+
+  def initialize(endpoint:, tags:)
+    @endpoint = URI("#{endpoint.chomp('/')}/v1/logs")
+    @run_id = SecureRandom.uuid
+    @resource_attributes = [
+      { key: "service.name", value: { stringValue: "kamal" } },
+      { key: "service.version", value: { stringValue: Kamal::VERSION } },
+      { key: "kamal.run_id", value: { stringValue: @run_id } },
+      *tags.tags.map do |key, value|
+        otel_key = OTEL_ATTRIBUTE_KEYS.fetch(key, "kamal.#{key}")
+        { key: otel_key, value: { stringValue: value.to_s } }
+      end
+    ]
+    @buffer = Queue.new
+    @flush_mutex = Mutex.new
+    @running = true
+    @signal = Queue.new
+    @thread = start_flush_thread
+  end
+
+  def <<(str)
+    append(str)
+  end
+
+  def append(str, host: nil, iostream: nil, severity: nil)
+    otel_severity = LOGGER_SEVERITIES.fetch(severity, :info)
+    extra = build_context_attributes(host: host, iostream: iostream)
+    str.to_s.each_line do |line|
+      enqueue build_record(line.chomp, severity: otel_severity, attributes: extra)
+    end
+
+    self
+  end
+
+  def event(name, severity: :info, **attributes)
+    attrs = attributes.map { |k, v| { key: k.to_s, value: typed_value(v) } }
+    enqueue build_record(name, severity: severity, event_name: name, attributes: attrs)
+
+    self
+  end
+
+  def flush
+    @flush_mutex.synchronize do
+      lines = drain_buffer
+      ship(lines) if lines.any?
+    end
+  end
+
+  def shutdown
+    @running = false
+    @signal << true
+    @thread&.join(FLUSH_INTERVAL + 1.second)
+    flush
+  end
+
+  private
+    def enqueue(record)
+      @buffer << record
+      @signal << true if @buffer.size >= BATCH_SIZE
+    end
+
+    def start_flush_thread
+      Thread.new do
+        while @running
+          @signal.pop(timeout: FLUSH_INTERVAL)
+          flush
+        end
+      end
+    end
+
+    def drain_buffer
+      records = []
+      records << @buffer.pop(true) until @buffer.empty?
+      records
+    end
+
+    def ship(records)
+      with_connection do |http|
+        records.each_slice(BATCH_SIZE) do |batch|
+          ship_records(http, batch)
+        end
+      end
+    end
+
+    def build_record(body, severity: :info, event_name: nil, attributes: nil)
+      now = time_ns
+      { timeUnixNano: now, observedTimeUnixNano: now, **SEVERITIES.fetch(severity),
+        body: { stringValue: body }, eventName: event_name, attributes: attributes }.compact
+    end
+
+    def build_context_attributes(host:, iostream:)
+      attrs = []
+      attrs << { key: "server.address", value: { stringValue: host } } if host
+      attrs << { key: "log.iostream", value: { stringValue: iostream } } if iostream
+      attrs.presence
+    end
+
+    def typed_value(v)
+      case v
+      when Integer then { intValue: v }
+      when Float   then { doubleValue: v }
+      when Array   then { arrayValue: { values: v.map { |e| typed_value(e) } } }
+      else              { stringValue: v.to_s }
+      end
+    end
+
+    def with_connection
+      http = Net::HTTP.new(@endpoint.host, @endpoint.port)
+      http.use_ssl = @endpoint.scheme == "https"
+      http.open_timeout = 2.seconds
+      http.read_timeout = 5.seconds
+      http.start { |conn| yield conn }
+    rescue StandardError => e
+      unless @ship_error_logged
+        @ship_error_logged = true
+        $stderr.puts "OTel log shipping failed: #{e.class}: #{e.message}"
+        $stderr.puts e.backtrace.join("\n") if ENV["VERBOSE"]
+      end
+    end
+
+    def ship_records(http, records)
+      payload = {
+        resourceLogs: [ {
+          resource: { attributes: @resource_attributes },
+          scopeLogs: [ { scope: { name: "kamal", version: Kamal::VERSION }, logRecords: records } ]
+        } ]
+      }
+
+      req = Net::HTTP::Post.new(@endpoint.request_uri, "Content-Type" => "application/json")
+      req.body = JSON.generate(payload)
+      response = http.request(req)
+
+      unless response.is_a?(Net::HTTPSuccess) || @ship_error_logged
+        @ship_error_logged = true
+        $stderr.puts "OTel log shipping failed: HTTP #{response.code} #{response.message}"
+      end
+    end
+
+    def time_ns
+      Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond).to_s
+    end
+end

--- a/lib/kamal/output/base_logger.rb
+++ b/lib/kamal/output/base_logger.rb
@@ -1,0 +1,29 @@
+require "logger"
+
+class Kamal::Output::BaseLogger < ::Logger
+  def initialize
+    super(nil)
+    @subscription = ActiveSupport::Notifications.subscribe("modify.kamal", self)
+  end
+
+  def start(name, id, payload)
+    @started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+    on_start(payload)
+  end
+
+  def finish(name, id, payload)
+    runtime = (Process.clock_gettime(Process::CLOCK_MONOTONIC) - @started_at).round(1)
+    on_finish(payload, runtime)
+  end
+
+  def add(severity, message = nil, progname = nil, &block)
+    if msg = message || (block ? block.call : progname)
+      self << msg.to_s
+    end
+  end
+
+  def close
+    ActiveSupport::Notifications.unsubscribe(@subscription)
+    on_close
+  end
+end

--- a/lib/kamal/output/file_logger.rb
+++ b/lib/kamal/output/file_logger.rb
@@ -1,0 +1,51 @@
+class Kamal::Output::FileLogger < Kamal::Output::BaseLogger
+  attr_reader :path
+
+  def self.build(settings:, config:)
+    raise ArgumentError, "file path is required" unless settings["path"]
+    new(path: settings["path"])
+  end
+
+  def initialize(path:)
+    @path = Pathname.new(path)
+    super()
+  end
+
+  def <<(message)
+    @file&.print(message)
+  end
+
+  private
+    def on_start(payload)
+      path.mkpath
+      @file_path = path.join(filename_for(payload))
+      @file = File.open(@file_path, "a")
+      @file.sync = true
+    end
+
+    def on_finish(payload, runtime)
+      if @file
+        if payload[:exception]
+          error_class, error_message = payload[:exception]
+          @file.puts "# FAILED: #{error_class}: #{error_message} (#{runtime}s)"
+        else
+          @file.puts "# Completed in #{runtime}s"
+        end
+        @file.close
+        @file = nil
+        puts "Logs written to #{@file_path}"
+      end
+    end
+
+    def on_close
+      if @file
+        @file.close
+        @file = nil
+      end
+    end
+
+    def filename_for(payload)
+      command = [ payload[:command], payload[:subcommand] ].compact.join("_")
+      [ Time.now.strftime("%Y-%m-%dT%H-%M-%S"), payload[:destination], command ].compact.join("_") + ".log"
+    end
+end

--- a/lib/kamal/output/formatter.rb
+++ b/lib/kamal/output/formatter.rb
@@ -1,0 +1,36 @@
+class Kamal::Output::Formatter < SSHKit::Formatter::Pretty
+  def initialize(output, logger)
+    @logger = logger
+    super(output)
+  end
+
+  def log_command_start(command)
+    with_command_context(command) { super }
+  end
+
+  def log_command_data(command, stream_type, stream_data)
+    with_command_context(command, iostream: stream_type.to_s) { super }
+  end
+
+  def log_command_exit(command)
+    with_command_context(command) { super }
+  end
+
+  private
+    def write_message(verbosity, message, uuid = nil)
+      super
+      Thread.current[:kamal_severity] = verbosity
+      @logger << "#{format_message(verbosity, message, uuid)}\n" rescue nil
+    ensure
+      Thread.current[:kamal_severity] = nil
+    end
+
+    def with_command_context(command, iostream: nil)
+      Thread.current[:kamal_host] = command.host.to_s
+      Thread.current[:kamal_iostream] = iostream
+      yield
+    ensure
+      Thread.current[:kamal_host] = nil
+      Thread.current[:kamal_iostream] = nil
+    end
+end

--- a/lib/kamal/output/otel_logger.rb
+++ b/lib/kamal/output/otel_logger.rb
@@ -1,0 +1,70 @@
+class Kamal::Output::OtelLogger < Kamal::Output::BaseLogger
+  def self.build(settings:, config:)
+    raise ArgumentError, "OTel endpoint is required" unless settings["endpoint"]
+    new(
+      endpoint: settings["endpoint"],
+      tags: Kamal::Tags.from_config(config).except(:service_version, :recorded_at),
+      service: config.service
+    )
+  end
+
+  def initialize(endpoint:, tags:, service: nil)
+    @endpoint = endpoint
+    @shipper = Kamal::OtelShipper.new(endpoint: endpoint, tags: tags)
+    @service = service
+    super()
+  end
+
+  def <<(message)
+    host = Thread.current[:kamal_host]
+    iostream = Thread.current[:kamal_iostream]
+    severity = Thread.current[:kamal_severity]
+    @shipper.append(message, host: host, iostream: iostream, severity: severity)
+  end
+
+  DEPLOY_COMMANDS = %w[ deploy redeploy rollback setup ].freeze
+
+  private
+    def on_start(payload)
+      @shipper.event("kamal.start",
+        "kamal.command": full_command(payload),
+        **deployment_attrs(payload))
+    end
+
+    def on_finish(payload, runtime)
+      if payload[:exception]
+        error_class, error_message = payload[:exception]
+        @shipper.event("kamal.failed", severity: :error,
+          "kamal.command": full_command(payload), "kamal.runtime": runtime,
+          "exception.type": error_class, "exception.message": error_message,
+          **deployment_attrs(payload, status: "failed"))
+      else
+        @shipper.event("kamal.complete",
+          "kamal.command": full_command(payload), "kamal.runtime": runtime,
+          **deployment_attrs(payload, status: "succeeded"))
+      end
+      puts "Logs sent to #{@endpoint}"
+    end
+
+    def on_close
+      @shipper.shutdown
+    end
+
+    def full_command(payload)
+      [ payload[:command], payload[:subcommand] ].compact.join(" ")
+    end
+
+    def deploy?(payload)
+      DEPLOY_COMMANDS.include?(payload[:command])
+    end
+
+    def deployment_attrs(payload, status: nil)
+      if deploy?(payload)
+        attrs = { "deployment.id": @shipper.run_id, "deployment.name": "#{full_command(payload)} #{@service}" }
+        attrs[:"deployment.status"] = status if status
+        attrs
+      else
+        {}
+      end
+    end
+end

--- a/test/cli/modify_test.rb
+++ b/test/cli/modify_test.rb
@@ -1,0 +1,75 @@
+require_relative "cli_test_case"
+
+class CliModifyTest < CliTestCase
+  setup do
+    @events = []
+    @subscription = ActiveSupport::Notifications.subscribe("modify.kamal", self)
+  end
+
+  teardown do
+    ActiveSupport::Notifications.unsubscribe(@subscription)
+  end
+
+  def start(name, id, payload)
+    @events << { type: :start, payload: payload }
+  end
+
+  def finish(name, id, payload)
+    @events << { type: :finish, payload: payload }
+  end
+
+  test "modify enables logging" do
+    assert_not KAMAL.logging
+
+    run_modify { }
+
+    assert KAMAL.logging
+  end
+
+  test "nested modify only instruments outermost" do
+    run_modify do |base|
+      base.send(:modify, lock: false) { }
+    end
+
+    starts = @events.select { |e| e[:type] == :start }
+    finishes = @events.select { |e| e[:type] == :finish }
+
+    assert_equal 1, starts.length, "Expected exactly one start event"
+    assert_equal 1, finishes.length, "Expected exactly one finish event"
+  end
+
+  test "modify depth resets after completion" do
+    run_modify { }
+
+    assert_equal 0, KAMAL.instance_variable_get(:@modify_depth)
+  end
+
+  test "modify depth resets after error" do
+    assert_raises(RuntimeError) do
+      run_modify { raise "boom" }
+    end
+
+    assert_equal 0, KAMAL.instance_variable_get(:@modify_depth)
+  end
+
+  test "output logger close called only on outermost modify" do
+    close_count = 0
+    KAMAL.send(:output_logger).define_singleton_method(:close) { close_count += 1 }
+
+    run_modify do |base|
+      base.send(:modify, lock: false) { }
+    end
+
+    assert_equal 1, close_count
+  end
+
+  private
+    def run_modify(&block)
+      base = Kamal::Cli::Main.new([], { "config_file" => "test/fixtures/deploy_simple.yml", "skip_hooks" => true })
+      base.stubs(:command).returns("deploy")
+      base.stubs(:subcommand).returns(nil)
+      base.send(:modify) do
+        block.call(base) if block
+      end
+    end
+end

--- a/test/commander_test.rb
+++ b/test/commander_test.rb
@@ -192,6 +192,14 @@ class CommanderTest < ActiveSupport::TestCase
     assert_equal original_primary, @kamal.primary_host
   end
 
+  test "reset clears output logger" do
+    @kamal.send(:output_logger)
+    assert_not_nil @kamal.instance_variable_get(:@output_logger)
+
+    @kamal.reset
+    assert_nil @kamal.instance_variable_get(:@output_logger)
+  end
+
   private
     def configure_with(variant)
       @kamal = Kamal::Commander.new.tap do |kamal|

--- a/test/configuration/output_test.rb
+++ b/test/configuration/output_test.rb
@@ -1,0 +1,76 @@
+require "test_helper"
+
+class ConfigurationOutputTest < ActiveSupport::TestCase
+  setup do
+    @deploy = {
+      service: "app", image: "dhh/app",
+      registry: { "username" => "dhh", "password" => "secret" },
+      builder: { "arch" => "amd64" },
+      servers: [ "1.1.1.1" ]
+    }
+    Kamal::OtelShipper.any_instance.stubs(:start_flush_thread)
+  end
+
+  teardown do
+    @config&.output&.loggers&.each(&:close)
+  end
+
+  test "disabled by default" do
+    @config = Kamal::Configuration.new(@deploy)
+    assert_not @config.output.enabled?
+    assert_empty @config.output.loggers
+  end
+
+  test "enabled with otel endpoint" do
+    @deploy[:output] = { "otel" => { "endpoint" => "http://otel-gateway:4318" } }
+    @config = Kamal::Configuration.new(@deploy)
+
+    assert @config.output.enabled?
+    assert_equal 1, @config.output.loggers.length
+    assert_kind_of Kamal::Output::OtelLogger, @config.output.loggers.first
+  end
+
+  test "enabled with file path" do
+    @deploy[:output] = { "file" => { "path" => "/var/log/kamal/" } }
+    @config = Kamal::Configuration.new(@deploy)
+
+    assert @config.output.enabled?
+    assert_equal 1, @config.output.loggers.length
+    assert_kind_of Kamal::Output::FileLogger, @config.output.loggers.first
+  end
+
+  test "enabled with both otel and file" do
+    @deploy[:output] = {
+      "otel" => { "endpoint" => "http://otel-gateway:4318" },
+      "file" => { "path" => "/var/log/kamal/" }
+    }
+    @config = Kamal::Configuration.new(@deploy)
+
+    assert @config.output.enabled?
+    assert_equal 2, @config.output.loggers.length
+  end
+
+  test "empty output section is not enabled" do
+    @deploy[:output] = {}
+    @config = Kamal::Configuration.new(@deploy)
+
+    assert_not @config.output.enabled?
+    assert_empty @config.output.loggers
+  end
+
+  test "otel without endpoint raises" do
+    @deploy[:output] = { "otel" => {} }
+
+    assert_raises(ArgumentError, "OTel endpoint is required") do
+      Kamal::Configuration.new(@deploy)
+    end
+  end
+
+  test "file without path raises" do
+    @deploy[:output] = { "file" => {} }
+
+    assert_raises(ArgumentError, "file path is required") do
+      Kamal::Configuration.new(@deploy)
+    end
+  end
+end

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -4,6 +4,7 @@ volumes:
   shared:
   registry:
   deployer_bundle:
+  otel:
 
 services:
   shared:
@@ -23,6 +24,7 @@ services:
       - shared:/shared
       - registry:/registry
       - deployer_bundle:/usr/local/bundle/
+      - otel:/tmp/otel
 
   registry:
     build:
@@ -57,6 +59,12 @@ services:
       context: docker/vm
     volumes:
       - shared:/shared
+
+  otel_collector:
+    build:
+      context: docker/otel_collector
+    volumes:
+      - otel:/tmp/otel
 
   load_balancer:
     build:

--- a/test/integration/docker/deployer/app/config/deploy.yml
+++ b/test/integration/docker/deployer/app/config/deploy.yml
@@ -27,6 +27,11 @@ hooks_output:
 deploy_timeout: 2
 drain_timeout: 2
 readiness_delay: 0
+output:
+  file:
+    path: /tmp/kamal-deploy-logs
+  otel:
+    endpoint: http://otel_collector:4318
 proxy:
   host: 127.0.0.1
   run:

--- a/test/integration/docker/otel_collector/Dockerfile
+++ b/test/integration/docker/otel_collector/Dockerfile
@@ -1,0 +1,4 @@
+FROM ruby:3.2-alpine
+COPY server.rb /server.rb
+HEALTHCHECK --interval=1s CMD pgrep ruby
+CMD ["ruby", "/server.rb"]

--- a/test/integration/docker/otel_collector/server.rb
+++ b/test/integration/docker/otel_collector/server.rb
@@ -1,0 +1,27 @@
+require "socket"
+require "fileutils"
+
+dir = "/tmp/otel"
+FileUtils.mkdir_p(dir)
+
+server = TCPServer.new("0.0.0.0", 4318)
+
+loop do
+  client = server.accept
+  request = ""
+  content_length = 0
+
+  while (line = client.gets) && line != "\r\n"
+    request << line
+    content_length = $1.to_i if line =~ /^Content-Length:\s*(\d+)/i
+  end
+
+  body = client.read(content_length) if content_length > 0
+
+  if body && !body.empty?
+    File.write("#{dir}/#{Process.clock_gettime(Process::CLOCK_REALTIME, :nanosecond)}.json", body)
+  end
+
+  client.print "HTTP/1.1 200 OK\r\nContent-Length: 0\r\n\r\n"
+  client.close
+end

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -7,6 +7,7 @@ class IntegrationTest < ActiveSupport::TestCase
     docker_compose "up --build -d"
     wait_for_healthy
     setup_deployer
+    deployer_exec("sh -c 'rm -f /tmp/otel/*.json /tmp/kamal-deploy-logs/*'", workdir: "/")
     @app = "app"
   end
 
@@ -195,6 +196,39 @@ class IntegrationTest < ActiveSupport::TestCase
       else
         "localhost"
       end
+    end
+
+    def deploy_log_content(pattern)
+      deployer_exec("sh -c 'cat /tmp/kamal-deploy-logs/#{pattern}'", capture: true)
+        .gsub(/\e\[[0-9;]*m/, "")
+    end
+
+    def otel_payloads
+      files = deployer_exec("sh -c 'ls /tmp/otel/*.json'", capture: true).strip.split("\n")
+      files.map { |f| JSON.parse(deployer_exec("cat #{f}", capture: true)) }
+    end
+
+    def otel_log_records
+      otel_payloads.flat_map { |p| p.dig("resourceLogs", 0, "scopeLogs", 0, "logRecords") || [] }
+    end
+
+    def otel_events
+      otel_log_records.select { |r| r["eventName"].present? }
+    end
+
+    def wait_for_otel_events(expected:, timeout: 3)
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + timeout
+      loop do
+        events = otel_events
+        return events if events.length >= expected
+        return events if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+        sleep 0.1
+      end
+    end
+
+    def otel_resource_attributes
+      attrs = otel_payloads.first&.dig("resourceLogs", 0, "resource", "attributes") || []
+      attrs.to_h { |a| [ a["key"], a.dig("value", "stringValue") ] }
     end
 
     def https_response_with_cert(uri, cert)

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -10,6 +10,12 @@ class MainTest < IntegrationTest
     assert_app_is_up version: first_version
     assert_hooks_ran "pre-connect", "pre-build", "pre-deploy", "pre-app-boot", "post-app-boot", "post-deploy"
     assert_hook_output deploy_output
+    assert_match %r{Logs written to /tmp/kamal-deploy-logs/.*_deploy\.log}, deploy_output
+    assert_match /Logs sent to http:\/\/otel_collector:4318/, deploy_output
+    assert_deploy_log "*_deploy.log",
+      /Build and push app image/,
+      /INFO .* Running docker/,
+      /post-deploy/
 
     assert_envs version: first_version
 
@@ -21,6 +27,9 @@ class MainTest < IntegrationTest
     kamal :redeploy
     assert_app_is_up version: second_version
     assert_hooks_ran "pre-connect", "pre-build", "pre-deploy", "pre-app-boot", "post-app-boot", "post-deploy"
+    assert_deploy_log "*_redeploy.log",
+      /Build and push app image/,
+      /INFO .* Running docker/
 
     assert_accumulated_assets first_version, second_version
     assert_asset_volume_read_only second_version
@@ -28,6 +37,9 @@ class MainTest < IntegrationTest
     kamal :rollback, first_version
     assert_hooks_ran "pre-connect", "pre-deploy", "pre-app-boot", "post-app-boot", "post-deploy"
     assert_app_is_up version: first_version
+    assert_deploy_log "*_rollback.log",
+      /INFO .* Running docker/,
+      /pre-connect/
 
     details = kamal :details, capture: true
     assert_match /Proxy Host: vm1/, details
@@ -39,6 +51,8 @@ class MainTest < IntegrationTest
 
     audit = kamal :audit, capture: true
     assert_match /Booted app version #{first_version}.*Booted app version #{second_version}.*Booted app version #{first_version}.*/m, audit
+
+    assert_otel_logs
   end
 
   test "app with roles" do
@@ -174,6 +188,79 @@ class MainTest < IntegrationTest
   end
 
   private
+    def assert_deploy_log(pattern, *lines)
+      content = deploy_log_content(pattern)
+      lines.each { |line| assert_match line, content }
+      assert_match /# Completed in \d+\.\d+s/, content
+    end
+
+    def assert_otel_logs
+      events = wait_for_otel_events(expected: 6)
+      records = otel_log_records
+
+      # Resource attributes
+      attrs = otel_resource_attributes
+      assert_equal "kamal", attrs["service.name"]
+      assert_equal "app", attrs["service.namespace"]
+      assert_equal Kamal::VERSION, attrs["service.version"]
+      assert attrs["kamal.run_id"].present?, "Expected kamal.run_id attribute"
+      assert attrs["kamal.performer"].present?, "Expected kamal.performer attribute"
+      assert attrs["kamal.deploy_version"].present?, "Expected kamal.deploy_version attribute"
+      # No destination set in test config, so deployment.environment.name is absent
+
+      # One start/complete pair per command (deploy, redeploy, rollback)
+      starts = events_named("kamal.start", events)
+      completes = events_named("kamal.complete", events)
+      assert_equal 3, starts.length, "Expected 3 kamal.start events, got #{starts.length}"
+      assert_equal 3, completes.length, "Expected 3 kamal.complete events, got #{completes.length}"
+
+      # Each command is identified in its events
+      %w[deploy redeploy rollback].each do |command|
+        start_event = starts.find { |e| event_attr(e, "kamal.command") == command }
+        assert start_event, "Expected kamal.start event for #{command}"
+
+        # Deployment attributes
+        assert event_attr(start_event, "deployment.id").present?, "Expected deployment.id on #{command}"
+        assert_equal "#{command} app", event_attr(start_event, "deployment.name")
+
+        complete_event = completes.find { |e| event_attr(e, "kamal.command") == command }
+        assert complete_event, "Expected kamal.complete event for #{command}"
+        assert_kind_of Float, event_attr(complete_event, "kamal.runtime")
+        assert_equal "succeeded", event_attr(complete_event, "deployment.status")
+      end
+
+      # Stream output lines with per-host tagging
+      host_tagged = records.select { |r| record_attr(r, "server.address").present? }
+      assert host_tagged.length > 5, "Expected many host-tagged log lines, got #{host_tagged.length}"
+
+      hosts_seen = host_tagged.map { |r| record_attr(r, "server.address") }.uniq.sort
+      assert_includes hosts_seen, "vm1"
+      assert_includes hosts_seen, "vm2"
+
+      iostreams_seen = records.filter_map { |r| record_attr(r, "log.iostream") }.uniq.sort
+      assert_includes iostreams_seen, "stdout"
+
+      # Raw log lines were shipped (not just events)
+      non_event_records = records.reject { |r| r["eventName"].present? }
+      log_lines = non_event_records.map { |r| r.dig("body", "stringValue") }
+      assert log_lines.length > 10, "Expected many raw log lines, got #{log_lines.length}"
+      assert log_lines.any? { |l| l.include?("Running docker") }, "Expected SSHKit output in log lines"
+    end
+
+    def events_named(name, events)
+      events.select { |r| r["eventName"] == name }
+    end
+
+    def event_attr(event, key)
+      value = event["attributes"]&.find { |a| a["key"] == key }&.dig("value")
+      value&.values&.first
+    end
+
+    def record_attr(record, key)
+      value = record["attributes"]&.find { |a| a["key"] == key }&.dig("value")
+      value&.values&.first
+    end
+
     def assert_envs(version:)
       assert_env :KAMAL_HOST, "vm1", version: version, vm: :vm1
       assert_env :CLEAR_TOKEN, "4321", version: version, vm: :vm1

--- a/test/otel_shipper_test.rb
+++ b/test/otel_shipper_test.rb
@@ -1,0 +1,283 @@
+require "test_helper"
+
+class OtelShipperTest < ActiveSupport::TestCase
+  setup do
+    @tags = Kamal::Tags.new(
+      performer: "deployer",
+      service: "myapp",
+      version: "abc123",
+      destination: "production"
+    )
+    Kamal::OtelShipper.any_instance.stubs(:start_flush_thread)
+    @shipper = Kamal::OtelShipper.new(endpoint: "http://localhost:4318", tags: @tags)
+  end
+
+  teardown do
+    @shipper.shutdown
+  end
+
+  test "appends log lines to buffer as OTLP records" do
+    @shipper << "hello world"
+    @shipper << "second line"
+
+    bodies = drain_buffer.map { |r| r[:body][:stringValue] }
+    assert_equal [ "hello world", "second line" ], bodies
+  end
+
+  test "splits multi-line strings into separate records" do
+    @shipper << "line one\nline two\nline three\n"
+
+    bodies = drain_buffer.map { |r| r[:body][:stringValue] }
+    assert_equal [ "line one", "line two", "line three" ], bodies
+  end
+
+  test "preserves empty lines" do
+    @shipper << "before\n\nafter\n"
+
+    bodies = drain_buffer.map { |r| r[:body][:stringValue] }
+    assert_equal [ "before", "", "after" ], bodies
+  end
+
+  test "event buffers structured data as OTLP record" do
+    @shipper.event("kamal.start", "kamal.deploy_version": "abc123")
+
+    record = drain_buffer.first
+    assert_equal "kamal.start", record[:body][:stringValue]
+    assert_equal "kamal.start", record[:eventName]
+    assert_not_nil record[:observedTimeUnixNano]
+
+    attr_keys = record[:attributes].map { |a| a[:key] }
+    assert_includes attr_keys, "kamal.deploy_version"
+  end
+
+  test "append includes server.address and log.iostream attributes" do
+    @shipper.append("output line", host: "1.1.1.1", iostream: "stdout")
+
+    record = drain_buffer.first
+    attrs = record[:attributes]
+
+    host_attr = attrs.find { |a| a[:key] == "server.address" }
+    assert_equal "1.1.1.1", host_attr[:value][:stringValue]
+
+    iostream_attr = attrs.find { |a| a[:key] == "log.iostream" }
+    assert_equal "stdout", iostream_attr[:value][:stringValue]
+  end
+
+  test "append maps Logger severity to OTel severity" do
+    @shipper.append("debug line", severity: Logger::DEBUG)
+    @shipper.append("info line", severity: Logger::INFO)
+    @shipper.append("warn line", severity: Logger::WARN)
+
+    records = drain_buffer
+    assert_equal 5, records[0][:severityNumber]
+    assert_equal "DEBUG", records[0][:severityText]
+    assert_equal 9, records[1][:severityNumber]
+    assert_equal "INFO", records[1][:severityText]
+    assert_equal 13, records[2][:severityNumber]
+    assert_equal "WARN", records[2][:severityText]
+  end
+
+  test "append defaults to INFO when no severity given" do
+    @shipper.append("plain line")
+
+    record = drain_buffer.first
+    assert_equal 9, record[:severityNumber]
+  end
+
+  test "append without host or iostream omits context attributes" do
+    @shipper.append("plain line")
+
+    record = drain_buffer.first
+    assert_nil record[:attributes]
+  end
+
+  test "records have no attributes when appended without context" do
+    @shipper << "line"
+
+    record = drain_buffer.first
+    assert_nil record[:attributes]
+  end
+
+  test "event defaults to INFO severity" do
+    @shipper.event("kamal.start", "kamal.command": "deploy")
+
+    record = drain_buffer.first
+    assert_equal 9, record[:severityNumber]
+    assert_equal "INFO", record[:severityText]
+  end
+
+  test "event supports ERROR severity" do
+    @shipper.event("kamal.failed", severity: :error, "kamal.command": "deploy")
+
+    record = drain_buffer.first
+    assert_equal 17, record[:severityNumber]
+    assert_equal "ERROR", record[:severityText]
+  end
+
+  test "event attributes preserve numeric types" do
+    @shipper.event("kamal.complete", "kamal.runtime": 1.5, retries: 3)
+
+    record = drain_buffer.first
+    runtime = record[:attributes].find { |a| a[:key] == "kamal.runtime" }
+    assert_equal({ doubleValue: 1.5 }, runtime[:value])
+    retries = record[:attributes].find { |a| a[:key] == "retries" }
+    assert_equal({ intValue: 3 }, retries[:value])
+  end
+
+  test "event attributes support arrays" do
+    @shipper.event("kamal.start", hosts: [ "1.1.1.1", "2.2.2.2" ])
+
+    record = drain_buffer.first
+    hosts = record[:attributes].find { |a| a[:key] == "hosts" }
+    assert_equal({ arrayValue: { values: [ { stringValue: "1.1.1.1" }, { stringValue: "2.2.2.2" } ] } }, hosts[:value])
+  end
+
+  test "flush ships buffered lines via HTTP" do
+    @shipper << "test log line"
+    stub_otel_http
+
+    @shipper.flush
+
+    assert_equal 1, shipped_records.length
+    assert_equal "test log line", shipped_records.first.dig("body", "stringValue")
+  end
+
+  test "flush ships events with eventName and OTLP attributes" do
+    @shipper.event("kamal.complete", status: "success")
+    stub_otel_http
+
+    @shipper.flush
+
+    record = shipped_records.first
+    assert_equal "kamal.complete", record.dig("body", "stringValue")
+    assert_equal "kamal.complete", record["eventName"]
+    status = record["attributes"].find { |a| a["key"] == "status" }
+    assert_equal "success", status.dig("value", "stringValue")
+  end
+
+  test "resource attributes use OTel semantic convention keys" do
+    @shipper << "line"
+    stub_otel_http
+
+    @shipper.flush
+
+    keys = shipped_resource_attrs.map { |a| a["key"] }
+    assert_includes keys, "service.name"
+    assert_includes keys, "service.namespace"
+    assert_includes keys, "service.version"
+    assert_includes keys, "kamal.run_id"
+    assert_includes keys, "kamal.deploy_version"
+    assert_includes keys, "kamal.performer"
+    assert_includes keys, "deployment.environment.name"
+
+    assert_equal "kamal", shipped_resource_attr("service.name")
+    assert_equal Kamal::VERSION, shipped_resource_attr("service.version")
+    assert_equal "myapp", shipped_resource_attr("service.namespace")
+    assert_equal @shipper.run_id, shipped_resource_attr("kamal.run_id")
+    assert_equal "abc123", shipped_resource_attr("kamal.deploy_version")
+    assert_equal "deployer", shipped_resource_attr("kamal.performer")
+  end
+
+  test "instrumentation scope identifies kamal" do
+    @shipper << "line"
+    stub_otel_http
+
+    @shipper.flush
+
+    scope = @shipped.first.dig("resourceLogs", 0, "scopeLogs", 0, "scope")
+    assert_equal "kamal", scope["name"]
+    assert_equal Kamal::VERSION, scope["version"]
+  end
+
+  test "accepts lines after shutdown" do
+    @shipper.shutdown
+    @shipper << "still works"
+
+    bodies = drain_buffer.map { |r| r[:body][:stringValue] }
+    assert_equal [ "still works" ], bodies
+  end
+
+  test "HTTP errors are swallowed and first failure logged to stderr" do
+    @shipper << "line"
+    Net::HTTP.any_instance.stubs(:start).raises(Errno::ECONNREFUSED)
+
+    stderr_output = capture_io { @shipper.flush }[1]
+    assert_match /OTel log shipping failed/, stderr_output
+
+    # Second failure is silent
+    @shipper << "another line"
+    stderr_output = capture_io { @shipper.flush }[1]
+    assert_empty stderr_output
+  end
+
+  test "flush thread ships buffered lines automatically" do
+    shipped = Queue.new
+    threaded_shipper = create_threaded_shipper
+
+    # Override flush to capture calls without HTTP
+    threaded_shipper.define_singleton_method(:flush) do
+      @flush_mutex.synchronize do
+        records = send(:drain_buffer)
+        shipped << records if records.any?
+      end
+    end
+
+    threaded_shipper << "threaded line"
+
+    # Wake the flush thread immediately
+    threaded_shipper.instance_variable_get(:@signal) << true
+
+    records = shipped.pop(timeout: 5)
+    assert_not_nil records, "Expected flush thread to ship within timeout"
+    bodies = records.map { |r| r[:body][:stringValue] }
+    assert_includes bodies, "threaded line"
+  ensure
+    threaded_shipper&.instance_variable_set(:@running, false)
+    threaded_shipper&.instance_variable_get(:@signal)&.push(true)
+    threaded_shipper&.instance_variable_get(:@thread)&.join(1)
+  end
+
+  test "shutdown flushes remaining lines" do
+    stub_otel_http
+
+    threaded_shipper = create_threaded_shipper
+    threaded_shipper << "final line"
+    threaded_shipper.shutdown
+
+    bodies = @shipped.flat_map { |b| b.dig("resourceLogs", 0, "scopeLogs", 0, "logRecords") }
+      .map { |r| r.dig("body", "stringValue") }
+    assert_includes bodies, "final line"
+  end
+
+  private
+    def drain_buffer
+      @shipper.send(:drain_buffer)
+    end
+
+    def create_threaded_shipper
+      Kamal::OtelShipper.any_instance.unstub(:start_flush_thread)
+      Kamal::OtelShipper.new(endpoint: "http://localhost:4318", tags: @tags)
+    end
+
+    def stub_otel_http
+      @shipped = []
+      http = stub("http")
+      http.stubs(:request).with do |req|
+        @shipped << JSON.parse(req.body)
+        true
+      end.returns(Net::HTTPOK.new("1.1", "200", "OK"))
+      Net::HTTP.any_instance.stubs(:start).yields(http)
+    end
+
+    def shipped_records
+      @shipped.flat_map { |b| b.dig("resourceLogs", 0, "scopeLogs", 0, "logRecords") }
+    end
+
+    def shipped_resource_attrs
+      @shipped.first.dig("resourceLogs", 0, "resource", "attributes")
+    end
+
+    def shipped_resource_attr(key)
+      shipped_resource_attrs.find { |a| a["key"] == key }.dig("value", "stringValue")
+    end
+end

--- a/test/output/file_logger_test.rb
+++ b/test/output/file_logger_test.rb
@@ -1,0 +1,90 @@
+require "test_helper"
+require "tmpdir"
+
+class OutputFileLoggerTest < ActiveSupport::TestCase
+  setup do
+    @dir = Dir.mktmpdir
+    @logger = Kamal::Output::FileLogger.new(path: @dir)
+  end
+
+  teardown do
+    @logger.close
+    FileUtils.rm_rf(@dir)
+  end
+
+  test "discards lines before start" do
+    @logger << "before modify\n"
+
+    assert_empty log_files
+  end
+
+  test "creates timestamped log file on start" do
+    @logger.start("modify.kamal", "id", command: "deploy")
+
+    assert_equal 1, log_files.length
+    assert_match /_deploy\.log$/, log_files.first
+  end
+
+  test "writes lines to file after start" do
+    @logger.start("modify.kamal", "id", command: "deploy")
+    @logger << "hello\n"
+    @logger << "world\n"
+
+    assert_includes log_content, "hello"
+    assert_includes log_content, "world"
+  end
+
+  test "finish writes completion message" do
+    @logger.start("modify.kamal", "id", command: "deploy")
+    @logger.finish("modify.kamal", "id", {})
+
+    assert_match /# Completed in \d+\.\d+s/, log_content
+  end
+
+  test "finish writes failure message on exception" do
+    @logger.start("modify.kamal", "id", command: "deploy")
+    @logger.finish("modify.kamal", "id", exception: [ "RuntimeError", "boom" ])
+
+    assert_includes log_content, "# FAILED: RuntimeError: boom"
+  end
+
+  test "includes subcommand in filename" do
+    @logger.start("modify.kamal", "id", command: "app", subcommand: "boot")
+
+    assert_match /_app_boot\.log$/, log_files.first
+  end
+
+  test "includes destination in filename" do
+    @logger.start("modify.kamal", "id", command: "deploy", destination: "staging")
+
+    assert_match /_staging_deploy\.log$/, log_files.first
+  end
+
+  test "includes destination and subcommand in filename" do
+    @logger.start("modify.kamal", "id", command: "app", subcommand: "boot", destination: "staging")
+
+    assert_match /_staging_app_boot\.log$/, log_files.first
+  end
+
+  test "finish prints log file path" do
+    @logger.start("modify.kamal", "id", command: "deploy")
+
+    output = capture_io { @logger.finish("modify.kamal", "id", {}) }.first
+    assert_match /Logs written to.*_deploy\.log/, output
+  end
+
+  test "close is idempotent" do
+    @logger.start("modify.kamal", "id", command: "deploy")
+    @logger.close
+    assert_nothing_raised { @logger.close }
+  end
+
+  private
+    def log_files
+      Dir.glob("#{@dir}/*.log")
+    end
+
+    def log_content
+      File.read(log_files.first)
+    end
+end

--- a/test/output/otel_logger_test.rb
+++ b/test/output/otel_logger_test.rb
@@ -1,0 +1,92 @@
+require "test_helper"
+
+class OutputOtelLoggerTest < ActiveSupport::TestCase
+  setup do
+    @tags = Kamal::Tags.new(
+      performer: "deployer",
+      service: "myapp",
+      version: "abc123",
+      destination: "production"
+    )
+    Kamal::OtelShipper.any_instance.stubs(:start_flush_thread)
+    Kamal::OtelShipper.any_instance.stubs(:flush)
+    @logger = Kamal::Output::OtelLogger.new(endpoint: "http://localhost:4318", tags: @tags, service: "myapp")
+  end
+
+  teardown do
+    @logger.close
+  end
+
+  test "start event includes subcommand in command" do
+    Kamal::OtelShipper.any_instance.expects(:event).with("kamal.start", "kamal.command": "app boot")
+    @logger.start("modify.kamal", "id", command: "app", subcommand: "boot", hosts: [ "1.1.1.1" ])
+  end
+
+  test "start event uses just command when no subcommand" do
+    Kamal::OtelShipper.any_instance.expects(:event).with("kamal.start",
+      "kamal.command": "deploy",
+      "deployment.id": anything, "deployment.name": "deploy myapp")
+    @logger.start("modify.kamal", "id", command: "deploy", subcommand: nil, hosts: [ "1.1.1.1" ])
+  end
+
+  test "deploy complete event includes deployment status" do
+    @logger.start("modify.kamal", "id", command: "deploy", hosts: [ "1.1.1.1" ])
+    Kamal::OtelShipper.any_instance.expects(:event).with("kamal.complete",
+      "kamal.command": "deploy", "kamal.runtime": anything,
+      "deployment.id": anything, "deployment.name": "deploy myapp", "deployment.status": "succeeded")
+    @logger.finish("modify.kamal", "id", command: "deploy")
+  end
+
+  test "deploy failed event includes deployment status" do
+    @logger.start("modify.kamal", "id", command: "deploy", hosts: [ "1.1.1.1" ])
+    Kamal::OtelShipper.any_instance.expects(:event).with("kamal.failed",
+      severity: :error, "kamal.command": "deploy", "kamal.runtime": anything,
+      "exception.type": "RuntimeError", "exception.message": "boom",
+      "deployment.id": anything, "deployment.name": "deploy myapp", "deployment.status": "failed")
+    @logger.finish("modify.kamal", "id", command: "deploy", exception: [ "RuntimeError", "boom" ])
+  end
+
+  test "non-deploy commands omit deployment attributes" do
+    Kamal::OtelShipper.any_instance.expects(:event).with("kamal.start", "kamal.command": "app boot")
+    @logger.start("modify.kamal", "id", command: "app", subcommand: "boot", hosts: [ "1.1.1.1" ])
+  end
+
+  test "complete event includes subcommand" do
+    @logger.start("modify.kamal", "id", command: "app", subcommand: "boot", hosts: [ "1.1.1.1" ])
+    Kamal::OtelShipper.any_instance.expects(:event).with("kamal.complete", "kamal.command": "app boot", "kamal.runtime": anything)
+    @logger.finish("modify.kamal", "id", command: "app", subcommand: "boot")
+  end
+
+  test "failed event includes subcommand with error severity and exception attributes" do
+    @logger.start("modify.kamal", "id", command: "app", subcommand: "boot", hosts: [ "1.1.1.1" ])
+    Kamal::OtelShipper.any_instance.expects(:event).with("kamal.failed",
+      severity: :error, "kamal.command": "app boot", "kamal.runtime": anything,
+      "exception.type": "RuntimeError", "exception.message": "boom")
+    @logger.finish("modify.kamal", "id", command: "app", subcommand: "boot", exception: [ "RuntimeError", "boom" ])
+  end
+
+  test "finish prints endpoint" do
+    @logger.start("modify.kamal", "id", command: "deploy", hosts: [ "1.1.1.1" ])
+
+    output = capture_io { @logger.finish("modify.kamal", "id", command: "deploy") }.first
+    assert_match /Logs sent to http:\/\/localhost:4318/, output
+  end
+
+  test "stream output includes host, iostream and severity from thread context" do
+    Thread.current[:kamal_host] = "1.1.1.1"
+    Thread.current[:kamal_iostream] = "stdout"
+    Thread.current[:kamal_severity] = Logger::DEBUG
+
+    Kamal::OtelShipper.any_instance.expects(:append).with("output line\n", host: "1.1.1.1", iostream: "stdout", severity: Logger::DEBUG)
+    @logger << "output line\n"
+  ensure
+    Thread.current[:kamal_host] = nil
+    Thread.current[:kamal_iostream] = nil
+    Thread.current[:kamal_severity] = nil
+  end
+
+  test "stream output without thread context omits host, iostream and severity" do
+    Kamal::OtelShipper.any_instance.expects(:append).with("output line\n", host: nil, iostream: nil, severity: nil)
+    @logger << "output line\n"
+  end
+end


### PR DESCRIPTION
## Summary

Add an output logging framework that captures deploy output and ships it to configurable destinations.

- `output:` config section with pluggable logger backends (OTel and file to start)
- `modify` method replaces `with_lock` as the integration point for all infrastructure-modifying commands — scopes output capture and instruments `ActiveSupport::Notifications` for deploy lifecycle events
- Output captured from two sources: CLI messages (Thor `say`) and remote command output (SSHKit formatter with per-host tagging)
- `ActiveSupport::BroadcastLogger` fans out to multiple loggers
- OTel logger ships log lines and structured lifecycle events (`kamal.start`/`kamal.complete`/`kamal.failed`) via OTLP HTTP, with OTel semantic convention attributes
- File logger writes one timestamped log file per command
- Log destinations printed on command completion
- Best-effort — output logger failures never block or fail a deploy

Idea by @djmb

## Usage

```yaml
# config/deploy.yml
output:
  otel:
    endpoint: http://otel-gateway:4318
  file:
    path: tmp/kamal/
```

## How it works

- `modify` replaces `with_lock` across all CLI commands. Every `modify` call enables output logging. The outermost `modify` instruments `modify.kamal` via AS::Notifications and closes loggers on exit. Nests safely.
- `Kamal::Output::Formatter` extends SSHKit's Pretty formatter to capture command output, tagging each line with `server.address` (host) and `log.iostream` (stdout/stderr) via thread-local context
- `Kamal::Output::OtelLogger` subscribes to `modify.kamal` start/finish for lifecycle events, receives log lines via BroadcastLogger `<<`. SSHKit severity levels mapped to OTel severity numbers.
- `Kamal::Output::FileLogger` opens a timestamped log file on start, discards pre-start lines, closes on finish
- `Kamal::OtelShipper` buffers lines in a thread-safe Queue, flushes every 5s or when buffer reaches batch size, via OTLP HTTP to `/v1/logs`
- OTel format follows semantic conventions: standard attributes (`deployment.*`, `exception.*`, `service.*`, `server.address`, `log.iostream`), custom attributes namespaced under `kamal.*` (`kamal.command`, `kamal.runtime`, `kamal.deploy_version`, `kamal.performer`, `kamal.run_id`)

## Test plan

- [x] `kamal deploy` with `output: otel:` configured — verify log records in collector (integration test)
- [x] `kamal deploy` with `output: file:` configured — verify timestamped log file with full output (integration test)
- [x] Deploy without `output:` — verify no behavioral change
- [x] Deploy with unreachable OTel endpoint — verify deploy completes normally (unit test)
- [x] Per-host tagging and iostream attributes on stream output (integration + unit tests)
- [x] Log summary output on command completion (integration + unit tests)
- [x] Full non-integration test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)