### PR TITLE
ci: harden GitHub Actions workflows

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+    schedule:
+      interval: weekly
+    cooldown:
+      default-days: 10

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,22 @@ jobs:
           bundler-cache: true
       - name: Run Rubocop
         run: bundle exec rubocop --parallel
+  lint-actions:
+    name: GitHub Actions audit
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run actionlint
+        uses: rhysd/actionlint@393031adb9afb225ee52ae2ccd7a5af5525e03e8 # v1.7.11
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@71321a20a9ded102f6e9ce5718a2fcec2c4f70d8 # v0.5.2
+        with:
+          advanced-security: false
   tests:
     strategy:
       fail-fast: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       - name: Setup Ruby and install gems
         uses: ruby/setup-ruby@708024e6c902387ab41de36e1669e43b5ee7085e # v1.283.0
         with:
@@ -46,6 +48,8 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/${{ matrix.gemfile }}
     steps:
       - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
 
       - name: Remove gemfile.lock
         run: rm Gemfile.lock

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,8 +9,6 @@ on:
     
   release:
     types: [created]
-    tags:
-      - 'v*'
 
 permissions: {}
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -38,11 +38,13 @@ jobs:
       - name: Determine version tag
         id: version-tag
         run: |
-          INPUT_VALUE="${{ github.event.inputs.tagInput }}"
+          INPUT_VALUE="${GITHUB_EVENT_INPUTS_TAGINPUT}"
           if [ -z "$INPUT_VALUE" ]; then
-            INPUT_VALUE="${{ github.ref_name }}"
+            INPUT_VALUE="${GITHUB_REF_NAME}"
           fi
           echo "::set-output name=value::$INPUT_VALUE"
+        env:
+          GITHUB_EVENT_INPUTS_TAGINPUT: ${{ github.event.inputs.tagInput }}
       -
         name: Build and push
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6.18.0

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -46,7 +46,7 @@ jobs:
           if [ -z "$INPUT_VALUE" ]; then
             INPUT_VALUE="${GITHUB_REF_NAME}"
           fi
-          echo "::set-output name=value::$INPUT_VALUE"
+          echo "value=$INPUT_VALUE" >> "$GITHUB_OUTPUT"
         env:
           GITHUB_EVENT_INPUTS_TAGINPUT: ${{ github.event.inputs.tagInput }}
       -

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -12,6 +12,8 @@ on:
     tags:
       - 'v*'
 
+permissions: {}
+
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
@@ -22,6 +24,8 @@ jobs:
       -
         name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          persist-credentials: false
       -
         name: Set up QEMU
         uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3.7.0


### PR DESCRIPTION
## Summary
- Fix zizmor findings: template-injection, artipacked, excessive-permissions
- Add zizmor + actionlint CI job
- Configure dependabot with weekly batching and 10-day cooldown

## Test plan
- [ ] CI passes on this branch
- [ ] Verify zizmor reports clean: `zizmor .`