### PR TITLE
Detect accessory image changes during boot

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -16,14 +16,14 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
             if capture_with_info(*accessory.info(all: true, quiet: true)).strip.presence
               running_image = capture_with_info(*accessory.running_image).strip.presence
               if running_image && running_image != accessory.image
-                raise "Accessory `#{name}` image has changed (#{running_image} → #{accessory.image}), run `kamal accessory reboot #{name}` to update"
+                raise "Accessory `#{name}` image has changed on host #{host} (#{running_image} → #{accessory.image}), run `kamal accessory reboot #{name}` to update"
               end
               booted_hosts << host.to_s
             end
           end
 
           if booted_hosts.any?
-            say "Skipping booting `#{name}` on #{booted_hosts.sort.join(", ")}, already running with the correct image", :yellow
+            say "Skipping booting `#{name}` on #{booted_hosts.sort.join(", ")}, container already exists with the correct image", :yellow
             hosts -= booted_hosts
           end
 

--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -13,11 +13,17 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
         with_accessory(name) do |accessory, hosts|
           booted_hosts = Concurrent::Array.new
           on(hosts) do |host|
-            booted_hosts << host.to_s if capture_with_info(*accessory.info(all: true, quiet: true)).strip.presence
+            if capture_with_info(*accessory.info(all: true, quiet: true)).strip.presence
+              running_image = capture_with_info(*accessory.running_image).strip.presence
+              if running_image && running_image != accessory.image
+                raise "Accessory `#{name}` image has changed (#{running_image} → #{accessory.image}), run `kamal accessory reboot #{name}` to update"
+              end
+              booted_hosts << host.to_s
+            end
           end
 
           if booted_hosts.any?
-            say "Skipping booting `#{name}` on #{booted_hosts.sort.join(", ")}, a container already exists", :yellow
+            say "Skipping booting `#{name}` on #{booted_hosts.sort.join(", ")}, already running with the correct image", :yellow
             hosts -= booted_hosts
           end
 

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -91,6 +91,10 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
     end
   end
 
+  def running_image
+    docker :inspect, service_name, "--format '{{.Config.Image}}'"
+  end
+
   def pull_image
     docker :image, :pull, image
   end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -19,6 +19,42 @@ class CliAccessoryTest < CliTestCase
     end
   end
 
+  test "boot with image changed" do
+    Thread.report_on_exception = false
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:docker, :ps, "-a", "-q", "--filter", "label=service=app-mysql")
+      .returns("abc123")
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:docker, :inspect, "app-mysql", "--format '{{.Config.Image}}'")
+      .returns("private.registry/mysql:5.6")
+
+    exception = assert_raises do
+      run_command("boot", "mysql")
+    end
+
+    assert_includes exception.message, "Accessory `mysql` image has changed (private.registry/mysql:5.6 → private.registry/mysql:5.7)"
+    assert_includes exception.message, "run `kamal accessory reboot mysql` to update"
+  ensure
+    Thread.report_on_exception = true
+  end
+
+  test "boot with same image" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:docker, :ps, "-a", "-q", "--filter", "label=service=app-mysql")
+      .returns("abc123")
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:docker, :inspect, "app-mysql", "--format '{{.Config.Image}}'")
+      .returns("private.registry/mysql:5.7")
+
+    run_command("boot", "mysql").tap do |output|
+      assert_match "already running with the correct image", output
+      assert_no_match(/docker run/, output)
+    end
+  end
+
   test "boot all" do
     Kamal::Cli::Accessory.any_instance.expects(:directories).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:upload).with("mysql")

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -34,7 +34,8 @@ class CliAccessoryTest < CliTestCase
       run_command("boot", "mysql")
     end
 
-    assert_includes exception.message, "Accessory `mysql` image has changed (private.registry/mysql:5.6 → private.registry/mysql:5.7)"
+    assert_includes exception.message, "Accessory `mysql` image has changed on host"
+    assert_includes exception.message, "(private.registry/mysql:5.6 → private.registry/mysql:5.7)"
     assert_includes exception.message, "run `kamal accessory reboot mysql` to update"
   ensure
     Thread.report_on_exception = true
@@ -50,7 +51,7 @@ class CliAccessoryTest < CliTestCase
       .returns("private.registry/mysql:5.7")
 
     run_command("boot", "mysql").tap do |output|
-      assert_match "already running with the correct image", output
+      assert_match "container already exists with the correct image", output
       assert_no_match(/docker run/, output)
     end
   end


### PR DESCRIPTION
## Summary

`kamal accessory boot` currently silently skips accessories when a container already exists, regardless of whether the configured image has changed. This makes it impossible for CI/CD pipelines to detect stale accessories — the only option is to unconditionally reboot all accessories on every deploy, causing unnecessary downtime.

This PR adds image change detection to `accessory boot`, following the same pattern established for `proxy boot` (which checks the running proxy version and raises when outdated).

**When the image has changed:**
```
Accessory `db` image has changed (postgres:16 → postgres:17),
run `kamal accessory reboot db` to update
```

**When the image matches:** the accessory is skipped as before (no-op).

This enables CI/CD pipelines to handle accessory updates the same way they handle proxy updates:

```bash
kamal accessory boot all || kamal accessory reboot all -y
```

## Changes

- **`lib/kamal/commands/accessory.rb`** — Added `running_image` method (mirrors proxy's `version` method)
- **`lib/kamal/cli/accessory.rb`** — Modified `boot` to compare running image against configured image; raises when they differ
- **`test/cli/accessory_test.rb`** — Added tests for image changed (raises) and same image (skips)

## Test plan

- [x] `bin/test test/cli/accessory_test.rb` — 34 runs, 180 assertions, 0 failures
- [x] `bin/test test/cli/proxy_test.rb` — 36 runs, 376 assertions, 0 failures
- [x] `bin/test test/commands/accessory_test.rb test/commands/proxy_test.rb` — all pass
- [x] Existing `boot`, `boot all`, `reboot` tests unaffected