### PR TITLE
Add `kamal app create` and `kamal accessory create` for standby container deployment

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -105,6 +105,27 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
     end
   end
 
+  desc "create [NAME]", "Create accessory container on host without starting it (use NAME=all to create all accessories)"
+  def create(name)
+    with_lock do
+      if name == "all"
+        KAMAL.accessory_names.each { |accessory_name| create(accessory_name) }
+      else
+        directories(name)
+        upload(name)
+
+        with_accessory(name) do |accessory, hosts|
+          on(hosts) do |host|
+            execute *KAMAL.auditor.record("Created #{name} accessory"), verbosity: :debug
+            execute *accessory.ensure_env_directory
+            upload! accessory.secrets_io, accessory.secrets_path, mode: "0600"
+            execute *accessory.create(host: host)
+          end
+        end
+      end
+    end
+  end
+
   desc "stop [NAME]", "Stop existing accessory container on host"
   def stop(name)
     with_lock do

--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -59,6 +59,48 @@ class Kamal::Cli::App < Kamal::Cli::Base
     end
   end
 
+  desc "create", "Create app container on servers without starting it"
+  def create
+    with_lock do
+      using_version(version_or_latest) do |version|
+        # Assets are prepared in a separate step to ensure they are on all hosts before creating
+        on(KAMAL.app_hosts) do
+          Kamal::Cli::App::ErrorPages.new(host, self).run
+
+          KAMAL.roles_on(host).each do |role|
+            Kamal::Cli::App::Assets.new(host, role, self).run
+            Kamal::Cli::App::SslCertificates.new(host, role, self).run
+          end
+        end
+
+        on_roles(KAMAL.roles, hosts: KAMAL.app_hosts, parallel: KAMAL.config.boot.parallel_roles) do |host, role|
+          app = KAMAL.app(role: role, host: host)
+
+          # Rename any existing container with the same version to avoid conflicts
+          if capture_with_info(*app.container_id_for_version(version), raise_on_non_zero_exit: false).present?
+            renamed_version = "#{version}_replaced_#{SecureRandom.hex(8)}"
+            info "Renaming container #{version} to #{renamed_version} as already exists on #{host}"
+            execute *KAMAL.auditor.record("Renaming container #{version} to #{renamed_version}", role: role), verbosity: :debug
+            execute *app.rename_container(version: version, new_version: renamed_version)
+          end
+
+          hostname = "#{host.to_s[0...51].chomp(".")}-#{SecureRandom.hex(6)}"
+
+          execute *KAMAL.auditor.record("Created app version #{version}", role: role), verbosity: :debug
+          execute *app.ensure_env_directory
+          upload! role.secrets_io(host), role.secrets_path, mode: "0600"
+          execute *app.create(hostname: hostname)
+        end
+
+        # Tag once the app booted on all hosts
+        on(KAMAL.app_hosts) do |host|
+          execute *KAMAL.auditor.record("Tagging #{KAMAL.config.absolute_image} as the latest image"), verbosity: :debug
+          execute *KAMAL.app.tag_latest_image
+        end
+      end
+    end
+  end
+
   desc "stop", "Stop app container on servers"
   def stop
     with_lock do

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -29,6 +29,22 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
       cmd
   end
 
+  def create(host: nil)
+    docker :create,
+      "--name", service_name,
+      "--restart", "unless-stopped",
+      *network_args,
+      *config.logging_args,
+      *publish_args,
+      *([ "--env", "KAMAL_HOST=\"#{host}\"" ] if host),
+      *env_args,
+      *volume_args,
+      *label_args,
+      *option_args,
+      image,
+      cmd
+  end
+
   def start
     docker :container, :start, service_name
   end

--- a/lib/kamal/commands/app.rb
+++ b/lib/kamal/commands/app.rb
@@ -34,6 +34,26 @@ class Kamal::Commands::App < Kamal::Commands::Base
       role.cmd
   end
 
+  def create(hostname: nil)
+    docker :create,
+      "--restart unless-stopped",
+      "--name", container_name,
+      "--network", "kamal",
+      *([ "--hostname", hostname ] if hostname),
+      "--env", "KAMAL_CONTAINER_NAME=\"#{container_name}\"",
+      "--env", "KAMAL_VERSION=\"#{config.version}\"",
+      "--env", "KAMAL_HOST=\"#{host}\"",
+      *([ "--env", "KAMAL_DESTINATION=\"#{config.destination}\"" ] if config.destination),
+      *role.env_args(host),
+      *role.logging_args,
+      *config.volume_args,
+      *role.asset_volume_args,
+      *role.label_args,
+      *role.option_args,
+      config.absolute_image,
+      role.cmd
+  end
+
   def start
     docker :start, container_name
   end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -47,9 +47,9 @@ class CliAccessoryTest < CliTestCase
     Kamal::Cli::Accessory.any_instance.expects(:upload).with("mysql")
 
     run_command("create", "mysql").tap do |output|
-      assert_match "docker create --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
-      # Should NOT contain start command
-      assert_no_match /docker container start/, output
+      assert_match "docker create --name app-mysql --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      # Should NOT contain run command
+      assert_no_match /docker run/, output
     end
   end
 
@@ -62,12 +62,12 @@ class CliAccessoryTest < CliTestCase
     Kamal::Cli::Accessory.any_instance.expects(:upload).with("busybox")
 
     run_command("create", "all").tap do |output|
-      assert_match "docker create --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
-      assert_match "docker create --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
-      assert_match "docker create --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
-      assert_match "docker create --name custom-box --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --env KAMAL_HOST=\"1.1.1.3\" --env-file .kamal/apps/app/env/accessories/busybox.env --label service=\"custom-box\" other.registry/busybox:latest on 1.1.1.3", output
-      # Should NOT contain start commands
-      assert_no_match /docker container start/, output
+      assert_match "docker create --name app-mysql --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker create --name app-redis --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker create --name app-redis --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
+      assert_match "docker create --name custom-box --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --env KAMAL_HOST=\"1.1.1.3\" --env-file .kamal/apps/app/env/accessories/busybox.env --label service=\"custom-box\" other.registry/busybox:latest on 1.1.1.3", output
+      # Should NOT contain run commands
+      assert_no_match /docker run/, output
     end
   end
 

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -42,6 +42,35 @@ class CliAccessoryTest < CliTestCase
     end
   end
 
+  test "create" do
+    Kamal::Cli::Accessory.any_instance.expects(:directories).with("mysql")
+    Kamal::Cli::Accessory.any_instance.expects(:upload).with("mysql")
+
+    run_command("create", "mysql").tap do |output|
+      assert_match "docker create --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      # Should NOT contain start command
+      assert_no_match /docker container start/, output
+    end
+  end
+
+  test "create all" do
+    Kamal::Cli::Accessory.any_instance.expects(:directories).with("mysql")
+    Kamal::Cli::Accessory.any_instance.expects(:upload).with("mysql")
+    Kamal::Cli::Accessory.any_instance.expects(:directories).with("redis")
+    Kamal::Cli::Accessory.any_instance.expects(:upload).with("redis")
+    Kamal::Cli::Accessory.any_instance.expects(:directories).with("busybox")
+    Kamal::Cli::Accessory.any_instance.expects(:upload).with("busybox")
+
+    run_command("create", "all").tap do |output|
+      assert_match "docker create --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker create --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker create --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
+      assert_match "docker create --name custom-box --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --env KAMAL_HOST=\"1.1.1.3\" --env-file .kamal/apps/app/env/accessories/busybox.env --label service=\"custom-box\" other.registry/busybox:latest on 1.1.1.3", output
+      # Should NOT contain start commands
+      assert_no_match /docker container start/, output
+    end
+  end
+
   test "upload" do
     run_command("upload", "mysql").tap do |output|
       assert_match "mkdir -p app-mysql/etc/mysql", output

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -266,9 +266,9 @@ class CliAppTest < CliTestCase
     stub_running
 
     run_command("create").tap do |output|
-      assert_match /docker create --detach --restart unless-stopped --name app-web-latest --network kamal --hostname 1.1.1.1-[0-9a-f]{12}/, output
-      # Should NOT contain start command
-      assert_no_match /docker start/, output
+      assert_match /docker create --restart unless-stopped --name app-web-latest --network kamal --hostname 1.1.1.1-[0-9a-f]{12}/, output
+      # Should NOT contain run command
+      assert_no_match /docker run/, output
       # Should NOT try to deploy to proxy (container not running)
       assert_no_match /kamal-proxy deploy/, output
     end
@@ -284,9 +284,9 @@ class CliAppTest < CliTestCase
     run_command("create").tap do |output|
       assert_match /Renaming container .* to .* as already exists on 1.1.1.1/, output
       assert_match /docker rename app-web-latest app-web-latest_replaced_[0-9a-f]{16}/, output
-      assert_match /docker create --detach --restart unless-stopped --name app-web-latest --network kamal --hostname 1.1.1.1-[0-9a-f]{12}/, output
-      # Should NOT contain start command or proxy deployment
-      assert_no_match /docker start/, output
+      assert_match /docker create --restart unless-stopped --name app-web-latest --network kamal --hostname 1.1.1.1-[0-9a-f]{12}/, output
+      # Should NOT contain run command or proxy deployment
+      assert_no_match /docker run/, output
       assert_no_match /kamal-proxy deploy/, output
     end
   end

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -262,6 +262,35 @@ class CliAppTest < CliTestCase
     end
   end
 
+  test "create" do
+    stub_running
+
+    run_command("create").tap do |output|
+      assert_match /docker create --detach --restart unless-stopped --name app-web-latest --network kamal --hostname 1.1.1.1-[0-9a-f]{12}/, output
+      # Should NOT contain start command
+      assert_no_match /docker start/, output
+      # Should NOT try to deploy to proxy (container not running)
+      assert_no_match /kamal-proxy deploy/, output
+    end
+  end
+
+  test "create will rename if same version already exists" do
+    stub_running
+
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+      .with(:docker, :container, :ls, "--all", "--filter", "'name=^app-web-latest$'", "--quiet", raise_on_non_zero_exit: false)
+      .returns("12345678") # existing container
+
+    run_command("create").tap do |output|
+      assert_match /Renaming container .* to .* as already exists on 1.1.1.1/, output
+      assert_match /docker rename app-web-latest app-web-latest_replaced_[0-9a-f]{16}/, output
+      assert_match /docker create --detach --restart unless-stopped --name app-web-latest --network kamal --hostname 1.1.1.1-[0-9a-f]{12}/, output
+      # Should NOT contain start command or proxy deployment
+      assert_no_match /docker start/, output
+      assert_no_match /kamal-proxy deploy/, output
+    end
+  end
+
   test "stop" do
     run_command("stop").tap do |output|
       assert_match "sh -c 'docker ps --latest --quiet --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --quiet --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting' | head -1 | xargs docker stop", output

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -91,21 +91,21 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
 
   test "create" do
     assert_equal \
-      "docker create --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
+      "docker create --name app-mysql --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
       new_command(:mysql).create.join(" ")
 
     assert_equal \
-      "docker create --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env SOMETHING=\"else\" --env-file .kamal/apps/app/env/accessories/redis.env --volume /var/lib/redis:/data --label service=\"app-redis\" --label cache=\"true\" redis:latest",
+      "docker create --name app-redis --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env SOMETHING=\"else\" --env-file .kamal/apps/app/env/accessories/redis.env --volume /var/lib/redis:/data --label service=\"app-redis\" --label cache=\"true\" redis:latest",
       new_command(:redis).create.join(" ")
 
     assert_equal \
-      "docker create --name custom-busybox --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --env-file .kamal/apps/app/env/accessories/busybox.env --label service=\"custom-busybox\" other.registry/busybox:latest",
+      "docker create --name custom-busybox --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --env-file .kamal/apps/app/env/accessories/busybox.env --label service=\"custom-busybox\" other.registry/busybox:latest",
       new_command(:busybox).create.join(" ")
   end
 
   test "create with host" do
     assert_equal \
-      "docker create --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.5\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
+      "docker create --name app-mysql --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.5\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
       new_command(:mysql).create(host: "1.1.1.5").join(" ")
   end
 

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -89,6 +89,26 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
       new_command(:mysql).run.join(" ")
   end
 
+  test "create" do
+    assert_equal \
+      "docker create --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
+      new_command(:mysql).create.join(" ")
+
+    assert_equal \
+      "docker create --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env SOMETHING=\"else\" --env-file .kamal/apps/app/env/accessories/redis.env --volume /var/lib/redis:/data --label service=\"app-redis\" --label cache=\"true\" redis:latest",
+      new_command(:redis).create.join(" ")
+
+    assert_equal \
+      "docker create --name custom-busybox --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --env-file .kamal/apps/app/env/accessories/busybox.env --label service=\"custom-busybox\" other.registry/busybox:latest",
+      new_command(:busybox).create.join(" ")
+  end
+
+  test "create with host" do
+    assert_equal \
+      "docker create --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.5\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
+      new_command(:mysql).create(host: "1.1.1.5").join(" ")
+  end
+
   test "start" do
     assert_equal \
       "docker container start app-mysql",


### PR DESCRIPTION


### Motivation

See issue https://github.com/basecamp/kamal/issues/1809. We need to deploy containers to standby hosts in a Created (stopped) state, to be activated later with kamal app start / kamal accessory start. This enables near-instant failover and precise maintenance-window cutover without requiring operator knowledge of kamal's internal docker invocation.

### Changes

* app.rb — adds App#create, mirroring App#run but using docker create instead of docker run. The --detach flag is omitted (meaningless for an unstarted container).
* accessory.rb — adds Accessory#create, same pattern.
* app.rb — kamal app create: performs asset/SSL/error-page prep and the rename-on-conflict deduplication logic identical to boot, then calls app.create. Deliberately omits docker start and kamal-proxy deploy.
* accessory.rb — kamal accessory create [NAME] / NAME=all: performs directory creation, file upload, secrets upload, then calls accessory.create. Skips proxy registration.
* app_test.rb, accessory_test.rb, app_test.rb, accessory_test.rb — test coverage for all new commands, including verification that docker start and kamal-proxy deploy are not issued.

