### PR TITLE
Add a stop_timeout option

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -241,6 +241,10 @@ class Kamal::Configuration
     raw_config.drain_timeout || 30
   end
 
+  def stop_timeout
+    raw_config.stop_timeout
+  end
+
   def run_directory
     ".kamal"
   end

--- a/lib/kamal/configuration/docs/configuration.yml
+++ b/lib/kamal/configuration/docs/configuration.yml
@@ -159,6 +159,13 @@ deploy_timeout: 10
 # How long to wait for a container to drain, default 30:
 drain_timeout: 10
 
+# Stop timeout
+#
+# How long to wait for a container to stop after SIGTERM, default is
+# the drain_timeout for non-proxied roles and 10s (Docker default) for proxied roles.
+# Can be overridden per role:
+stop_timeout: 30
+
 # Run directory
 #
 # Directory to store kamal runtime files in on the host, default `.kamal`:

--- a/lib/kamal/configuration/docs/role.yml
+++ b/lib/kamal/configuration/docs/role.yml
@@ -39,6 +39,7 @@ servers:
       - 172.1.0.3
       - 172.1.0.4: experiment1
     cmd: "bin/jobs"
+    stop_timeout: 30
     options:
       memory: 2g
       cpus: 4

--- a/lib/kamal/configuration/role.rb
+++ b/lib/kamal/configuration/role.rb
@@ -81,9 +81,13 @@ class Kamal::Configuration::Role
 
   def stop_args
     # When deploying with the proxy, kamal-proxy will drain request before returning so we don't need to wait.
-    timeout = running_proxy? ? nil : config.drain_timeout
+    timeout = stop_timeout || (running_proxy? ? nil : config.drain_timeout)
 
     [ *argumentize("-t", timeout) ]
+  end
+
+  def stop_timeout
+    specializations["stop_timeout"] || config.stop_timeout
   end
 
   def env(host)

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -101,6 +101,17 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command(role: "workers").stop.join(" ")
   end
 
+  test "stop with stop_timeout" do
+    @config[:servers] = { "web" => { "hosts" => [ "1.1.1.1" ], "stop_timeout" => 30 }, "workers" => { "hosts" => [ "1.1.1.2" ], "cmd" => "bin/jobs", "stop_timeout" => 60 } }
+    assert_equal \
+      "sh -c 'docker ps --latest --quiet --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --quiet --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting' | head -1 | xargs docker stop -t 30",
+      new_command.stop.join(" ")
+
+    assert_equal \
+      "sh -c 'docker ps --latest --quiet --filter label=service=app --filter label=destination= --filter label=role=workers --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --quiet --filter label=service=app --filter label=destination= --filter label=role=workers --filter status=running --filter status=restarting' | head -1 | xargs docker stop -t 60",
+      new_command(role: "workers").stop.join(" ")
+  end
+
   test "stop with version" do
     assert_equal \
       "docker container ls --all --filter 'name=^app-web-123$' --quiet | xargs docker stop",

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -109,6 +109,17 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command(role: "workers").stop.join(" ")
   end
 
+  test "stop with stop_timeout" do
+    @config[:servers] = { "web" => { "hosts" => [ "1.1.1.1" ], "stop_timeout" => 30 }, "workers" => { "hosts" => [ "1.1.1.2" ], "cmd" => "bin/jobs", "stop_timeout" => 60 } }
+    assert_equal \
+      "sh -c 'docker ps --latest --quiet --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --quiet --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting' | head -1 | xargs docker stop -t 30",
+      new_command.stop.join(" ")
+
+    assert_equal \
+      "sh -c 'docker ps --latest --quiet --filter label=service=app --filter label=destination= --filter label=role=workers --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --quiet --filter label=service=app --filter label=destination= --filter label=role=workers --filter status=running --filter status=restarting' | head -1 | xargs docker stop -t 60",
+      new_command(role: "workers").stop.join(" ")
+  end
+
   test "stop with version" do
     assert_equal \
       "docker container ls --all --filter 'name=^app-web-123$' --quiet | xargs docker stop",

--- a/test/configuration/role_test.rb
+++ b/test/configuration/role_test.rb
@@ -278,6 +278,29 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
     assert_equal [ "-t", 30 ], config_with_roles.role(:workers).stop_args
   end
 
+  test "stop args with proxy and stop_timeout" do
+    @deploy_with_roles[:servers]["web"] = { "hosts" => [ "1.1.1.1", "1.1.1.2" ], "stop_timeout" => 60 }
+    assert_equal [ "-t", 60 ], config_with_roles.role(:web).stop_args
+  end
+
+  test "stop args with no proxy and stop_timeout" do
+    @deploy_with_roles[:servers]["workers"] = { "hosts" => [ "1.1.1.3", "1.1.1.4" ], "cmd" => "bin/jobs", "stop_timeout" => 60 }
+    assert_equal [ "-t", 60 ], config_with_roles.role(:workers).stop_args
+  end
+
+  test "stop args with root stop_timeout" do
+    @deploy_with_roles[:stop_timeout] = 45
+    assert_equal [ "-t", 45 ], config_with_roles.role(:web).stop_args
+    assert_equal [ "-t", 45 ], config_with_roles.role(:workers).stop_args
+  end
+
+  test "stop args with role stop_timeout overriding root" do
+    @deploy_with_roles[:stop_timeout] = 45
+    @deploy_with_roles[:servers]["web"] = { "hosts" => [ "1.1.1.1", "1.1.1.2" ], "stop_timeout" => 60 }
+    assert_equal [ "-t", 60 ], config_with_roles.role(:web).stop_args
+    assert_equal [ "-t", 45 ], config_with_roles.role(:workers).stop_args
+  end
+
   test "role specific proxy config" do
     @deploy_with_roles[:proxy] = { "response_timeout" => 15 }
     @deploy_with_roles[:servers]["workers"]["proxy"] = { "response_timeout" => 18 }

--- a/test/configuration/role_test.rb
+++ b/test/configuration/role_test.rb
@@ -289,6 +289,29 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
     assert_equal "unless-stopped", config_with_roles.role(:workers).restart_policy
   end
 
+  test "stop args with proxy and stop_timeout" do
+    @deploy_with_roles[:servers]["web"] = { "hosts" => [ "1.1.1.1", "1.1.1.2" ], "stop_timeout" => 60 }
+    assert_equal [ "-t", 60 ], config_with_roles.role(:web).stop_args
+  end
+
+  test "stop args with no proxy and stop_timeout" do
+    @deploy_with_roles[:servers]["workers"] = { "hosts" => [ "1.1.1.3", "1.1.1.4" ], "cmd" => "bin/jobs", "stop_timeout" => 60 }
+    assert_equal [ "-t", 60 ], config_with_roles.role(:workers).stop_args
+  end
+
+  test "stop args with root stop_timeout" do
+    @deploy_with_roles[:stop_timeout] = 45
+    assert_equal [ "-t", 45 ], config_with_roles.role(:web).stop_args
+    assert_equal [ "-t", 45 ], config_with_roles.role(:workers).stop_args
+  end
+
+  test "stop args with role stop_timeout overriding root" do
+    @deploy_with_roles[:stop_timeout] = 45
+    @deploy_with_roles[:servers]["web"] = { "hosts" => [ "1.1.1.1", "1.1.1.2" ], "stop_timeout" => 60 }
+    assert_equal [ "-t", 60 ], config_with_roles.role(:web).stop_args
+    assert_equal [ "-t", 45 ], config_with_roles.role(:workers).stop_args
+  end
+
   test "role specific proxy config" do
     @deploy_with_roles[:proxy] = { "response_timeout" => 15 }
     @deploy_with_roles[:servers]["workers"]["proxy"] = { "response_timeout" => 18 }


### PR DESCRIPTION
The `drain_timeout` option is used to allow in flight requests to finish.

For proxied roles draining is handled by the proxy deploy command - once it starts no new requests are sent to the old container. Then when calling `docker stop` we can use a short timeout (we use the default of 10s, but really it should be shorter).

For non-proxied roles calling `docker stop` initially sends a SIGTERM and we assume that will start the drain process, so we use drain timeout as the timeout there.

If you are running proxy + non-proxied workloads in a single container, then the default behaviour means that the non-proxied workload will get a 10 second timeout via `docker stop`, which may not be enough.

Add a `stop_timeout` option that allows you to configure the timeout used for `docker stop`. By default it will use the drain timeout for non-proxied roles and 10s for proxied roles, but you can override it globally or per role.