### PR TITLE
fix: use portable shebang in sample hooks

### DIFF
--- a/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
+++ b/lib/kamal/cli/templates/sample_hooks/docker-setup.sample
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 echo "Docker set up on $KAMAL_HOSTS..."

--- a/lib/kamal/cli/templates/sample_hooks/post-app-boot.sample
+++ b/lib/kamal/cli/templates/sample_hooks/post-app-boot.sample
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 echo "Booted app version $KAMAL_VERSION on $KAMAL_HOSTS..."

--- a/lib/kamal/cli/templates/sample_hooks/post-deploy.sample
+++ b/lib/kamal/cli/templates/sample_hooks/post-deploy.sample
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # A sample post-deploy hook
 #

--- a/lib/kamal/cli/templates/sample_hooks/post-proxy-reboot.sample
+++ b/lib/kamal/cli/templates/sample_hooks/post-proxy-reboot.sample
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 echo "Rebooted kamal-proxy on $KAMAL_HOSTS"

--- a/lib/kamal/cli/templates/sample_hooks/pre-app-boot.sample
+++ b/lib/kamal/cli/templates/sample_hooks/pre-app-boot.sample
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 echo "Booting app version $KAMAL_VERSION on $KAMAL_HOSTS..."

--- a/lib/kamal/cli/templates/sample_hooks/pre-build.sample
+++ b/lib/kamal/cli/templates/sample_hooks/pre-build.sample
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 # A sample pre-build hook
 #

--- a/lib/kamal/cli/templates/sample_hooks/pre-proxy-reboot.sample
+++ b/lib/kamal/cli/templates/sample_hooks/pre-proxy-reboot.sample
@@ -1,3 +1,3 @@
-#!/bin/sh
+#!/usr/bin/env sh
 
 echo "Rebooting kamal-proxy on $KAMAL_HOSTS..."


### PR DESCRIPTION
On some systems, like NixOS or certain BSDs, the shell isn't located at `/bin/sh`. Using `#!/usr/bin/env sh` instead resolves this by searching the user's `PATH`, matching the pattern already used in the Ruby sample hooks (`pre-connect.sample` and `pre-deploy.sample`).