### PR TITLE
Add value equality to Proxy::Run

### DIFF
--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -131,6 +131,15 @@ class Kamal::Configuration::Proxy::Run
     File.join apps_container_directory, config.service_and_destination
   end
 
+  def ==(other)
+    other.is_a?(self.class) && run_config == other.run_config
+  end
+  alias_method :eql?, :==
+
+  def hash
+    run_config.hash
+  end
+
   private
     def format_bind_ip(ip)
       # Ensure IPv6 address inside square brackets - e.g. [::1]

--- a/test/configuration/proxy/run_test.rb
+++ b/test/configuration/proxy/run_test.rb
@@ -1,0 +1,68 @@
+require "test_helper"
+
+class ConfigurationProxyRunTest < ActiveSupport::TestCase
+  setup do
+    ENV["RAILS_MASTER_KEY"] = "456"
+    ENV["VERSION"] = "missing"
+  end
+
+  test "run objects with identical config are equal" do
+    deploy = base_deploy.deep_merge(proxy: { "run" => { "log_max_size" => "50m" } })
+    config = Kamal::Configuration.new(deploy)
+
+    run_a = Kamal::Configuration::Proxy::Run.new(config, run_config: { "log_max_size" => "50m" })
+    run_b = Kamal::Configuration::Proxy::Run.new(config, run_config: { "log_max_size" => "50m" })
+
+    assert_equal run_a, run_b
+    assert_equal run_a.hash, run_b.hash
+    assert_equal 1, [ run_a, run_b ].uniq.size
+  end
+
+  test "run objects with different config are not equal" do
+    deploy = base_deploy.deep_merge(proxy: { "run" => { "log_max_size" => "50m" } })
+    config = Kamal::Configuration.new(deploy)
+
+    run_a = Kamal::Configuration::Proxy::Run.new(config, run_config: { "log_max_size" => "50m" })
+    run_b = Kamal::Configuration::Proxy::Run.new(config, run_config: { "log_max_size" => "100m" })
+
+    assert_not_equal run_a, run_b
+    assert_equal 2, [ run_a, run_b ].uniq.size
+  end
+
+  test "no conflict when global proxy run config is inherited by role proxy" do
+    deploy = base_deploy.deep_merge(
+      servers: {
+        "web" => { "hosts" => [ "1.1.1.1" ] },
+        "worker" => {
+          "hosts" => [ "1.1.1.1" ],
+          "cmd" => "bin/jobs",
+          "proxy" => {
+            "hosts" => [ "worker.example.com" ],
+            "app_port" => 8080
+          }
+        }
+      },
+      proxy: {
+        "hosts" => [ "example.com" ],
+        "run" => {
+          "log_max_size" => "",
+          "options" => { "log-driver" => "journald" }
+        }
+      }
+    )
+
+    # Should not raise Kamal::ConfigurationError
+    config = Kamal::Configuration.new(deploy)
+    assert config
+  end
+
+  private
+    def base_deploy
+      {
+        service: "app", image: "dhh/app",
+        registry: { "username" => "dhh", "password" => "secret" },
+        builder: { "arch" => "amd64" },
+        servers: [ "1.1.1.1" ]
+      }
+    end
+end


### PR DESCRIPTION
When multiple roles share a host, the global `proxy.run` config gets merged into each role's proxy config via `deep_merge`. This creates separate `Run` objects with identical `run_config` hashes.

`ensure_no_conflicting_proxy_runs` uses `Array#uniq` to detect conflicts, but `Run` doesn't implement `==`/`eql?`/`hash`, so `uniq` compares by object identity. The check always fails when two or more roles with proxy config exist on the same host, even if the merged run configs are identical.

### Changes

- Add `==`, `eql?`, and `hash` to `Proxy::Run` based on `run_config`
- Add tests for value equality and the multi-role-same-host scenario

### Reproduction

```yaml
servers:
  web:
    hosts:
      - 1.1.1.1
  worker:
    hosts:
      - 1.1.1.1
    proxy:
      hosts:
        - worker.example.com
      app_port: 8080

proxy:
  hosts:
    - example.com
  run:
    log_max_size: ""
    options:
      log-driver: journald
```

```
$ kamal config
ERROR (Kamal::ConfigurationError): Conflicting proxy run configurations for host 1.1.1.1
```