### PR TITLE
Upload custom SSL certificates for accessories

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -28,6 +28,9 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
             execute *KAMAL.auditor.record("Booted #{name} accessory"), verbosity: :debug
             execute *accessory.ensure_env_directory
             upload! accessory.secrets_io, accessory.secrets_path, mode: "0600"
+
+            Kamal::Cli::Accessory::SslCertificates.new(accessory, self).run
+
             execute *accessory.run(host: host)
 
             if accessory.running_proxy?

--- a/lib/kamal/cli/accessory/ssl_certificates.rb
+++ b/lib/kamal/cli/accessory/ssl_certificates.rb
@@ -11,15 +11,32 @@ class Kamal::Cli::Accessory::SslCertificates
     return unless accessory.running_proxy? && accessory.proxy.custom_ssl_certificate?
 
     proxy = accessory.proxy
+    ssl = proxy.proxy_config["ssl"]
+
+    cert_content = require_secret!(
+      content: proxy.certificate_pem_content,
+      secret_key: ssl["certificate_pem"],
+      config_key: "certificate_pem"
+    )
+    key_content = require_secret!(
+      content: proxy.private_key_pem_content,
+      secret_key: ssl["private_key_pem"],
+      config_key: "private_key_pem"
+    )
 
     info "Writing SSL certificates for accessory #{accessory.name}"
     execute *accessory.create_ssl_directory
 
-    if (cert_content = proxy.certificate_pem_content)
-      upload!(StringIO.new(cert_content), proxy.host_tls_cert, mode: "0644")
-    end
-    if (key_content = proxy.private_key_pem_content)
-      upload!(StringIO.new(key_content), proxy.host_tls_key, mode: "0644")
-    end
+    upload!(StringIO.new(cert_content), proxy.host_tls_cert, mode: "0644")
+    upload!(StringIO.new(key_content), proxy.host_tls_key, mode: "0644")
   end
+
+  private
+    def require_secret!(content:, secret_key:, config_key:)
+      return content if content.present?
+
+      raise ArgumentError,
+        "Missing SSL secret #{secret_key.inspect} " \
+        "for accessory #{accessory.name.inspect} (#{config_key})"
+    end
 end

--- a/lib/kamal/cli/accessory/ssl_certificates.rb
+++ b/lib/kamal/cli/accessory/ssl_certificates.rb
@@ -1,0 +1,25 @@
+class Kamal::Cli::Accessory::SslCertificates
+  attr_reader :accessory, :sshkit
+  delegate :execute, :info, :upload!, to: :sshkit
+
+  def initialize(accessory, sshkit)
+    @accessory = accessory
+    @sshkit = sshkit
+  end
+
+  def run
+    return unless accessory.running_proxy? && accessory.proxy.custom_ssl_certificate?
+
+    proxy = accessory.proxy
+
+    info "Writing SSL certificates for accessory #{accessory.name}"
+    execute *accessory.create_ssl_directory
+
+    if (cert_content = proxy.certificate_pem_content)
+      upload!(StringIO.new(cert_content), proxy.host_tls_cert, mode: "0644")
+    end
+    if (key_content = proxy.private_key_pem_content)
+      upload!(StringIO.new(key_content), proxy.host_tls_key, mode: "0644")
+    end
+  end
+end

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -2,7 +2,7 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
   include Proxy
 
   attr_reader :accessory_config
-  delegate :service_name, :image, :hosts, :port, :files, :directories, :cmd,
+  delegate :name, :service_name, :image, :hosts, :port, :files, :directories, :cmd,
            :network_args, :publish_args, :env_args, :volume_args, :label_args, :option_args,
            :secrets_io, :secrets_path, :env_directory, :proxy, :running_proxy?, :registry,
            to: :accessory_config

--- a/lib/kamal/commands/accessory/proxy.rb
+++ b/lib/kamal/commands/accessory/proxy.rb
@@ -9,6 +9,10 @@ module Kamal::Commands::Accessory::Proxy
     proxy_exec :remove, service_name
   end
 
+  def create_ssl_directory
+    make_directory File.join(config.proxy_boot.tls_directory, proxy.role_name)
+  end
+
   private
     def proxy_exec(*command)
       docker :exec, proxy_container_name, "kamal-proxy", *command

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -131,6 +131,7 @@ class Kamal::Configuration::Accessory
       Kamal::Configuration::Proxy.new \
         config: config,
         proxy_config: accessory_config["proxy"],
+        role_name: "accessories/#{name}",
         context: "accessories/#{name}/proxy",
         secrets: config.secrets
     end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -273,8 +273,29 @@ class CliAccessoryTest < CliTestCase
     end
   end
 
+  test "boot with custom ssl certificate" do
+    Kamal::Cli::Accessory.any_instance.expects(:directories).with("monitoring")
+    Kamal::Cli::Accessory.any_instance.expects(:upload).with("monitoring")
+    Kamal::Configuration::Proxy.any_instance.stubs(:custom_ssl_certificate?).returns(true)
+    Kamal::Configuration::Proxy.any_instance.stubs(:certificate_pem_content).returns("CERTIFICATE CONTENT")
+    Kamal::Configuration::Proxy.any_instance.stubs(:private_key_pem_content).returns("PRIVATE KEY CONTENT")
+
+    run_command_with_custom_ssl("boot", "monitoring").tap do |output|
+      assert_match "Writing SSL certificates for accessory monitoring", output
+      assert_match "mkdir -p .kamal/proxy/apps-config/app/tls/accessories/monitoring", output
+      assert_match %r{Uploading .* to .kamal/proxy/apps-config/app/tls/accessories/monitoring/cert\.pem}, output
+      assert_match %r{Uploading .* to .kamal/proxy/apps-config/app/tls/accessories/monitoring/key\.pem}, output
+      assert_match "--tls-certificate-path=\"/home/kamal-proxy/.apps-config/app/tls/accessories/monitoring/cert.pem\"", output
+      assert_match "--tls-private-key-path=\"/home/kamal-proxy/.apps-config/app/tls/accessories/monitoring/key.pem\"", output
+    end
+  end
+
   private
     def run_command(*command)
       stdouted { Kamal::Cli::Accessory.start([ *command, "-c", "test/fixtures/deploy_with_accessories_with_different_registries.yml" ]) }
+    end
+
+    def run_command_with_custom_ssl(*command)
+      stdouted { Kamal::Cli::Accessory.start([ *command, "-c", "test/fixtures/deploy_with_accessory_custom_ssl.yml" ]) }
     end
 end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -290,6 +290,17 @@ class CliAccessoryTest < CliTestCase
     end
   end
 
+  test "boot with custom ssl certificate raises when secret is missing" do
+    Kamal::Configuration::Proxy.any_instance.stubs(:custom_ssl_certificate?).returns(true)
+    Kamal::Configuration::Proxy.any_instance.stubs(:certificate_pem_content).returns(nil)
+    Kamal::Configuration::Proxy.any_instance.stubs(:private_key_pem_content).returns("PRIVATE KEY CONTENT")
+
+    error = assert_raises(SSHKit::Runner::ExecuteError) do
+      run_command_with_custom_ssl("boot", "monitoring")
+    end
+    assert_match %r{Missing SSL secret "CERT_PEM" for accessory "monitoring" \(certificate_pem\)}, error.message
+  end
+
   private
     def run_command(*command)
       stdouted { Kamal::Cli::Accessory.start([ *command, "-c", "test/fixtures/deploy_with_accessories_with_different_registries.yml" ]) }

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -321,6 +321,22 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "monitoring.example.com" ], @config.accessory(:monitoring).proxy.hosts
   end
 
+  test "proxy ssl certificate paths are scoped by accessory name" do
+    with_test_secrets("secrets" => "CERT_PEM=cert\nKEY_PEM=key") do
+      @deploy[:accessories]["monitoring"]["proxy"]["ssl"] = {
+        "certificate_pem" => "CERT_PEM",
+        "private_key_pem" => "KEY_PEM"
+      }
+
+      config = Kamal::Configuration.new(@deploy)
+      proxy = config.accessory(:monitoring).proxy
+
+      assert proxy.custom_ssl_certificate?
+      assert_match %r{accessories/monitoring/cert\.pem$}, proxy.host_tls_cert
+      assert_match %r{accessories/monitoring/key\.pem$}, proxy.host_tls_key
+    end
+  end
+
   test "can't set restart in options" do
     @deploy[:accessories]["mysql"]["options"] = { "restart" => "always" }
 

--- a/test/fixtures/deploy_with_accessory_custom_ssl.yml
+++ b/test/fixtures/deploy_with_accessory_custom_ssl.yml
@@ -1,0 +1,22 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+    - "1.1.1.2"
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64
+
+accessories:
+  monitoring:
+    image: monitoring:latest
+    host: 1.1.1.1
+    proxy:
+      host: monitoring.example.com
+      ssl:
+        certificate_pem: CERT_PEM
+        private_key_pem: KEY_PEM
+      app_port: 9090


### PR DESCRIPTION
This is my first contribution, please be extra careful with the review :) Sadly I didn't manage to run the integration tests on OSX. Original commit follows:

---

When an accessory is configured with custom SSL certificates via certificate_pem and private_key_pem in its proxy config, kamal fails with "unable to load certificate" during kamal-proxy deploy.

The root cause is that Kamal::Cli::App::SslCertificates, which handles uploading PEM files into the kamal-proxy container, is only called during app boot (cli/app.rb), never during accessory boot (cli/accessory.rb). The kamal-proxy deploy command references cert paths that don't exist because nobody uploaded the files.

I hit this while configuring a proxied imgproxy accessory on a separate subdomain with a Cloudflare Origin Certificate.

The fix has two parts:

1. Pass role_name: "accessories/#{name}" when initializing the proxy configuration for accessories. Without this, role_name is nil and cert paths collapse to tls/cert.pem, which would collide between multiple accessories or with an app role that also has no name. The accessories/ prefix keeps them in a separate namespace from app roles (e.g. tls/web/ vs tls/accessories/monitoring/).

2. Add Kamal::Cli::Accessory::SslCertificates, mirroring the existing Kamal::Cli::App::SslCertificates. It creates the target directory and uploads cert/key PEM files before the container is registered with kamal-proxy. This is called in the accessory boot path, between the env upload and docker run.

Fixes #1769