### PR TITLE
Add GitLab CI/CD secrets adapter

### DIFF
--- a/lib/kamal/secrets/adapters.rb
+++ b/lib/kamal/secrets/adapters.rb
@@ -5,6 +5,7 @@ module Kamal::Secrets::Adapters
     name = "last_pass" if name.downcase == "lastpass"
     name = "gcp_secret_manager" if name.downcase == "gcp"
     name = "bitwarden_secrets_manager" if name.downcase == "bitwarden-sm"
+    name = "gitlab_ci" if name.downcase == "gitlab-ci"
     adapter_class(name)
   end
 

--- a/lib/kamal/secrets/adapters/gitlab_ci.rb
+++ b/lib/kamal/secrets/adapters/gitlab_ci.rb
@@ -1,0 +1,53 @@
+class Kamal::Secrets::Adapters::GitlabCi < Kamal::Secrets::Adapters::Base
+  def requires_account?
+    false
+  end
+
+  private
+    def login(*)
+      nil
+    end
+
+    def fetch_secrets(secrets, from:, **)
+      variables = glab_variable_list
+
+      {}.tap do |results|
+        variables.each do |var|
+          next if secrets.any? && !secrets.include?(var["key"])
+
+          case var["environment_scope"]
+          when "*"
+            results[var["key"]] ||= var["value"]
+          when from
+            results[var["key"]] = var["value"]
+          end
+        end
+      end
+    end
+
+    def glab_variable_list
+      per_page = 100
+      all = []
+
+      (1..).each do |page|
+        output = `glab variable list --output json --per-page #{per_page} --page #{page}`
+        raise RuntimeError, "Failed to list GitLab CI/CD variables" unless $?.success?
+
+        variables = JSON.parse(output)
+        all.concat(variables)
+
+        break if variables.length < per_page
+      end
+
+      all
+    end
+
+    def check_dependencies!
+      raise RuntimeError, "glab CLI is not installed" unless cli_installed?
+    end
+
+    def cli_installed?
+      `glab --version 2> /dev/null`
+      $?.success?
+    end
+end

--- a/test/secrets/gitlab_ci_adapter_test.rb
+++ b/test/secrets/gitlab_ci_adapter_test.rb
@@ -1,0 +1,173 @@
+require "test_helper"
+
+class GitlabCiAdapterTest < SecretAdapterTestCase
+  test "fetch with specific secrets and scope" do
+    stub_ticks_with("glab --version 2> /dev/null", succeed: true)
+
+    stub_ticks
+      .with("glab variable list --output json --per-page 100 --page 1")
+      .returns(<<~JSON)
+        [
+          {"key":"DATABASE_URL","value":"postgres://localhost/myapp_production","environment_scope":"production"},
+          {"key":"DATABASE_URL","value":"postgres://localhost/myapp_staging","environment_scope":"staging"},
+          {"key":"DATABASE_URL","value":"postgres://localhost/myapp","environment_scope":"*"},
+          {"key":"RAILS_MASTER_KEY","value":"abc123production","environment_scope":"production"},
+          {"key":"RAILS_MASTER_KEY","value":"abc123staging","environment_scope":"staging"},
+          {"key":"SECRET_KEY_BASE","value":"globalsecret","environment_scope":"*"}
+        ]
+      JSON
+
+    json = JSON.parse(run_command("fetch", "--from", "staging", "DATABASE_URL", "RAILS_MASTER_KEY"))
+
+    expected_json = {
+      "DATABASE_URL" => "postgres://localhost/myapp_staging",
+      "RAILS_MASTER_KEY" => "abc123staging"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch falls back to default scope" do
+    stub_ticks_with("glab --version 2> /dev/null", succeed: true)
+
+    stub_ticks
+      .with("glab variable list --output json --per-page 100 --page 1")
+      .returns(<<~JSON)
+        [
+          {"key":"SECRET_KEY_BASE","value":"globalsecret","environment_scope":"*"},
+          {"key":"DATABASE_URL","value":"postgres://localhost/myapp_staging","environment_scope":"staging"}
+        ]
+      JSON
+
+    json = JSON.parse(run_command("fetch", "--from", "staging", "SECRET_KEY_BASE", "DATABASE_URL"))
+
+    expected_json = {
+      "SECRET_KEY_BASE" => "globalsecret",
+      "DATABASE_URL" => "postgres://localhost/myapp_staging"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch falls back to wildcard when scoped variant is missing" do
+    stub_ticks_with("glab --version 2> /dev/null", succeed: true)
+
+    stub_ticks
+      .with("glab variable list --output json --per-page 100 --page 1")
+      .returns(<<~JSON)
+        [
+          {"key":"SECRET_KEY_BASE","value":"globalsecret","environment_scope":"*"},
+          {"key":"DATABASE_URL","value":"postgres://localhost/myapp_staging","environment_scope":"staging"}
+        ]
+      JSON
+
+    json = JSON.parse(run_command("fetch", "--from", "staging", "SECRET_KEY_BASE"))
+
+    expected_json = {
+      "SECRET_KEY_BASE" => "globalsecret"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch without scope returns only default scope" do
+    stub_ticks_with("glab --version 2> /dev/null", succeed: true)
+
+    stub_ticks
+      .with("glab variable list --output json --per-page 100 --page 1")
+      .returns(<<~JSON)
+        [
+          {"key":"SECRET_KEY_BASE","value":"globalsecret","environment_scope":"*"},
+          {"key":"DATABASE_URL","value":"postgres://localhost/myapp_staging","environment_scope":"staging"}
+        ]
+      JSON
+
+    json = JSON.parse(run_command("fetch", "SECRET_KEY_BASE", "DATABASE_URL"))
+
+    expected_json = {
+      "SECRET_KEY_BASE" => "globalsecret"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch all secrets" do
+    stub_ticks_with("glab --version 2> /dev/null", succeed: true)
+
+    stub_ticks
+      .with("glab variable list --output json --per-page 100 --page 1")
+      .returns(<<~JSON)
+        [
+          {"key":"SECRET_KEY_BASE","value":"globalsecret","environment_scope":"*"},
+          {"key":"DATABASE_URL","value":"postgres://localhost/myapp_staging","environment_scope":"staging"}
+        ]
+      JSON
+
+    json = JSON.parse(run_command("fetch", "--from", "staging"))
+
+    expected_json = {
+      "SECRET_KEY_BASE" => "globalsecret",
+      "DATABASE_URL" => "postgres://localhost/myapp_staging"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch with pagination" do
+    stub_ticks_with("glab --version 2> /dev/null", succeed: true)
+
+    page1 = (1..100).map { |i| { key: "VAR_#{i}", value: "val_#{i}", environment_scope: "*" } }
+
+    stub_ticks
+      .with("glab variable list --output json --per-page 100 --page 1")
+      .returns(JSON.generate(page1))
+
+    stub_ticks
+      .with("glab variable list --output json --per-page 100 --page 2")
+      .returns(<<~JSON)
+        [
+          {"key":"LAST_VAR","value":"last_value","environment_scope":"*"}
+        ]
+      JSON
+
+    json = JSON.parse(run_command("fetch", "--from", "production", "VAR_1", "LAST_VAR"))
+
+    expected_json = {
+      "VAR_1" => "val_1",
+      "LAST_VAR" => "last_value"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch with glab variable list failure" do
+    stub_ticks_with("glab --version 2> /dev/null", succeed: true)
+    stub_ticks_with("glab variable list --output json --per-page 100 --page 1", succeed: false)
+
+    error = assert_raises RuntimeError do
+      run_command("fetch", "SECRET1")
+    end
+
+    assert_equal "Failed to list GitLab CI/CD variables", error.message
+  end
+
+  test "fetch without CLI installed" do
+    stub_ticks_with("glab --version 2> /dev/null", succeed: false)
+
+    error = assert_raises RuntimeError do
+      run_command("fetch", "SECRET1")
+    end
+
+    assert_equal "glab CLI is not installed", error.message
+  end
+
+  private
+    def run_command(*command)
+      stdouted do
+        Kamal::Cli::Secrets.start \
+          [ *command,
+            "-c", "test/fixtures/deploy_with_accessories.yml",
+            "--adapter", "gitlab-ci" ]
+      end
+    end
+end


### PR DESCRIPTION
## Summary

Adds a secrets adapter for GitLab CI/CD project variables using the [`glab`](https://gitlab.com/gitlab-org/cli) CLI.

- Fetches variables via `glab variable list` with pagination support
- Uses `--from` to select an environment scope (e.g. `staging`, `production`), falling back to wildcard (`*`) scoped variables
- Scoped variables take precedence over wildcard variables for the same key

### Usage

```sh
# .kamal/secrets
SECRETS=$(kamal secrets fetch --adapter gitlab-ci --from "$KAMAL_DESTINATION" DATABASE_URL SECRET_KEY_BASE)
```

### Test plan

- Fetch specific secrets with environment scope
- Fallback to wildcard scope when no scoped match exists
- Fetch without scope returns only wildcard-scoped variables
- Fetch all secrets (no specific keys requested)
- Pagination across multiple pages
- Error when glab variable list fails
- Error when glab CLI is not installed
