### PR TITLE
Add value equality to Proxy::Run to fix false conflict errors

### DIFF
--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -131,6 +131,15 @@ class Kamal::Configuration::Proxy::Run
     File.join apps_container_directory, config.service_and_destination
   end
 
+  def ==(other)
+    other.is_a?(self.class) && run_config == other.run_config
+  end
+  alias_method :eql?, :==
+
+  def hash
+    run_config.hash
+  end
+
   private
     def format_bind_ip(ip)
       # Ensure IPv6 address inside square brackets - e.g. [::1]

--- a/test/configuration/proxy_run_equality_test.rb
+++ b/test/configuration/proxy_run_equality_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+class ConfigurationProxyRunEqualityTest < ActiveSupport::TestCase
+  setup do
+    @deploy = {
+      service: "app", image: "dhh/app",
+      registry: { "username" => "dhh", "password" => "secret" },
+      builder: { "arch" => "amd64" },
+      servers: {
+        "web" => { "hosts" => [ "1.2.3.4" ] },
+        "worker" => {
+          "hosts" => [ "1.2.3.4" ],
+          "proxy" => { "hosts" => [ "worker.example.com" ], "app_port" => 8080 }
+        }
+      },
+      proxy: {
+        "hosts" => [ "example.com" ],
+        "run" => { "log_max_size" => "", "options" => { "log-driver" => "journald" } }
+      }
+    }
+  end
+
+  test "identical proxy run configs across roles on same host do not conflict" do
+    config = Kamal::Configuration.new(@deploy)
+    assert_not_nil config
+  end
+
+  test "different proxy run configs across roles on same host raise conflict" do
+    deploy = @deploy.merge(servers: @deploy[:servers].merge(
+      "web" => { "hosts" => [ "1.2.3.4" ], "proxy" => { "hosts" => [ "example.com" ], "run" => { "log_max_size" => "5m" } } },
+      "worker" => { "hosts" => [ "1.2.3.4" ], "proxy" => { "hosts" => [ "worker.example.com" ], "run" => { "log_max_size" => "10m" } } }
+    ))
+
+    assert_raises(Kamal::ConfigurationError) { Kamal::Configuration.new(deploy) }
+  end
+
+  test "Run objects with identical run_config are equal" do
+    config = Kamal::Configuration.new(@deploy)
+    run_config = { "log_max_size" => "10m" }
+
+    run1 = Kamal::Configuration::Proxy::Run.new(config, run_config: run_config)
+    run2 = Kamal::Configuration::Proxy::Run.new(config, run_config: run_config)
+
+    assert_equal run1, run2
+    assert_equal run1.hash, run2.hash
+    assert_equal [ run1 ], [ run1, run2 ].uniq
+  end
+
+  test "Run objects with different run_config are not equal" do
+    config = Kamal::Configuration.new(@deploy)
+
+    run1 = Kamal::Configuration::Proxy::Run.new(config, run_config: { "log_max_size" => "5m" })
+    run2 = Kamal::Configuration::Proxy::Run.new(config, run_config: { "log_max_size" => "10m" })
+
+    assert_not_equal run1, run2
+    assert_equal 2, [ run1, run2 ].uniq.size
+  end
+end


### PR DESCRIPTION
Fixes #1817

## Problem

When multiple roles share a host and the global `proxy.run` config is `deep_merge`d into each role's proxy config, `ensure_no_conflicting_proxy_runs` raises a false `ConfigurationError`. Two `Run` objects with identical `run_config` hashes are treated as different because `Array#uniq` compares by object identity.

## Fix

Add `==`, `eql?`, and `hash` methods to `Kamal::Configuration::Proxy::Run` so that `Array#uniq` correctly deduplicates identical run configs.

## Testing

4 new tests in `test/configuration/proxy_run_equality_test.rb`:
- Identical run configs across roles on same host → no error
- Different run configs across roles on same host → raises conflict
- Run objects with identical config are equal and deduplicate via `uniq`
- Run objects with different config are not equal

All 30 configuration unit tests pass.