### PR TITLE
Stringify AWS Secrets Manager values

### DIFF
--- a/lib/kamal/secrets/adapters/aws_secrets_manager.rb
+++ b/lib/kamal/secrets/adapters/aws_secrets_manager.rb
@@ -14,8 +14,12 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
           secret_name = secret["Name"]
           secret_string = JSON.parse(secret["SecretString"])
 
-          secret_string.each do |key, value|
-            results["#{secret_name}/#{key}"] = value
+          if secret_string.is_a?(Hash)
+            secret_string.each do |key, value|
+              results["#{secret_name}/#{key}"] = stringify_secret_value(value)
+            end
+          else
+            results["#{secret_name}"] = stringify_secret_value(secret_string)
           end
         rescue JSON::ParserError
           results["#{secret_name}"] = secret["SecretString"]
@@ -38,6 +42,10 @@ class Kamal::Secrets::Adapters::AwsSecretsManager < Kamal::Secrets::Adapters::Ba
 
         raise RuntimeError, secrets["Errors"].map { |error| "#{error['SecretId']}: #{error['Message']}" }.join(" ")
       end
+    end
+
+    def stringify_secret_value(value)
+      value.is_a?(String) ? value : JSON.dump(value)
     end
 
     def check_dependencies!

--- a/test/secrets/aws_secrets_manager_adapter_test.rb
+++ b/test/secrets/aws_secrets_manager_adapter_test.rb
@@ -147,6 +147,99 @@ class AwsSecretsManagerAdapterTest < SecretAdapterTestCase
     assert_equal expected_json, json
   end
 
+  test "fetch with bare JSON primitive SecretString values" do
+    stub_ticks.with("aws --version 2> /dev/null")
+    stub_ticks
+      .with("aws secretsmanager batch-get-secret-value --secret-id-list port flag name nothing --profile default --output json")
+      .returns(<<~JSON)
+        {
+          "SecretValues": [
+            {
+              "ARN": "arn:aws:secretsmanager:us-east-1:aaaaaaaaaaaa:secret:port",
+              "Name": "port",
+              "VersionId": "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv",
+              "SecretString": "5432",
+              "VersionStages": [ "AWSCURRENT" ],
+              "CreatedDate": "2024-01-01T00:00:00.000000"
+            },
+            {
+              "ARN": "arn:aws:secretsmanager:us-east-1:aaaaaaaaaaaa:secret:flag",
+              "Name": "flag",
+              "VersionId": "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv",
+              "SecretString": "true",
+              "VersionStages": [ "AWSCURRENT" ],
+              "CreatedDate": "2024-01-01T00:00:00.000000"
+            },
+            {
+              "ARN": "arn:aws:secretsmanager:us-east-1:aaaaaaaaaaaa:secret:name",
+              "Name": "name",
+              "VersionId": "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv",
+              "SecretString": "\\"quoted-string\\"",
+              "VersionStages": [ "AWSCURRENT" ],
+              "CreatedDate": "2024-01-01T00:00:00.000000"
+            },
+            {
+              "ARN": "arn:aws:secretsmanager:us-east-1:aaaaaaaaaaaa:secret:nothing",
+              "Name": "nothing",
+              "VersionId": "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv",
+              "SecretString": "null",
+              "VersionStages": [ "AWSCURRENT" ],
+              "CreatedDate": "2024-01-01T00:00:00.000000"
+            }
+          ],
+          "Errors": []
+        }
+      JSON
+
+    json = JSON.parse(run_command("fetch", "port", "flag", "name", "nothing"))
+
+    expected_json = {
+      "port"    => "5432",
+      "flag"    => "true",
+      "name"    => "quoted-string",
+      "nothing" => "null"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch coerces non-string JSON field values to strings" do
+    stub_ticks.with("aws --version 2> /dev/null")
+    stub_ticks
+      .with("aws secretsmanager batch-get-secret-value --secret-id-list myapp/RailsUser --profile default --output json")
+      .returns(<<~JSON)
+        {
+          "SecretValues": [
+            {
+              "ARN": "arn:aws:secretsmanager:us-east-1:aaaaaaaaaaaa:secret:myapp/RailsUser",
+              "Name": "myapp/RailsUser",
+              "VersionId": "vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv",
+              "SecretString": "{\\"host\\":\\"db.example\\",\\"port\\":5432,\\"ssl\\":true,\\"weight\\":1.5,\\"missing\\":null,\\"replicas\\":{\\"read\\":\\"r.example\\",\\"port\\":5433},\\"tags\\":[\\"prod\\",\\"db\\"]}",
+              "VersionStages": [
+                  "AWSCURRENT"
+              ],
+              "CreatedDate": "2024-01-01T00:00:00.000000"
+            }
+          ],
+          "Errors": []
+        }
+      JSON
+
+    json = JSON.parse(run_command("fetch", "myapp/RailsUser"))
+
+    expected_json = {
+      "myapp/RailsUser/host" => "db.example",
+      "myapp/RailsUser/port" => "5432",
+      "myapp/RailsUser/ssl"  => "true",
+      "myapp/RailsUser/weight" => "1.5",
+      "myapp/RailsUser/missing" => "null",
+      "myapp/RailsUser/replicas" => '{"read":"r.example","port":5433}',
+      "myapp/RailsUser/tags" => '["prod","db"]'
+    }
+
+    assert_equal expected_json, json
+  end
+
   test "fetch without CLI installed" do
     stub_ticks_with("aws --version 2> /dev/null", succeed: false)
 


### PR DESCRIPTION
When working with the AWS Secrets Manager, secrets that are stored as JSON are subject to unexpected type changes. In particular, when calling `kamal secrets extract` JSON objects that contain integers get unconditionally #chomp-ed, causing a crash.

## Fix
This fix `JSON.dump`s non-string values to allow chomp to succeed, and also should produce fewer surprises for end users via better handling of JSON values.

This issue is related to #1816 (they hit the primitive-only path) and should fix it as well. For non-hash secret strings, we simply stringify the whole thing.

## Edge Cases
* For null handling, I chose to emit the string `null`. I feel like this produces fewer surprises than an empty string or omission.
* Quoted strings in a secret will have their quotes stripped as they are `JSON.parse`able.

## Alternatives
* I considered supporting recursive JSON documents. "Flat" secrets are most common, and this would require extra cli options if the value was needed raw instead of parsed.
* Rejecting or omitting non-primitives.
* Calling `#to_s` instead of `JSON.dump`. This produces odd behavior with complex JSON types and `null`.