### PR TITLE
fix: passbolt list resources with passwords

### DIFF
--- a/lib/kamal/secrets/adapters/passbolt.rb
+++ b/lib/kamal/secrets/adapters/passbolt.rb
@@ -47,7 +47,7 @@ class Kamal::Secrets::Adapters::Passbolt < Kamal::Secrets::Adapters::Base
       end
 
       filter_condition = filter_conditions.any? ? "--filter '#{filter_conditions.join(" || ")}'" : ""
-      items = `passbolt list resources #{filter_condition} #{folders.map { |item| "--folder #{item["id"].to_s.shellescape}" }.join(" ")} --json`
+      items = `passbolt list resources #{filter_condition} #{folders.map { |item| "--folder #{item["id"].to_s.shellescape}" }.join(" ")} --column name --column password --json`
       raise RuntimeError, "Could not read #{secrets} from Passbolt" unless $?.success?
       items = JSON.parse(items)
       found_names = items.map { |item| item["name"] }


### PR DESCRIPTION
[By default, passwords are not shown](https://github.com/passbolt/go-passbolt-cli/blob/0ad20030711654391545279154c2429084cb9450/resource/list.go#L73) with the `passbolt list resources` command.

Fix #1835 