### PR TITLE
Clarify destination secrets docs

### DIFF
--- a/bin/docs
+++ b/bin/docs
@@ -23,6 +23,7 @@ DOCS = {
   "configuration" => "Configuration overview",
   "env" => "Environment variables",
   "logging" => "Logging",
+  "output" => "Output",
   "proxy" => "Proxy",
   "registry" => "Docker Registry",
   "role" => "Roles",

--- a/lib/kamal/cli/templates/secrets
+++ b/lib/kamal/cli/templates/secrets
@@ -1,6 +1,10 @@
 # Secrets defined here are available for reference under registry/password, env/secret, builder/secrets,
 # and accessories/*/env/secret in config/deploy.yml. All secrets should be pulled from either
 # password manager, ENV, or a file. DO NOT ENTER RAW CREDENTIALS HERE! This file needs to be safe for git.
+#
+# When deploying with destinations, shared secrets can go in .kamal/secrets-common and
+# destination-specific secrets in .kamal/secrets.<destination>. This .kamal/secrets file is used
+# only when no destination is selected.
 
 # Option 1: Read secrets from the environment
 # KAMAL_REGISTRY_PASSWORD=$KAMAL_REGISTRY_PASSWORD

--- a/lib/kamal/configuration/docs/configuration.yml
+++ b/lib/kamal/configuration/docs/configuration.yml
@@ -108,7 +108,9 @@ hooks_output:
 # Secrets path
 #
 # Path to secrets, defaults to `.kamal/secrets`.
-# Kamal will look for `<secrets_path>-common` and `<secrets_path>` (or `<secrets_path>.<destination>` when using destinations):
+# Kamal looks for `<secrets_path>-common` first and then `<secrets_path>`.
+# When using destinations, it instead looks for `<secrets_path>-common` first and then
+# `<secrets_path>.<destination>`. Later files override earlier ones.
 secrets_path: /user_home/kamal/secrets
 
 # Error pages

--- a/lib/kamal/configuration/docs/env.yml
+++ b/lib/kamal/configuration/docs/env.yml
@@ -14,12 +14,14 @@ env:
 
 # Secrets
 #
-# Kamal uses dotenv to automatically load environment variables set in the `.kamal/secrets` file.
+# Kamal uses dotenv to automatically load environment variables from the configured secrets files.
 #
-# If you are using destinations, secrets will instead be read from `.kamal/secrets.<DESTINATION>` if
-# it exists.
+# Common secrets across all destinations can be set in `.kamal/secrets-common`. Kamal looks for
+# `.kamal/secrets-common` first, then `.kamal/secrets`, with later values overriding earlier ones.
 #
-# Common secrets across all destinations can be set in `.kamal/secrets-common`.
+# If you are using destinations, Kamal looks for `.kamal/secrets-common` first, then
+# `.kamal/secrets.<destination>`. The non-destination `.kamal/secrets` file is not read when a
+# destination is selected.
 #
 # This file can be used to set variables like `KAMAL_REGISTRY_PASSWORD` or database passwords.
 # You can use variable or command substitution in the secrets file.


### PR DESCRIPTION
## Summary
- Document the exact secrets file lookup order with and without destinations.
- Clarify that `.kamal/secrets` is not read when a destination is selected.
- Add the destination note to the generated docs source and the init secrets template.
- Include the existing output docs page in the docs generator map so all configuration docs sources can be generated.

## Testing
- `tmpdir=$(mktemp -d); mkdir -p "$tmpdir/docs/configuration"; ruby bin/docs "$tmpdir"`
- `ruby -c bin/docs`
- `git diff --check`
- Not run: Ruby unit tests; the local Ruby toolchain does not match the lockfile.
