### PR TITLE
Add `builder.output_options` configuration for buildx output parameters

### DIFF
--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -16,7 +16,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
 
   def push(export_action = "registry", tag_as_dirty: false, no_cache: false)
     docker :buildx, :build,
-      "--output=#{[ "type=#{export_action}", output ].compact.join(",")}",
+      "--output=#{[ "type=#{export_action}", output.presence ].compact.join(",")}",
       *platform_options(arches),
       *([ "--builder", builder_name ] unless docker_driver?),
       *build_tag_options(tag_as_dirty: tag_as_dirty),

--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -7,7 +7,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   delegate \
     :args, :secrets, :dockerfile, :target, :arches, :local_arches, :remote_arches, :remote,
     :pack?, :pack_builder, :pack_buildpacks,
-    :cache_from, :cache_to, :ssh, :provenance, :sbom, :driver, :docker_driver?,
+    :cache_from, :cache_to, :ssh, :provenance, :sbom, :output, :driver, :docker_driver?,
     to: :builder_config
 
   def clean
@@ -16,7 +16,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
 
   def push(export_action = "registry", tag_as_dirty: false, no_cache: false)
     docker :buildx, :build,
-      "--output=type=#{export_action}",
+      "--output=#{[ "type=#{export_action}", output ].compact.join(",")}",
       *platform_options(arches),
       *([ "--builder", builder_name ] unless docker_driver?),
       *build_tag_options(tag_as_dirty: tag_as_dirty),

--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -7,7 +7,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   delegate \
     :args, :secrets, :dockerfile, :target, :arches, :local_arches, :remote_arches, :remote,
     :pack?, :pack_builder, :pack_buildpacks,
-    :cache_from, :cache_to, :ssh, :provenance, :sbom, :output, :driver, :docker_driver?,
+    :cache_from, :cache_to, :ssh, :provenance, :sbom, :output_options, :driver, :docker_driver?,
     to: :builder_config
 
   def clean
@@ -16,7 +16,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
 
   def push(export_action = "registry", tag_as_dirty: false, no_cache: false)
     docker :buildx, :build,
-      "--output=#{[ "type=#{export_action}", output.presence ].compact.join(",")}",
+      build_output(export_action),
       *platform_options(arches),
       *([ "--builder", builder_name ] unless docker_driver?),
       *build_tag_options(tag_as_dirty: tag_as_dirty),
@@ -70,6 +70,12 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   end
 
   private
+    def build_output(export_action)
+      output = [ "type=#{export_action}", *output_options.map { |key, value| "#{key}=#{value}" } ]
+
+      "--output=#{output.join(",")}"
+    end
+
     def build_tag_names(tag_as_dirty: false)
       tag_names = [ config.absolute_image, config.latest_image ]
       tag_names.map! { |t| "#{t}-dirty" } if tag_as_dirty

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -135,6 +135,10 @@ class Kamal::Configuration::Builder
     builder_config["sbom"]
   end
 
+  def output
+    builder_config["output"]
+  end
+
   def git_clone?
     Kamal::Git.used? && builder_config["context"].nil?
   end

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -135,8 +135,8 @@ class Kamal::Configuration::Builder
     builder_config["sbom"]
   end
 
-  def output
-    builder_config["output"]
+  def output_options
+    builder_config["output_options"] || {}
   end
 
   def git_clone?

--- a/lib/kamal/configuration/docs/builder.yml
+++ b/lib/kamal/configuration/docs/builder.yml
@@ -135,4 +135,4 @@ builder:
   #
   # Docker output type parameters appended to the buildx `--output=type=...` flag.
   # Useful for configuring the compression type:
-  output: compression=zstd,compression-level=9,force-compression=true
+  output: compression=zstd,compression-level=3,force-compression=true

--- a/lib/kamal/configuration/docs/builder.yml
+++ b/lib/kamal/configuration/docs/builder.yml
@@ -130,3 +130,9 @@ builder:
   # It is used to configure SBOM generation for the build result.
   # The value can also be a boolean to enable or disable SBOM generation.
   sbom: true
+
+  # Output
+  #
+  # Docker output type parameters appended to the buildx `--output=type=...` flag.
+  # Useful for configuring the compression type:
+  output: compression=zstd,compression-level=9,force-compression=true

--- a/lib/kamal/configuration/docs/builder.yml
+++ b/lib/kamal/configuration/docs/builder.yml
@@ -131,8 +131,12 @@ builder:
   # The value can also be a boolean to enable or disable SBOM generation.
   sbom: true
 
-  # Output
+  # Output options
   #
-  # Docker output type parameters appended to the buildx `--output=type=...` flag.
-  # Useful for configuring the compression type:
-  output: compression=zstd,compression-level=3,force-compression=true
+  # Extra parameters for the buildx `--output` flag, useful for configuring the compression.
+  #
+  # The output type is set by Kamal and cannot be overridden here.
+  output_options:
+    compression: zstd
+    compression-level: 3
+    force-compression: true

--- a/lib/kamal/configuration/validator.rb
+++ b/lib/kamal/configuration/validator.rb
@@ -47,7 +47,7 @@ class Kamal::Configuration::Validator
               case key.to_s
               when "options", "args"
                 validate_type! value, Hash
-              when "labels"
+              when "labels", "output_options"
                 validate_hash_of! value, example_value.first[1].class
               else
                 validate_against_example! value, example_value

--- a/lib/kamal/configuration/validator/builder.rb
+++ b/lib/kamal/configuration/validator/builder.rb
@@ -11,5 +11,7 @@ class Kamal::Configuration::Validator::Builder < Kamal::Configuration::Validator
     error "buildpacks only support building for one arch" if config["pack"] && config["arch"].is_a?(Array) && config["arch"].size > 1
 
     error "Cannot disable local builds, no remote is set" if config["local"] == false && config["remote"].blank?
+
+    error "Cannot set the output type, Kamal sets this based on the build" if config["output_options"] && config["output_options"].key?("type")
   end
 end

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -28,6 +28,13 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "push with blank builder output is omitted" do
+    builder = new_builder_command(builder: { "output" => "" })
+    assert_equal \
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
+      builder.push.join(" ")
+  end
+
   test "build with caching" do
     builder = new_builder_command(builder: { "cache" => { "type" => "gha" } })
     assert_equal "local", builder.name

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -21,6 +21,13 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "push with builder output type parameters" do
+    builder = new_builder_command(builder: { "output" => "compression=zstd,compression-level=12,force-compression=true" })
+    assert_equal \
+      "docker buildx build --output=type=registry,compression=zstd,compression-level=12,force-compression=true --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
+      builder.push.join(" ")
+  end
+
   test "build with caching" do
     builder = new_builder_command(builder: { "cache" => { "type" => "gha" } })
     assert_equal "local", builder.name

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -22,9 +22,9 @@ class CommandsBuilderTest < ActiveSupport::TestCase
   end
 
   test "push with builder output type parameters" do
-    builder = new_builder_command(builder: { "output" => "compression=zstd,compression-level=12,force-compression=true" })
+    builder = new_builder_command(builder: { "output" => "compression=zstd,compression-level=3,force-compression=true" })
     assert_equal \
-      "docker buildx build --output=type=registry,compression=zstd,compression-level=12,force-compression=true --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
+      "docker buildx build --output=type=registry,compression=zstd,compression-level=3,force-compression=true --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
       builder.push.join(" ")
   end
 

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -21,15 +21,15 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
-  test "push with builder output type parameters" do
-    builder = new_builder_command(builder: { "output" => "compression=zstd,compression-level=3,force-compression=true" })
+  test "push with output options" do
+    builder = new_builder_command(builder: { "output_options" => { "compression" => "zstd", "compression-level" => 3, "force-compression" => true } })
     assert_equal \
       "docker buildx build --output=type=registry,compression=zstd,compression-level=3,force-compression=true --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
       builder.push.join(" ")
   end
 
-  test "push with blank builder output is omitted" do
-    builder = new_builder_command(builder: { "output" => "" })
+  test "push with empty output options" do
+    builder = new_builder_command(builder: { "output_options" => {} })
     assert_equal \
       "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
       builder.push.join(" ")

--- a/test/configuration/builder_test.rb
+++ b/test/configuration/builder_test.rb
@@ -171,6 +171,16 @@ class ConfigurationBuilderTest < ActiveSupport::TestCase
     assert_equal true, config.builder.sbom
   end
 
+  test "output" do
+    assert_nil config.builder.output
+  end
+
+  test "setting output" do
+    @deploy[:builder]["output"] = "compression=zstd,compression-level=12,force-compression=true"
+
+    assert_equal "compression=zstd,compression-level=12,force-compression=true", config.builder.output
+  end
+
   test "local disabled but no remote set" do
     @deploy[:builder]["local"] = false
 

--- a/test/configuration/builder_test.rb
+++ b/test/configuration/builder_test.rb
@@ -176,9 +176,9 @@ class ConfigurationBuilderTest < ActiveSupport::TestCase
   end
 
   test "setting output" do
-    @deploy[:builder]["output"] = "compression=zstd,compression-level=12,force-compression=true"
+    @deploy[:builder]["output"] = "compression=zstd,compression-level=3,force-compression=true"
 
-    assert_equal "compression=zstd,compression-level=12,force-compression=true", config.builder.output
+    assert_equal "compression=zstd,compression-level=3,force-compression=true", config.builder.output
   end
 
   test "local disabled but no remote set" do

--- a/test/configuration/builder_test.rb
+++ b/test/configuration/builder_test.rb
@@ -171,14 +171,22 @@ class ConfigurationBuilderTest < ActiveSupport::TestCase
     assert_equal true, config.builder.sbom
   end
 
-  test "output" do
-    assert_nil config.builder.output
+  test "output options" do
+    assert_equal({}, config.builder.output_options)
   end
 
-  test "setting output" do
-    @deploy[:builder]["output"] = "compression=zstd,compression-level=3,force-compression=true"
+  test "setting output options" do
+    @deploy[:builder]["output_options"] = { "compression" => "zstd", "compression-level" => 3, "force-compression" => true }
 
-    assert_equal "compression=zstd,compression-level=3,force-compression=true", config.builder.output
+    assert_equal({ "compression" => "zstd", "compression-level" => 3, "force-compression" => true }, config.builder.output_options)
+  end
+
+  test "setting the output type" do
+    @deploy[:builder]["output_options"] = { "type" => "docker" }
+
+    assert_raises(Kamal::ConfigurationError) do
+      config.builder
+    end
   end
 
   test "local disabled but no remote set" do


### PR DESCRIPTION
This change adds a new configration option, that allows you to pass buildx build output parameters[^1].

I can see this mainly being used to configure compression.

For a bit of context, I found https://github.com/basecamp/kamal/discussions/1549 when trying to sort this out myself today.

Using zstd should(?) be a bit faster to deploy that the default gzip, compression level 3 is the default level. I'm using the patch from the discussion on a Ubuntu Hetzner VM with no issues. Useful when deploying locally on a slow upstream connection with a local registry.

Configuration would look like:

```yaml
builder:
  arch: amd64
  output_options:
    compression: zstd
    force-compression: true
```

Worth noting, `kamal build push` already supports an `--output` option, so you could achieve this today as a two command deploy:

```bash
bin/kamal build push --output registry,compression=zstd
bin/kamal deploy --skip-push
```

[^1]: https://docs.docker.com/build/exporters/image-registry/#synopsis