### PR TITLE
Add `--lock-wait` to retry deploy lock acquisition

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -6,6 +6,10 @@ module Kamal::Cli
     include SSHKit::DSL
 
     VERBOSITY = { verbose: :debug, quiet: :error }.freeze
+    AUTOMATIC_DEPLOY_LOCK_MESSAGE = "Automatic deploy lock"
+
+    class LockHeldError < StandardError; end
+    class LockMissingError < StandardError; end
 
     def self.exit_on_failure?() true end
     def self.dynamic_command_class() Kamal::Cli::Alias::Command end
@@ -23,6 +27,10 @@ module Kamal::Cli
     class_option :destination, aliases: "-d", desc: "Specify destination to be used for config file (staging -> deploy.staging.yml)"
 
     class_option :skip_hooks, aliases: "-H", type: :boolean, default: false, desc: "Don't run hooks"
+
+    class_option :lock_wait, type: :boolean, default: false, desc: "Wait for the deploy lock if it's already held instead of failing immediately"
+    class_option :lock_wait_timeout, type: :numeric, default: 900, desc: "Maximum seconds to wait for the deploy lock when --lock-wait is set"
+    class_option :lock_wait_interval, type: :numeric, default: 15, desc: "Seconds between deploy lock polls when --lock-wait is set"
 
     def initialize(args = [], local_options = {}, config = {})
       if config[:current_command].is_a?(Kamal::Cli::Alias::Command)
@@ -60,6 +68,10 @@ module Kamal::Cli
           commander.specific_hosts    = options[:hosts]&.split(",")
           commander.specific_roles    = options[:roles]&.split(",")
           commander.specific_primary! if options[:primary]
+
+          commander.lock_wait          = options[:lock_wait]
+          commander.lock_wait_timeout  = options[:lock_wait_timeout]
+          commander.lock_wait_interval = options[:lock_wait_interval]
         end
       end
 
@@ -123,31 +135,90 @@ module Kamal::Cli
       def acquire_lock
         ensure_run_directory
 
-        raise_if_locked do
-          say "Acquiring the deploy lock...", :magenta
-          on(KAMAL.primary_host) { execute *KAMAL.lock.acquire("Automatic deploy lock", KAMAL.config.version), verbosity: :debug }
+        if KAMAL.lock_wait
+          acquire_lock_with_wait
+        else
+          raise_if_locked do
+            say "Acquiring the deploy lock...", :magenta
+            execute_lock_acquire(AUTOMATIC_DEPLOY_LOCK_MESSAGE)
+          end
         end
 
         KAMAL.holding_lock = true
       end
 
+      def acquire_lock_with_wait
+        timeout = KAMAL.lock_wait_timeout
+        interval = KAMAL.lock_wait_interval
+        deadline = Time.now + timeout
+        details_shown = false
+
+        say "Acquiring the deploy lock (waiting up to #{timeout}s)...", :magenta
+
+        loop do
+          execute_lock_acquire(AUTOMATIC_DEPLOY_LOCK_MESSAGE)
+          break
+        rescue LockHeldError
+          unless details_shown
+            status = capture_lock_status
+
+            say "Deploy lock is held by:", :magenta
+            puts status
+
+            unless status.include?(AUTOMATIC_DEPLOY_LOCK_MESSAGE)
+              raise LockError, "Deploy lock held manually, not waiting. Run 'kamal lock help' for more information"
+            end
+
+            details_shown = true
+          end
+
+          remaining = (deadline - Time.now).to_i
+          if remaining <= 0
+            say "Timed out after #{timeout}s waiting for the deploy lock", :red
+            raise LockError, "Timed out waiting for deploy lock"
+          end
+
+          say "Retrying in #{interval}s (#{remaining}s remaining)...", :magenta
+          sleep [ interval, remaining ].min
+        end
+      end
+
       def release_lock
         say "Releasing the deploy lock...", :magenta
-        on(KAMAL.primary_host) { execute *KAMAL.lock.release, verbosity: :debug }
+        execute_lock_release
 
         KAMAL.holding_lock = false
       end
 
       def raise_if_locked
         yield
+      rescue LockHeldError
+        say "Deploy lock already in place!", :red
+        puts capture_lock_status
+        raise LockError, "Deploy lock found. Run 'kamal lock help' for more information"
+      end
+
+      def execute_lock_acquire(message)
+        on(KAMAL.primary_host) { execute *KAMAL.lock.acquire(message, KAMAL.config.version), verbosity: :debug }
       rescue SSHKit::Runner::ExecuteError => e
-        if e.message =~ /cannot create directory/
-          say "Deploy lock already in place!", :red
-          on(KAMAL.primary_host) { puts capture_with_debug(*KAMAL.lock.status) }
-          raise LockError, "Deploy lock found. Run 'kamal lock help' for more information"
-        else
-          raise e
-        end
+        raise LockHeldError if e.message =~ /cannot create directory/
+        raise
+      end
+
+      def execute_lock_release
+        on(KAMAL.primary_host) { execute *KAMAL.lock.release, verbosity: :debug }
+      rescue SSHKit::Runner::ExecuteError => e
+        raise LockMissingError if e.message =~ /No such file or directory/
+        raise
+      end
+
+      def capture_lock_status
+        status = nil
+        on(KAMAL.primary_host) { status = capture_with_debug(*KAMAL.lock.status) }
+        status
+      rescue SSHKit::Runner::ExecuteError => e
+        raise LockMissingError if e.message =~ /No such file or directory/
+        raise
       end
 
       def run_hook(hook, **extra_details)

--- a/lib/kamal/cli/lock.rb
+++ b/lib/kamal/cli/lock.rb
@@ -2,22 +2,17 @@ class Kamal::Cli::Lock < Kamal::Cli::Base
   desc "status", "Report lock status"
   def status
     handle_missing_lock do
-      on(KAMAL.primary_host) do
-        puts capture_with_debug(*KAMAL.lock.status)
-      end
+      puts capture_lock_status
     end
   end
 
   desc "acquire", "Acquire the deploy lock"
   option :message, aliases: "-m", type: :string, desc: "A lock message", required: true
   def acquire
-    message = options[:message]
     ensure_run_directory
 
     raise_if_locked do
-      on(KAMAL.primary_host) do
-        execute *KAMAL.lock.acquire(message, KAMAL.config.version), verbosity: :debug
-      end
+      execute_lock_acquire(options[:message])
       say "Acquired the deploy lock"
     end
   end
@@ -25,9 +20,7 @@ class Kamal::Cli::Lock < Kamal::Cli::Base
   desc "release", "Release the deploy lock"
   def release
     handle_missing_lock do
-      on(KAMAL.primary_host) do
-        execute *KAMAL.lock.release, verbosity: :debug
-      end
+      execute_lock_release
       say "Released the deploy lock"
     end
   end
@@ -35,11 +28,7 @@ class Kamal::Cli::Lock < Kamal::Cli::Base
   private
     def handle_missing_lock
       yield
-    rescue SSHKit::Runner::ExecuteError => e
-      if e.message =~ /No such file or directory/
-        say "There is no deploy lock"
-      else
-        raise
-      end
+    rescue LockMissingError
+      say "There is no deploy lock"
     end
 end

--- a/lib/kamal/commander.rb
+++ b/lib/kamal/commander.rb
@@ -5,7 +5,7 @@ require "active_support/broadcast_logger"
 require "active_support/notifications"
 
 class Kamal::Commander
-  attr_accessor :verbosity, :holding_lock, :connected, :logging
+  attr_accessor :verbosity, :holding_lock, :connected, :logging, :lock_wait, :lock_wait_timeout, :lock_wait_interval
   attr_reader :specific_roles, :specific_hosts
   delegate :hosts, :roles, :primary_host, :primary_role, :roles_on, :app_hosts, :proxy_hosts, :accessory_hosts, to: :specifics
 
@@ -18,6 +18,9 @@ class Kamal::Commander
     self.holding_lock = ENV["KAMAL_LOCK"] == "true"
     self.connected = false
     self.logging = false
+    self.lock_wait = false
+    self.lock_wait_timeout = 900
+    self.lock_wait_interval = 15
     @modify_depth = 0
     @specifics = @specific_roles = @specific_hosts = nil
     @config = @config_kwargs = nil

--- a/test/cli/lock_test.rb
+++ b/test/cli/lock_test.rb
@@ -13,6 +13,24 @@ class CliLockTest < CliTestCase
     end
   end
 
+  test "status when there is no deploy lock" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_debug)
+      .raises(RuntimeError, "cat: .kamal/lock-app/details: No such file or directory")
+
+    run_command("status").tap do |output|
+      assert_match "There is no deploy lock", output
+    end
+  end
+
+  test "release when there is no deploy lock" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+      .raises(RuntimeError, "rm: cannot remove '.kamal/lock-app/details': No such file or directory")
+
+    run_command("release").tap do |output|
+      assert_match "There is no deploy lock", output
+    end
+  end
+
   private
     def run_command(*command)
       stdouted { Kamal::Cli::Lock.start([ *command, "-v", "-c", "test/fixtures/deploy_with_accessories.yml" ]) }

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -5,7 +5,7 @@ class CliMainTest < CliTestCase
   teardown { ENV.clear; ENV.update @original_env }
 
   test "setup" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
+    invoke_options = base_invoke_options
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:deploy).with(boot_accessories: true)
@@ -16,7 +16,7 @@ class CliMainTest < CliTestCase
   end
 
   test "setup with skip_push" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
+    invoke_options = base_invoke_options
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
@@ -41,7 +41,7 @@ class CliMainTest < CliTestCase
 
   test "deploy with local registry" do
     with_test_secrets("secrets" => "DB_PASSWORD=secret") do
-      invoke_options = { "config_file" => "test/fixtures/deploy_with_local_registry.yml", "version" => "999", "skip_hooks" => false, "verbose" => true }
+      invoke_options = base_invoke_options(config_file: "deploy_with_local_registry.yml", verbose: true)
 
       Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
       Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:boot", [], invoke_options)
@@ -64,7 +64,7 @@ class CliMainTest < CliTestCase
   end
 
   test "setup with no_cache" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false, "no_cache" => true }
+    invoke_options = base_invoke_options(no_cache: true)
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:server:bootstrap", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:boot", [ "all" ], invoke_options)
@@ -87,7 +87,7 @@ class CliMainTest < CliTestCase
 
   test "deploy" do
     with_test_secrets("secrets" => "DB_PASSWORD=secret") do
-      invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false, "verbose" => true }
+      invoke_options = base_invoke_options(verbose: true)
 
       Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
       Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:boot", [], invoke_options)
@@ -110,7 +110,7 @@ class CliMainTest < CliTestCase
   end
 
   test "deploy with skip_push" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
+    invoke_options = base_invoke_options
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:pull", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:boot", [], invoke_options)
@@ -129,7 +129,7 @@ class CliMainTest < CliTestCase
   end
 
   test "deploy with no_cache" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false, "no_cache" => true }
+    invoke_options = base_invoke_options(no_cache: true)
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:boot", [], invoke_options)
@@ -179,10 +179,122 @@ class CliMainTest < CliTestCase
     end
   end
 
+  test "deploy with --lock-wait retries and acquires lock when freed" do
+    Thread.report_on_exception = false
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+    Dir.stubs(:chdir)
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+      .with { |*args| args == [ :mkdir, "-p", ".kamal/apps/app" ] }
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+      .with { |*arg| arg[0..1] == [ :mkdir, ".kamal/lock-app" ] }
+      .raises(RuntimeError, "mkdir: cannot create directory ‘kamal/lock-app’: File exists").then
+      .raises(RuntimeError, "mkdir: cannot create directory ‘kamal/lock-app’: File exists").then
+      .returns(nil)
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_debug)
+      .with(:stat, ".kamal/lock-app", ">", "/dev/null", "&&", :cat, ".kamal/lock-app/details", "|", :base64, "-d")
+      .returns("Locked by: alice\nVersion: 999\nMessage: Automatic deploy lock")
+
+    Kamal::Cli::Base.any_instance.stubs(:sleep)
+
+    Kamal::Cli::Main.any_instance.stubs(:invoke)
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:git, "-C", anything, :"rev-parse", :HEAD)
+      .returns(Kamal::Git.revision)
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:git, "-C", anything, :status, "--porcelain")
+      .returns("")
+
+    output = run_command("deploy", "--lock-wait", "--lock-wait-interval", "0", "--lock-wait-timeout", "60")
+    assert_match /Acquiring the deploy lock \(waiting up to 60s\)/, output
+    assert_match /Deploy lock is held by:/, output
+    assert_match /Retrying in 0s/, output
+    assert_match /Releasing the deploy lock/, output
+  end
+
+  test "deploy with --lock-wait times out" do
+    Thread.report_on_exception = false
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+    Dir.stubs(:chdir)
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+      .with { |*args| args == [ :mkdir, "-p", ".kamal/apps/app" ] }
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+      .with { |*arg| arg[0..1] == [ :mkdir, ".kamal/lock-app" ] }
+      .raises(RuntimeError, "mkdir: cannot create directory ‘kamal/lock-app’: File exists")
+
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_debug)
+      .with(:stat, ".kamal/lock-app", ">", "/dev/null", "&&", :cat, ".kamal/lock-app/details", "|", :base64, "-d")
+      .returns("Locked by: alice\nVersion: 999\nMessage: Automatic deploy lock")
+
+    Kamal::Cli::Base.any_instance.stubs(:sleep)
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:git, "-C", anything, :"rev-parse", :HEAD)
+      .returns(Kamal::Git.revision)
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:git, "-C", anything, :status, "--porcelain")
+      .returns("")
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:docker, :info, "--format '{{index .RegistryConfig.Mirrors 0}}'")
+      .returns("")
+
+    assert_raises(Kamal::Cli::LockError) do
+      run_command("deploy", "--lock-wait", "--lock-wait-timeout", "0", "--lock-wait-interval", "0")
+    end
+  end
+
+  test "deploy with --lock-wait fails immediately when the lock is held manually" do
+    Thread.report_on_exception = false
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+    Dir.stubs(:chdir)
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+      .with { |*args| args == [ :mkdir, "-p", ".kamal/apps/app" ] }
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+      .with { |*arg| arg[0..1] == [ :mkdir, ".kamal/lock-app" ] }
+      .raises(RuntimeError, "mkdir: cannot create directory ‘kamal/lock-app’: File exists")
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_debug)
+      .with(:stat, ".kamal/lock-app", ">", "/dev/null", "&&", :cat, ".kamal/lock-app/details", "|", :base64, "-d")
+      .returns("Locked by: alice\nVersion: 999\nMessage: Stopping deploys for maintenance")
+
+    # A manually held lock must never trigger a wait, even with a long timeout
+    Kamal::Cli::Base.any_instance.expects(:sleep).never
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:git, "-C", anything, :"rev-parse", :HEAD)
+      .returns(Kamal::Git.revision)
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:git, "-C", anything, :status, "--porcelain")
+      .returns("")
+
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with(:docker, :info, "--format '{{index .RegistryConfig.Mirrors 0}}'")
+      .returns("")
+
+    error = assert_raises(Kamal::Cli::LockError) do
+      run_command("deploy", "--lock-wait", "--lock-wait-timeout", "60", "--lock-wait-interval", "0")
+    end
+    assert_match /held manually/, error.message
+  end
+
   test "deploy when inheriting lock" do
     Thread.report_on_exception = false
 
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
+    invoke_options = base_invoke_options
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:boot", [], invoke_options)
@@ -237,7 +349,7 @@ class CliMainTest < CliTestCase
   end
 
   test "deploy errors during outside section leave remote lock" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
+    invoke_options = base_invoke_options
 
     Kamal::Cli::Main.any_instance.expects(:invoke)
       .with("kamal:cli:build:deliver", [], invoke_options)
@@ -251,7 +363,7 @@ class CliMainTest < CliTestCase
   end
 
   test "deploy with skipped hooks" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => true }
+    invoke_options = base_invoke_options(skip_hooks: true)
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:boot", [], invoke_options)
@@ -265,7 +377,7 @@ class CliMainTest < CliTestCase
   end
 
   test "deploy with missing secrets" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_with_secrets.yml", "version" => "999", "skip_hooks" => false }
+    invoke_options = base_invoke_options(config_file: "deploy_with_secrets.yml")
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:boot", [], invoke_options)
@@ -277,7 +389,7 @@ class CliMainTest < CliTestCase
   end
 
   test "redeploy" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false, "verbose" => true }
+    invoke_options = base_invoke_options(verbose: true)
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
@@ -295,7 +407,7 @@ class CliMainTest < CliTestCase
   end
 
   test "redeploy with skip_push" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false }
+    invoke_options = base_invoke_options
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:pull", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
@@ -307,7 +419,7 @@ class CliMainTest < CliTestCase
   end
 
   test "redeploy with no_cache" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_simple.yml", "version" => "999", "skip_hooks" => false, "no_cache" => true }
+    invoke_options = base_invoke_options(no_cache: true)
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
@@ -378,7 +490,7 @@ class CliMainTest < CliTestCase
   end
 
   test "remove" do
-    options = { "config_file" => "test/fixtures/deploy_simple.yml", "skip_hooks" => false, "confirmed" => true }
+    options = base_invoke_options(version: nil, confirmed: true)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:remove", [], options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:remove", [], options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:remove", [ "all" ], options)
@@ -678,7 +790,7 @@ class CliMainTest < CliTestCase
   end
 
   test "run an alias with require_destination" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_for_required_dest.yml", "version" => "999", "skip_hooks" => false, "destination" => "world" }
+    invoke_options = base_invoke_options(config_file: "deploy_for_required_dest.yml", destination: "world")
 
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:boot", [], invoke_options)
@@ -697,7 +809,7 @@ class CliMainTest < CliTestCase
   end
 
   test "upgrade" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_with_accessories.yml", "skip_hooks" => false, "confirmed" => true, "rolling" => false }
+    invoke_options = base_invoke_options(config_file: "deploy_with_accessories.yml", version: nil, confirmed: true, rolling: false)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:upgrade", [], invoke_options)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:upgrade", [ "all" ], invoke_options)
 
@@ -708,7 +820,7 @@ class CliMainTest < CliTestCase
   end
 
   test "upgrade rolling" do
-    invoke_options = { "config_file" => "test/fixtures/deploy_with_accessories.yml", "skip_hooks" => false, "confirmed" => true, "rolling" => false }
+    invoke_options = base_invoke_options(config_file: "deploy_with_accessories.yml", version: nil, confirmed: true, rolling: false)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:upgrade", [], invoke_options).times(4)
     Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:accessory:upgrade", [ "all" ], invoke_options).times(3)
 
@@ -773,5 +885,17 @@ class CliMainTest < CliTestCase
       yield
     ensure
       ENV.delete("KAMAL_LOCK")
+    end
+
+    def base_invoke_options(config_file: "deploy_simple.yml", version: "999", **extras)
+      base = {
+        "config_file" => "test/fixtures/#{config_file}",
+        "skip_hooks" => false,
+        "lock_wait" => false,
+        "lock_wait_timeout" => 900,
+        "lock_wait_interval" => 15
+      }
+      base["version"] = version unless version.nil?
+      base.merge(extras.transform_keys(&:to_s))
     end
 end


### PR DESCRIPTION
Multiple CI workflows targeting the same Kamal deployment race on the deploy lock — only the first wins and the rest abort with `LockError`. `--lock-wait` makes lock-acquiring commands (`deploy`, `redeploy`, `rollback`, `app boot`, etc.) poll for the lock instead of failing immediately, useful for shared CI environments.

The retry target is the same atomic `mkdir` that backs `lock acquire`, so wait-then-acquire is race-free without a separate check phase. On timeout, the existing lock holder's details are printed and `Kamal::Cli::LockError` is raised.

Defaults: 15 minute timeout, 15 second poll interval. Both configurable.

```bash
# Wait up to default 15m for the lock, polling every 15s
kamal deploy --lock-wait

# Custom timeout/interval (30 minutes, 30 second polls)
kamal deploy --lock-wait --lock-wait-timeout 1800 --lock-wait-interval 30
```

Heartbeat output during the wait:

```
Acquiring the deploy lock (waiting up to 900s)...
Deploy lock is held by:
Locked by: alice at 2026-04-28T15:23:45Z
Version: abc1234
Message: deploying
Retrying in 15s (885s remaining)...
Retrying in 15s (870s remaining)...
```