### PR TITLE
Ensure local registry is started for remote builders

### DIFF
--- a/lib/kamal/cli/build.rb
+++ b/lib/kamal/cli/build.rb
@@ -18,7 +18,8 @@ class Kamal::Cli::Build < Kamal::Cli::Base
     pre_connect_if_required
 
     ensure_docker_installed
-    login_to_registry_locally if KAMAL.builder.login_to_registry_locally?
+    setup_local_registry      if KAMAL.registry.local?
+    login_to_registry_locally if !KAMAL.registry.local? && KAMAL.builder.login_to_registry_locally?
 
     run_hook "pre-build"
 
@@ -194,13 +195,15 @@ class Kamal::Cli::Build < Kamal::Cli::Base
       end
     end
 
+    def setup_local_registry
+      run_locally do
+        execute *KAMAL.registry.setup
+      end
+    end
+
     def login_to_registry_locally
       run_locally do
-        if KAMAL.registry.local?
-          execute *KAMAL.registry.setup
-        else
-          execute *KAMAL.registry.login
-        end
+        execute *KAMAL.registry.login
       end
     end
 

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -56,34 +56,21 @@ class CliBuildTest < CliTestCase
     # Even though we skip `docker login` locally for remote builders (#1664),
     # we must still ensure the local registry container is running on the dev
     # machine, since the remote builder pushes to it through an SSH tunnel.
-    with_build_directory do |build_directory|
-      Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).returns(true)
+    assert_local_registry_started_before_push(
+      fixture: :with_local_registry_and_remote_builder,
+      remote_host: "1.1.1.5"
+    )
+  end
 
-      # Stub the SSH reverse tunnel set up for the remote builder so the test
-      # doesn't try to actually connect to 1.1.1.5.
-      port_forwarding_mock = mock("port_forwarding")
-      port_forwarding_mock.expects(:forward).yields
-      Kamal::Cli::Build::PortForwarding.expects(:new)
-        .with([ "1.1.1.5" ], 5000, has_entries(keepalive: true, keepalive_interval: 30))
-        .returns(port_forwarding_mock)
-
-      SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
-        .with(:git, "-C", anything, :"rev-parse", :HEAD)
-        .returns(Kamal::Git.revision)
-
-      SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
-        .with(:git, "-C", anything, :status, "--porcelain")
-        .returns("")
-
-      run_command("push", "--verbose", fixture: :with_local_registry_and_remote_builder).tap do |output|
-        # The local registry container is started (or restarted) on the dev machine
-        assert_match "docker start kamal-docker-registry || docker run --detach -p 127.0.0.1:5000:5000 --name kamal-docker-registry registry:3", output
-        # `docker login` is NOT run locally for a local registry (#1664 behavior preserved)
-        assert_no_match "Running docker login -u [REDACTED] -p [REDACTED] as ", output
-        # And the remote builder push still happens with BUILDKIT_NO_CLIENT_TOKEN
-        assert_match "BUILDKIT_NO_CLIENT_TOKEN=\"1\"", output
-      end
-    end
+  test "push with hybrid builder and local registry starts the local registry container" do
+    # `Kamal::Commands::Builder::Hybrid` inherits from `Remote`, so it has the
+    # same `login_to_registry_locally? => false` and would suffer from the
+    # same regression as the pure-remote builder when combined with a local
+    # registry.
+    assert_local_registry_started_before_push(
+      fixture: :with_local_registry_and_hybrid_builder,
+      remote_host: "1.1.1.5"
+    )
   end
 
   test "push --output=docker" do
@@ -486,6 +473,47 @@ class CliBuildTest < CliTestCase
   end
 
   private
+    def assert_local_registry_started_before_push(fixture:, remote_host:)
+      with_build_directory do |build_directory|
+        Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).returns(true)
+
+        # Stub the SSH reverse tunnel set up for the remote builder so the
+        # test doesn't try to actually connect to the remote host.
+        port_forwarding_mock = mock("port_forwarding")
+        port_forwarding_mock.expects(:forward).yields
+        Kamal::Cli::Build::PortForwarding.expects(:new)
+          .with([ remote_host ], 5000, has_entries(keepalive: true, keepalive_interval: 30))
+          .returns(port_forwarding_mock)
+
+        SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+          .with(:git, "-C", anything, :"rev-parse", :HEAD)
+          .returns(Kamal::Git.revision)
+
+        SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+          .with(:git, "-C", anything, :status, "--porcelain")
+          .returns("")
+
+        output = run_command("push", "--verbose", fixture: fixture)
+
+        registry_setup = "docker start kamal-docker-registry || docker run --detach -p 127.0.0.1:5000:5000 --name kamal-docker-registry registry:3"
+        buildx_build   = "docker buildx build"
+
+        # The local registry container is started (or restarted) on the dev machine.
+        assert_match registry_setup, output
+
+        # And it must happen *before* the build/push, otherwise the remote
+        # builder will try to push to a registry that isn't up yet.
+        assert_operator output.index(registry_setup), :<, output.index(buildx_build),
+          "Expected `#{registry_setup}` to run before `#{buildx_build}`"
+
+        # `docker login` is NOT run locally for a local registry (#1664 behavior preserved).
+        assert_no_match "Running docker login -u [REDACTED] -p [REDACTED] as ", output
+
+        # And the remote builder push still happens with BUILDKIT_NO_CLIENT_TOKEN.
+        assert_match "BUILDKIT_NO_CLIENT_TOKEN=\"1\"", output
+      end
+    end
+
     def run_command(*command, fixture: :with_accessories)
       stdouted { stderred { Kamal::Cli::Build.start([ *command, "-c", "test/fixtures/deploy_#{fixture}.yml" ]) } }
     end

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -51,6 +51,41 @@ class CliBuildTest < CliTestCase
     end
   end
 
+  test "push with remote builder and local registry starts the local registry container" do
+    # Regression test for the combination of `builder.remote` + `registry.server: localhost:...`.
+    # Even though we skip `docker login` locally for remote builders (#1664),
+    # we must still ensure the local registry container is running on the dev
+    # machine, since the remote builder pushes to it through an SSH tunnel.
+    with_build_directory do |build_directory|
+      Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).returns(true)
+
+      # Stub the SSH reverse tunnel set up for the remote builder so the test
+      # doesn't try to actually connect to 1.1.1.5.
+      port_forwarding_mock = mock("port_forwarding")
+      port_forwarding_mock.expects(:forward).yields
+      Kamal::Cli::Build::PortForwarding.expects(:new)
+        .with([ "1.1.1.5" ], 5000, has_entries(keepalive: true, keepalive_interval: 30))
+        .returns(port_forwarding_mock)
+
+      SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+        .with(:git, "-C", anything, :"rev-parse", :HEAD)
+        .returns(Kamal::Git.revision)
+
+      SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
+        .with(:git, "-C", anything, :status, "--porcelain")
+        .returns("")
+
+      run_command("push", "--verbose", fixture: :with_local_registry_and_remote_builder).tap do |output|
+        # The local registry container is started (or restarted) on the dev machine
+        assert_match "docker start kamal-docker-registry || docker run --detach -p 127.0.0.1:5000:5000 --name kamal-docker-registry registry:3", output
+        # `docker login` is NOT run locally for a local registry (#1664 behavior preserved)
+        assert_no_match "Running docker login -u [REDACTED] -p [REDACTED] as ", output
+        # And the remote builder push still happens with BUILDKIT_NO_CLIENT_TOKEN
+        assert_match "BUILDKIT_NO_CLIENT_TOKEN=\"1\"", output
+      end
+    end
+  end
+
   test "push --output=docker" do
     with_build_directory do |build_directory|
       Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).returns(true)

--- a/test/fixtures/deploy_with_local_registry_and_hybrid_builder.yml
+++ b/test/fixtures/deploy_with_local_registry_and_hybrid_builder.yml
@@ -1,0 +1,14 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+    - "1.1.1.2"
+registry:
+  server: localhost:5000
+
+builder:
+  arch:
+    - amd64
+    - arm64
+  remote: ssh://app@1.1.1.5


### PR DESCRIPTION
## Summary

When using `builder.remote` with a local registry (`registry.server: localhost:5555`), `kamal deploy` fails to push the image whenever the local `kamal-docker-registry` container is not currently running:

```
failed to push localhost:5555/<image>:<sha>: failed to do request:
Head "http://localhost:5555/v2/...": dial tcp [::1]:5555: connect: connection refused
```

The SSH reverse port-forward set up by #1679 is in place, but it forwards to a registry container that has exited (e.g. host reboot, OOM kill, Docker daemon restart, `docker system prune`, exit code 2, ...). `kamal deploy` does not auto-(re)start the container in this configuration, so users have to manually `docker start kamal-docker-registry` (or `bin/kamal registry setup`) before every deploy after any such event.

## Root cause

`Kamal::Cli::Build#push` gates both responsibilities behind a single predicate:

```ruby
# lib/kamal/cli/build.rb (before)
login_to_registry_locally if KAMAL.builder.login_to_registry_locally?

def login_to_registry_locally
  run_locally do
    if KAMAL.registry.local?
      execute *KAMAL.registry.setup    # ← starts kamal-docker-registry
    else
      execute *KAMAL.registry.login    # ← docker login on dev machine
    end
  end
end
```

The single boolean `KAMAL.builder.login_to_registry_locally?` controls **two semantically different things**:

| Registry type | What this method does |
|---|---|
| Remote (`ghcr.io`, Docker Hub, …) | `docker login` on the dev machine |
| Local (`localhost:5555`) | `docker run` / `docker start` the local registry container |

#1664 ("Don't login to registry locally for remote build: take 2") legitimately made `Kamal::Commands::Builder::Remote#login_to_registry_locally?` return `false` so the dev machine doesn't need `docker login` when the remote builder authenticates itself via SSH (with `BUILDKIT_NO_CLIENT_TOKEN=1`). That fix is correct for the remote-registry path, but as a side effect it also disabled the local-registry container start-up.

#1679 ("Add local registry support for remote builders") then made the network plumbing work for that combination by adding the SSH reverse tunnel and `--driver-opt network=host`, but it didn't restore the container start-up that #1664 had silently turned off. The two PRs were authored independently and the gap went unnoticed because the implicit assumption is *"you ran `kamal setup` once; the container persists forever."* That assumption fails any time the container exits.

## Fix

Decouple the two responsibilities:

```ruby
# lib/kamal/cli/build.rb (after)
ensure_docker_installed
setup_local_registry      if KAMAL.registry.local?
login_to_registry_locally if !KAMAL.registry.local? && KAMAL.builder.login_to_registry_locally?

def setup_local_registry
  run_locally { execute *KAMAL.registry.setup }
end

def login_to_registry_locally
  run_locally { execute *KAMAL.registry.login }
end
```

* `setup_local_registry` runs whenever `registry.local?` is true, regardless of which builder is used. The underlying command (`docker start kamal-docker-registry || docker run --detach -p 127.0.0.1:5555:5000 --name kamal-docker-registry registry:3`) is idempotent, so calling it on every push is safe and self-healing.
* `login_to_registry_locally` keeps its original meaning (run `docker login` on the dev machine) and is only invoked for non-local registries when the builder needs local credentials. Remote / Hybrid builders still skip it, preserving the #1664 behavior — verified by the existing `push with remote builder checks both the builder and the remote context` test.

## Test

Adds a regression test `push with remote builder and local registry starts the local registry container` that:

1. Asserts `docker start kamal-docker-registry || docker run … registry:3` runs locally.
2. Asserts `docker login` does **not** run locally (the #1664 behavior is preserved).
3. Asserts the remote build still happens with `BUILDKIT_NO_CLIENT_TOKEN=1`.

I verified the test correctly fails on `main` without the fix and passes with it. The pre-existing `push without builder for local registry` test (local builder + local registry) continues to pass, confirming no regression in that path.

`./bin/test` is green for all unit tests; the 17 integration-test failures observed locally are pre-existing and unrelated to this change (they fail on `builder/arch: should be an array or a string` because the docker-compose harness pins to the published `kamal-2.11.0` gem).

## Related

* #1355 – original local-registry feature
* #1656 / #1662 / #1664 – history of the "don't login to registry locally for remote build" change that introduced this regression
* #1679 – added port-forwarding for remote builder + local registry, but didn't restore container start-up

cc @djmb @npezza93
