### PR TITLE
Fix --container-id to produce log output

### DIFF
--- a/lib/kamal/commands/app/logging.rb
+++ b/lib/kamal/commands/app/logging.rb
@@ -21,7 +21,7 @@ module Kamal::Commands::App::Logging
   def container_id_command(container_id)
     case container_id
     when Array then container_id
-    when String, Symbol then "echo #{container_id}"
+    when String, Symbol then shell(["echo #{container_id}"])
     else current_running_container_id
     end
   end

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -486,9 +486,9 @@ class CliAppTest < CliTestCase
 
   test "logs with follow and container_id" do
     SSHKit::Backend::Abstract.any_instance.stubs(:exec)
-      .with("ssh -t root@1.1.1.1 -p 22 'echo ID123 | xargs docker logs --timestamps --tail 10 --follow 2>&1'")
+      .with("ssh -t root@1.1.1.1 -p 22 'sh -c '\\''echo ID123'\\'' | xargs docker logs --timestamps --tail 10 --follow 2>&1'")
 
-    assert_match "echo ID123 | xargs docker logs --timestamps --tail 10 --follow 2>&1", run_command("logs", "--follow", "--container-id", "ID123")
+    assert_match "sh -c '\\''echo ID123'\\'' | xargs docker logs --timestamps --tail 10 --follow 2>&1", run_command("logs", "--follow", "--container-id", "ID123")
   end
 
   test "logs with follow and grep" do

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -164,7 +164,7 @@ class CommandsAppTest < ActiveSupport::TestCase
 
   test "logs with container_id" do
     assert_equal \
-      "echo C137 | xargs docker logs --timestamps 2>&1",
+      "sh -c 'echo C137' | xargs docker logs --timestamps 2>&1",
       new_command.logs(container_id: "C137").join(" ")
   end
 
@@ -220,7 +220,7 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command.follow_logs(host: "app-1", grep: "Completed")
 
     assert_equal \
-      "ssh -t root@app-1 -p 22 'echo ID321 | xargs docker logs --timestamps --follow 2>&1'",
+      "ssh -t root@app-1 -p 22 'sh -c '\\''echo ID321'\\'' | xargs docker logs --timestamps --follow 2>&1'",
       new_command.follow_logs(host: "app-1", container_id: "ID321")
 
     assert_equal \


### PR DESCRIPTION
In order to pipe echo into xargs the command needs to run under a shell.

Fixes #1841