### PR TITLE
Add dashlane adapter

### DIFF
--- a/lib/kamal/secrets/adapters/dashlane.rb
+++ b/lib/kamal/secrets/adapters/dashlane.rb
@@ -1,23 +1,30 @@
 class Kamal::Secrets::Adapters::Dashlane < Kamal::Secrets::Adapters::Base
+  def requires_account?
+    false
+  end
+
   private
     def login(account)
-      unless logged_in?(account)
+      unless logged_in?
         system("dcli sync 2> /dev/null")
         raise RuntimeError, "Failed to login to or unlock Dashlane" unless $?.success?
       end
     end
 
-    def logged_in?(account)
-      status = <<~STATUS
-      Logged in: yes
-      Login: #{account}
-      Locked: no
-      STATUS
-      `dcli status 2> /dev/null` == status
+    def logged_in?
+      status = `dcli status 2> /dev/null`
+      return false unless $?.success?
+
+      status = status.each_line(chomp: true).with_object({}) do |line, hash|
+        key, value = line.split(":").map(&:strip)
+        hash[key] = value if key && value
+      end
+
+      status["Logged in"] == "yes" && status["Locked"] == "no"
     end
 
     def fetch_secrets(secrets, from:, account:, session:)
-      raise RuntimeError, "Unsupported 'from' argument for Dashlane" if from
+      raise ArgumentError, "Dashlane adapter does not support the --from option" if from.present?
 
       shell_secrets_string = secrets.map(&:shellescape).join(" ")
       dashlane_passwords = `dcli password #{shell_secrets_string} -o json`

--- a/lib/kamal/secrets/adapters/dashlane.rb
+++ b/lib/kamal/secrets/adapters/dashlane.rb
@@ -1,0 +1,45 @@
+class Kamal::Secrets::Adapters::Dashlane < Kamal::Secrets::Adapters::Base
+  private
+    def login(account)
+      unless logged_in?(account)
+        system("dcli sync 2> /dev/null")
+        raise RuntimeError, "Failed to login to or unlock Dashlane" unless $?.success?
+      end
+    end
+
+    def logged_in?(account)
+      status = <<~STATUS
+      Logged in: yes
+      Login: #{account}
+      Locked: no
+      STATUS
+      `dcli status 2> /dev/null` == status
+    end
+
+    def fetch_secrets(secrets, from:, account:, session:)
+      shell_secrets_string = secrets.map(&:shellescape).join(" ")
+      dashlane_passwords = JSON.parse(`dcli password #{shell_secrets_string} -o json`)
+      dashlane_secrets = JSON.parse(`dcli secret #{shell_secrets_string} -o json`)
+
+      results = {}
+      dashlane_passwords.each do |password|
+        results[password["title"]] = password["password"]
+      end
+      dashlane_secrets.each do |secret|
+        results[secret["title"]] = secret["content"]
+      end
+      if (missing_items = secrets - results.keys).any?
+        raise RuntimeError, "Could not find #{missing_items.join(", ")} in Dashlane passwords or secrets"
+      end
+      results
+    end
+
+    def check_dependencies!
+      raise RuntimeError, "Dashlane CLI is not installed" unless cli_installed?
+    end
+
+    def cli_installed?
+      `dcli --version 2> /dev/null`
+      $?.success?
+    end
+end

--- a/lib/kamal/secrets/adapters/dashlane.rb
+++ b/lib/kamal/secrets/adapters/dashlane.rb
@@ -17,20 +17,29 @@ class Kamal::Secrets::Adapters::Dashlane < Kamal::Secrets::Adapters::Base
     end
 
     def fetch_secrets(secrets, from:, account:, session:)
-      shell_secrets_string = secrets.map(&:shellescape).join(" ")
-      dashlane_passwords = JSON.parse(`dcli password #{shell_secrets_string} -o json`)
-      dashlane_secrets = JSON.parse(`dcli secret #{shell_secrets_string} -o json`)
+      raise RuntimeError, "Unsupported 'from' argument for Dashlane" if from
 
+      shell_secrets_string = secrets.map(&:shellescape).join(" ")
+      dashlane_passwords = `dcli password #{shell_secrets_string} -o json`
+      raise RuntimeError, "Could not read #{secrets} from Dashlane passwords" unless $?.success?
+      dashlane_secrets = `dcli secret #{shell_secrets_string} -o json`
+      raise RuntimeError, "Could not read #{secrets} from Dashlane secrets" unless $?.success?
+
+      dashlane_passwords = JSON.parse(dashlane_passwords)
+      dashlane_secrets = JSON.parse(dashlane_secrets)
       results = {}
+
       dashlane_passwords.each do |password|
         results[password["title"]] = password["password"]
       end
       dashlane_secrets.each do |secret|
         results[secret["title"]] = secret["content"]
       end
+
       if (missing_items = secrets - results.keys).any?
         raise RuntimeError, "Could not find #{missing_items.join(", ")} in Dashlane passwords or secrets"
       end
+
       results
     end
 

--- a/test/secrets/dashlane_adapter_test.rb
+++ b/test/secrets/dashlane_adapter_test.rb
@@ -9,7 +9,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
     stub_cli_installed(false)
 
     assert_raises(RuntimeError, "Dashlane CLI is not installed") do
-      run_command("fetch", "SECRET1")
+      run_command("fetch", *secrets.keys)
     end
   end
 
@@ -82,6 +82,21 @@ class DashlaneAdapterTest < SecretAdapterTestCase
       stub_ticks_with("dcli --version 2> /dev/null", succeed: installed)
     end
 
+    def run_command(*command)
+      stdouted do
+        Kamal::Cli::Secrets.start \
+          [ *command,
+            "-c", "test/fixtures/deploy_with_accessories.yml",
+            "--adapter", "dashlane",
+            "--account", "email@example.com" ]
+      end
+      Kamal::Secrets::Adapters::Dashlane.new
+    end
+
+    def secrets
+      { "SECRET1" => "secret_password", "PASSWORD1" => "password_password" }
+    end
+
     def stub_status(logged_in)
       if logged_in
         stub_ticks_with("dcli status 2> /dev/null", succeed: true).returns(<<~STATUS)
@@ -98,18 +113,8 @@ class DashlaneAdapterTest < SecretAdapterTestCase
       @adapter.stubs(:system).with { "dcli sync 2> /dev/null" && (success ? `true` : `false`) }
     end
 
-    def setup_logged_in
-      stub_cli_installed(true)
-      stub_status(true)
-    end
-
-    def stub_dashlane_secret(found:, secrets:)
-      output = if found
-        "[{\"id\":\"{ZD26708D-5KJ4-12KI-5K0G-4J34FFF67JT2}\",\"creationDatetime\":\"1777896821\",\"lastBackupTime\":\"0\",\"lastUse\":\"1777896821\",\"localeFormat\":\"UNIVERSAL\",\"attachments\":\"[]\",\"userModificationDatetime\":\"1777896821\",\"title\":\"SECRET1\",\"content\":\"secret_password\",\"category\":\"noCategory\",\"secured\":\"false\",\"type\":\"GRAY\",\"creationDate\":\"1777896821\",\"updateDate\":\"1777896821\"}]"
-      else
-        "[]"
-      end
-      stub_ticks.with("dcli secret #{secrets.keys.join(" ")} -o json").returns(output)
+    def account
+      "email@example.com"
     end
 
     def stub_dashlane_password(found:, secrets:)
@@ -121,22 +126,17 @@ class DashlaneAdapterTest < SecretAdapterTestCase
       stub_ticks.with("dcli password #{secrets.keys.join(" ")} -o json").returns(output)
     end
 
-    def account
-      "email@example.com"
-    end
-
-    def secrets
-      { "SECRET1" => "secret_password", "PASSWORD1" => "password_password" }
-    end
-
-    def run_command(*command)
-      stdouted do
-        Kamal::Cli::Secrets.start \
-          [ *command,
-            "-c", "test/fixtures/deploy_with_accessories.yml",
-            "--adapter", "dashlane",
-            "--account", "email@example.com" ]
+    def stub_dashlane_secret(found:, secrets:)
+      output = if found
+        "[{\"id\":\"{ZD26708D-5KJ4-12KI-5K0G-4J34FFF67JT2}\",\"creationDatetime\":\"1777896821\",\"lastBackupTime\":\"0\",\"lastUse\":\"1777896821\",\"localeFormat\":\"UNIVERSAL\",\"attachments\":\"[]\",\"userModificationDatetime\":\"1777896821\",\"title\":\"SECRET1\",\"content\":\"secret_password\",\"category\":\"noCategory\",\"secured\":\"false\",\"type\":\"GRAY\",\"creationDate\":\"1777896821\",\"updateDate\":\"1777896821\"}]"
+      else
+        "[]"
       end
-      Kamal::Secrets::Adapters::Dashlane.new
+      stub_ticks.with("dcli secret #{secrets.keys.join(" ")} -o json").returns(output)
+    end
+
+    def setup_logged_in
+      stub_cli_installed(true)
+      stub_status(true)
     end
 end

--- a/test/secrets/dashlane_adapter_test.rb
+++ b/test/secrets/dashlane_adapter_test.rb
@@ -1,0 +1,142 @@
+require "test_helper"
+
+class DashlaneAdapterTest < SecretAdapterTestCase
+  setup do
+    @adapter = Kamal::Secrets::Adapters::Dashlane.new
+  end
+
+  test "fetch without CLI installed" do
+    stub_cli_installed(false)
+
+    assert_raises(RuntimeError, "Dashlane CLI is not installed") do
+      run_command("fetch", "SECRET1")
+    end
+  end
+
+  test "fetch with failed login" do
+    stub_cli_installed(true)
+    stub_status(false)
+    stub_login(false)
+
+    assert_raises(RuntimeError, "Failed to login to or unlock Dashlane") do
+      @adapter.fetch([ "SECRET1, PASSWORD1" ], account: account)
+    end
+  end
+
+  test "fetch with successful login" do
+    stub_cli_installed(true)
+    stub_status(false)
+    stub_login(true)
+    stub_dashlane_password(found: true, secrets: secrets)
+    stub_dashlane_secret(found: true, secrets: secrets)
+
+    result = @adapter.fetch(secrets.keys, account: account)
+
+    assert_equal(result.sort, secrets.sort)
+  end
+
+  test "fetch when already logged in" do
+    setup_logged_in
+    stub_dashlane_password(found: true, secrets: secrets)
+    stub_dashlane_secret(found: true, secrets: secrets)
+
+    result = @adapter.fetch(secrets.keys, account: account)
+
+    assert_equal(result.sort, secrets.sort)
+  end
+
+  test "fetch with missing entries" do
+    setup_logged_in
+    stub_dashlane_password(found: false, secrets: secrets)
+    stub_dashlane_secret(found: false, secrets: secrets)
+
+    assert_raises RuntimeError, "Could not find #{secrets.keys.join(", ")} in Dashlane passwords or secrets" do
+      @adapter.fetch(secrets.keys, account: account)
+    end
+  end
+
+  test "fetch dashlane passwords and no secrets" do
+    only_passwords = secrets.select { |k| k.match? "PASSWORD" }
+    setup_logged_in
+    stub_dashlane_password(found: true, secrets: only_passwords)
+    stub_dashlane_secret(found: false, secrets: only_passwords)
+
+    result = @adapter.fetch(only_passwords.keys, account: account)
+
+    assert_equal(result.sort, only_passwords.sort)
+  end
+
+  test "fetch dashlane secrets and no passwords" do
+    only_secrets = secrets.select { |k| k.match? "SECRET" }
+    setup_logged_in
+    stub_dashlane_password(found: false, secrets: only_secrets)
+    stub_dashlane_secret(found: true, secrets: only_secrets)
+
+    result = @adapter.fetch(only_secrets.keys, account: account)
+
+    assert_equal(result.sort, only_secrets.sort)
+  end
+
+  private
+    def stub_cli_installed(installed)
+      stub_ticks_with("dcli --version 2> /dev/null", succeed: installed)
+    end
+
+    def stub_status(logged_in)
+      if logged_in
+        stub_ticks_with("dcli status 2> /dev/null", succeed: true).returns(<<~STATUS)
+        Logged in: yes
+        Login: #{account}
+        Locked: no
+        STATUS
+      else
+        stub_ticks_with("dcli status 2> /dev/null", succeed: false)
+      end
+    end
+
+    def stub_login(success)
+      @adapter.stubs(:system).with { "dcli sync 2> /dev/null" && (success ? `true` : `false`) }
+    end
+
+    def setup_logged_in
+      stub_cli_installed(true)
+      stub_status(true)
+    end
+
+    def stub_dashlane_secret(found:, secrets:)
+      output = if found
+        "[{\"id\":\"{ZD26708D-5KJ4-12KI-5K0G-4J34FFF67JT2}\",\"creationDatetime\":\"1777896821\",\"lastBackupTime\":\"0\",\"lastUse\":\"1777896821\",\"localeFormat\":\"UNIVERSAL\",\"attachments\":\"[]\",\"userModificationDatetime\":\"1777896821\",\"title\":\"SECRET1\",\"content\":\"secret_password\",\"category\":\"noCategory\",\"secured\":\"false\",\"type\":\"GRAY\",\"creationDate\":\"1777896821\",\"updateDate\":\"1777896821\"}]"
+      else
+        "[]"
+      end
+      stub_ticks.with("dcli secret #{secrets.keys.join(" ")} -o json").returns(output)
+    end
+
+    def stub_dashlane_password(found:, secrets:)
+      output = if found
+        "[{\"id\":\"{ZD26708D-5KJ4-12KI-5K0G-4J34FFF67JT3}\",\"creationDatetime\":\"1777982025\",\"lastBackupTime\":\"0\",\"lastUse\":\"1777982025\",\"localeFormat\":\"UNIVERSAL\",\"userModificationDatetime\":\"1777982025\",\"autoLogin\":\"true\",\"autoProtected\":\"false\",\"checked\":\"false\",\"password\":\"password_password\",\"status\":\"ACCOUNT_NOT_VERIFIED\",\"strength\":\"0\",\"subdomainOnly\":\"false\",\"title\":\"PASSWORD1\",\"useFixedUrl\":\"true\",\"linkedServices\":\"{\\\"associated_domains\\\":[]}\",\"modificationDatetime\":\"1777982025\"}]"
+      else
+        "[]"
+      end
+      stub_ticks.with("dcli password #{secrets.keys.join(" ")} -o json").returns(output)
+    end
+
+    def account
+      "email@example.com"
+    end
+
+    def secrets
+      { "SECRET1" => "secret_password", "PASSWORD1" => "password_password" }
+    end
+
+    def run_command(*command)
+      stdouted do
+        Kamal::Cli::Secrets.start \
+          [ *command,
+            "-c", "test/fixtures/deploy_with_accessories.yml",
+            "--adapter", "dashlane",
+            "--account", "email@example.com" ]
+      end
+      Kamal::Secrets::Adapters::Dashlane.new
+    end
+end

--- a/test/secrets/dashlane_adapter_test.rb
+++ b/test/secrets/dashlane_adapter_test.rb
@@ -8,9 +8,10 @@ class DashlaneAdapterTest < SecretAdapterTestCase
   test "fetch without CLI installed" do
     stub_cli_installed(false)
 
-    assert_raises(RuntimeError, "Dashlane CLI is not installed") do
+    error = assert_raises RuntimeError do
       run_command("fetch", *secrets.keys)
     end
+    assert_equal "Dashlane CLI is not installed", error.message
   end
 
   test "fetch with failed login" do
@@ -18,9 +19,10 @@ class DashlaneAdapterTest < SecretAdapterTestCase
     stub_status(false)
     stub_login(false)
 
-    assert_raises(RuntimeError, "Failed to login to or unlock Dashlane") do
+    error = assert_raises RuntimeError do
       @adapter.fetch(secrets.keys, account: account)
     end
+    assert_equal "Failed to login to or unlock Dashlane", error.message
   end
 
   test "fetch with successful login" do
@@ -50,9 +52,10 @@ class DashlaneAdapterTest < SecretAdapterTestCase
     stub_dashlane_password(found: false, secrets: secrets)
     stub_dashlane_secret(found: false, secrets: secrets)
 
-    assert_raises RuntimeError, "Could not find #{secrets.keys.join(", ")} in Dashlane passwords or secrets" do
+    error = assert_raises RuntimeError do
       @adapter.fetch(secrets.keys, account: account)
     end
+    assert_equal "Could not find #{secrets.keys.join(", ")} in Dashlane passwords or secrets", error.message
   end
 
   test "fetch dashlane passwords and no secrets" do

--- a/test/secrets/dashlane_adapter_test.rb
+++ b/test/secrets/dashlane_adapter_test.rb
@@ -93,7 +93,6 @@ class DashlaneAdapterTest < SecretAdapterTestCase
             "--adapter", "dashlane",
             "--account", "email@example.com" ]
       end
-      Kamal::Secrets::Adapters::Dashlane.new
     end
 
     def secrets
@@ -113,7 +112,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
     end
 
     def stub_login(success)
-      @adapter.stubs(:system).with { "dcli sync 2> /dev/null" && (success ? `true` : `false`) }
+      @adapter.stubs(:system).with { |c| c == "dcli sync 2> /dev/null" && (success ? `true` : `false`) }
     end
 
     def account

--- a/test/secrets/dashlane_adapter_test.rb
+++ b/test/secrets/dashlane_adapter_test.rb
@@ -19,7 +19,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
     stub_login(false)
 
     assert_raises(RuntimeError, "Failed to login to or unlock Dashlane") do
-      @adapter.fetch([ "SECRET1, PASSWORD1" ], account: account)
+      @adapter.fetch(secrets.keys, account: account)
     end
   end
 

--- a/test/secrets/dashlane_adapter_test.rb
+++ b/test/secrets/dashlane_adapter_test.rb
@@ -20,7 +20,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
     stub_login(false)
 
     error = assert_raises RuntimeError do
-      @adapter.fetch(secrets.keys, account: account)
+      @adapter.fetch(secrets.keys)
     end
     assert_equal "Failed to login to or unlock Dashlane", error.message
   end
@@ -32,7 +32,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
     stub_dashlane_password(found: true, secrets: secrets)
     stub_dashlane_secret(found: true, secrets: secrets)
 
-    result = @adapter.fetch(secrets.keys, account: account)
+    result = @adapter.fetch(secrets.keys)
 
     assert_equal secrets.sort, result.sort
   end
@@ -42,7 +42,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
     stub_dashlane_password(found: true, secrets: secrets)
     stub_dashlane_secret(found: true, secrets: secrets)
 
-    result = @adapter.fetch(secrets.keys, account: account)
+    result = @adapter.fetch(secrets.keys)
 
     assert_equal secrets.sort, result.sort
   end
@@ -53,7 +53,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
     stub_dashlane_secret(found: false, secrets: secrets)
 
     error = assert_raises RuntimeError do
-      @adapter.fetch(secrets.keys, account: account)
+      @adapter.fetch(secrets.keys)
     end
     assert_equal "Could not find #{secrets.keys.join(", ")} in Dashlane passwords or secrets", error.message
   end
@@ -64,7 +64,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
     stub_dashlane_password(found: true, secrets: only_passwords)
     stub_dashlane_secret(found: false, secrets: only_passwords)
 
-    result = @adapter.fetch(only_passwords.keys, account: account)
+    result = @adapter.fetch(only_passwords.keys)
 
     assert_equal only_passwords.sort, result.sort
   end
@@ -75,9 +75,28 @@ class DashlaneAdapterTest < SecretAdapterTestCase
     stub_dashlane_password(found: false, secrets: only_secrets)
     stub_dashlane_secret(found: true, secrets: only_secrets)
 
-    result = @adapter.fetch(only_secrets.keys, account: account)
+    result = @adapter.fetch(only_secrets.keys)
 
     assert_equal only_secrets.sort, result.sort
+  end
+
+  test "fetch with --from option" do
+    setup_logged_in
+
+    error = assert_raises ArgumentError do
+      @adapter.fetch(secrets.keys, from: "test")
+    end
+    assert_equal "Dashlane adapter does not support the --from option", error.message
+  end
+
+  test "fetch with failed password command" do
+    stub_ticks_with("dcli password #{secrets.keys.join(" ")} -o json", succeed: false)
+    setup_logged_in
+
+    error = assert_raises RuntimeError do
+      @adapter.fetch(secrets.keys)
+    end
+    assert_equal "Could not read #{secrets.keys} from Dashlane passwords", error.message
   end
 
   private
@@ -90,8 +109,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
         Kamal::Cli::Secrets.start \
           [ *command,
             "-c", "test/fixtures/deploy_with_accessories.yml",
-            "--adapter", "dashlane",
-            "--account", "email@example.com" ]
+            "--adapter", "dashlane" ]
       end
     end
 
@@ -103,20 +121,16 @@ class DashlaneAdapterTest < SecretAdapterTestCase
       if logged_in
         stub_ticks_with("dcli status 2> /dev/null", succeed: true).returns(<<~STATUS)
         Logged in: yes
-        Login: #{account}
+        Login: example@email.com
         Locked: no
         STATUS
       else
-        stub_ticks_with("dcli status 2> /dev/null", succeed: false)
+        stub_ticks_with("dcli status 2> /dev/null", succeed: true).returns("Logged in: no\n")
       end
     end
 
     def stub_login(success)
       @adapter.stubs(:system).with { |c| c == "dcli sync 2> /dev/null" && (success ? `true` : `false`) }
-    end
-
-    def account
-      "email@example.com"
     end
 
     def stub_dashlane_password(found:, secrets:)

--- a/test/secrets/dashlane_adapter_test.rb
+++ b/test/secrets/dashlane_adapter_test.rb
@@ -59,7 +59,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch dashlane passwords and no secrets" do
-    only_passwords = secrets.select { |k| k.match? "PASSWORD" }
+    only_passwords = secrets.select { |k| k.include? "PASSWORD" }
     setup_logged_in
     stub_dashlane_password(found: true, secrets: only_passwords)
     stub_dashlane_secret(found: false, secrets: only_passwords)
@@ -70,7 +70,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
   end
 
   test "fetch dashlane secrets and no passwords" do
-    only_secrets = secrets.select { |k| k.match? "SECRET" }
+    only_secrets = secrets.select { |k| k.include? "SECRET" }
     setup_logged_in
     stub_dashlane_password(found: false, secrets: only_secrets)
     stub_dashlane_secret(found: true, secrets: only_secrets)

--- a/test/secrets/dashlane_adapter_test.rb
+++ b/test/secrets/dashlane_adapter_test.rb
@@ -34,7 +34,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
 
     result = @adapter.fetch(secrets.keys, account: account)
 
-    assert_equal(result.sort, secrets.sort)
+    assert_equal secrets.sort, result.sort
   end
 
   test "fetch when already logged in" do
@@ -44,7 +44,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
 
     result = @adapter.fetch(secrets.keys, account: account)
 
-    assert_equal(result.sort, secrets.sort)
+    assert_equal secrets.sort, result.sort
   end
 
   test "fetch with missing entries" do
@@ -66,7 +66,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
 
     result = @adapter.fetch(only_passwords.keys, account: account)
 
-    assert_equal(result.sort, only_passwords.sort)
+    assert_equal only_passwords.sort, result.sort
   end
 
   test "fetch dashlane secrets and no passwords" do
@@ -77,7 +77,7 @@ class DashlaneAdapterTest < SecretAdapterTestCase
 
     result = @adapter.fetch(only_secrets.keys, account: account)
 
-    assert_equal(result.sort, only_secrets.sort)
+    assert_equal only_secrets.sort, result.sort
   end
 
   private


### PR DESCRIPTION
This PR adds an adapter for the Dashlane CLI, as per #1761, as well as tests for it.

Dashlane supports both _password_ and _secret_ as models for storing credentials, but secrets might be enterprise only (I don't have access to them), hence the implementation with indifferent access to both. This behaviour could be changed if not ideal.

`account`'s only purpose in this adapter is to verify that we are logged in with the right account if already logged in, so it might not be necessary if being logged in to the wrong accoung is out of scope as an edge case.