### PR TITLE
Add forward_agent option to SSH configuration

### DIFF
--- a/lib/kamal/configuration/docs/ssh.yml
+++ b/lib/kamal/configuration/docs/ssh.yml
@@ -71,3 +71,11 @@ ssh:
   # /etc/ssh_config), to false ignore config files, or to a file path
   # (or array of paths) to load specific configuration. Defaults to true.
   config: [ "~/.ssh/myconfig" ]
+
+  # Forward agent
+  #
+  # Whether to forward the local SSH agent to the remote host. Defaults to
+  # true (sshkit's default). Set to false when connecting through a jump
+  # host or tunnel that does not support agent forwarding (for example,
+  # Cloudflare Access for Infrastructure with SSH).
+  forward_agent: false

--- a/lib/kamal/configuration/ssh.rb
+++ b/lib/kamal/configuration/ssh.rb
@@ -53,8 +53,12 @@ class Kamal::Configuration::Ssh
     ssh_config["config"]
   end
 
+  def forward_agent
+    ssh_config["forward_agent"]
+  end
+
   def options
-    { user: user, port: port, proxy: proxy, logger: logger, keepalive: true, keepalive_interval: 30, keys_only: keys_only, keys: keys, key_data: key_data, config: config  }.compact
+    { user: user, port: port, proxy: proxy, logger: logger, keepalive: true, keepalive_interval: 30, keys_only: keys_only, keys: keys, key_data: key_data, config: config, forward_agent: forward_agent }.compact
   end
 
   def to_h

--- a/test/configuration/ssh_test.rb
+++ b/test/configuration/ssh_test.rb
@@ -38,6 +38,14 @@ class ConfigurationSshTest < ActiveSupport::TestCase
 
     config = Kamal::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "config" => [ "~/config.mine.1", "~/config.mine.2" ] }) })
     assert_equal [ "~/config.mine.1", "~/config.mine.2" ], config.ssh.options[:config]
+
+    assert_nil @config.ssh.options[:forward_agent]
+
+    config = Kamal::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "forward_agent" => false }) })
+    assert_equal false, config.ssh.options[:forward_agent]
+
+    config = Kamal::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "forward_agent" => true }) })
+    assert_equal true, config.ssh.options[:forward_agent]
   end
 
   test "ssh options with proxy host" do


### PR DESCRIPTION
## Summary

Expose `forward_agent` under `ssh:` so users can disable SSH agent
forwarding when deploying through a jump host or tunnel that doesn't
support it (for example, Cloudflare Access for Infrastructure with SSH).

SSHKit hardcodes `forward_agent: true` and merges per-host `ssh_options`
on top (`sshkit/lib/sshkit/host.rb`), but Kamal's `ssh:` config didn't
expose a way to override it — and since the validator is driven by
`docs/ssh.yml`, an unknown `forward_agent` key would be rejected even
if a user tried to pass one through.

## Usage

```yaml
ssh:
  user: app
  forward_agent: false
```