### PR TITLE
Fix adapters test helper issue

### DIFF
--- a/test/secrets/passbolt_adapter_test.rb
+++ b/test/secrets/passbolt_adapter_test.rb
@@ -7,7 +7,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
 
   test "fetch" do
     stub_ticks_with("passbolt --version 2> /dev/null", succeed: true)
-    stub_ticks.with("passbolt verify 2> /dev/null", succeed: true)
+    stub_ticks_with("passbolt verify", succeed: true)
 
     stub_ticks
       .with("passbolt list resources --filter 'Name == \"SECRET1\" || Name == \"FSECRET1\" || Name == \"FSECRET2\"'  --json")
@@ -64,7 +64,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
 
   test "fetch with --from" do
     stub_ticks_with("passbolt --version 2> /dev/null", succeed: true)
-    stub_ticks.with("passbolt verify 2> /dev/null", succeed: true)
+    stub_ticks_with("passbolt verify", succeed: true)
 
     stub_ticks
       .with("passbolt list folders --filter 'Name == \"my-project\"' --json")
@@ -135,7 +135,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
 
   test "fetch with folder in secret" do
     stub_ticks_with("passbolt --version 2> /dev/null", succeed: true)
-    stub_ticks.with("passbolt verify 2> /dev/null", succeed: true)
+    stub_ticks_with("passbolt verify", succeed: true)
 
     stub_ticks
       .with("passbolt list folders --filter 'Name == \"my-project\"' --json")
@@ -206,7 +206,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
 
   test "fetch from multiple folders" do
     stub_ticks_with("passbolt --version 2> /dev/null", succeed: true)
-    stub_ticks.with("passbolt verify 2> /dev/null", succeed: true)
+    stub_ticks_with("passbolt verify", succeed: true)
 
     stub_ticks
       .with("passbolt list folders --filter 'Name == \"my-project\" || Name == \"other-project\"' --json")
@@ -284,7 +284,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
 
   test "fetch from nested folder" do
     stub_ticks_with("passbolt --version 2> /dev/null", succeed: true)
-    stub_ticks.with("passbolt verify 2> /dev/null", succeed: true)
+    stub_ticks_with("passbolt verify", succeed: true)
 
     stub_ticks
       .with("passbolt list folders --filter 'Name == \"my-project\"' --json")
@@ -369,7 +369,7 @@ class PassboltAdapterTest < SecretAdapterTestCase
 
   test "fetch from nested folder in secret" do
     stub_ticks_with("passbolt --version 2> /dev/null", succeed: true)
-    stub_ticks.with("passbolt verify 2> /dev/null", succeed: true)
+    stub_ticks_with("passbolt verify", succeed: true)
 
     stub_ticks
       .with("passbolt list folders --filter 'Name == \"my-project\"' --json")

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -134,6 +134,5 @@ class SecretAdapterTestCase < ActiveSupport::TestCase
     def stub_ticks_with(command, succeed: true)
       # Sneakily run `false`/`true` after a match to set $? to 1/0
       stub_ticks.with { |c| c == command && (succeed ? `true` : `false`) }
-      Kamal::Secrets::Adapters::Base.any_instance.stubs(:`)
     end
 end


### PR DESCRIPTION
Fixes #1857.

I removed the line responsible for the unwanted behaviour in `test_helper.rb`.
I then corrected the failing tests in `passbolt_adapter_test.rb`, which failed for two unrelated reasons: 

- the adapter calls `` `passbolt verify` `` while the stubs expected `` `passbolt verify 2> /dev/null` ``, resulting in 
``unexpected invocation: #<AnyInstance:Kamal::Secrets::Adapters::Base>.`("passbolt verify")``
- the tests called `stub_ticks.with` instead of `stub_ticks_with`, so the `succeed` parameter was actually set on the resulting `Expectation` rather than having the intended effect

These tests previously worked when they shouldn't have because a "catch-all" stub was created for the `` ` `` method.