### PR TITLE
Add Fossil SCM support alongside Git

### DIFF
--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -136,7 +136,7 @@ class Kamal::Configuration::Builder
   end
 
   def git_clone?
-    Kamal::Git.used? && builder_config["context"].nil?
+    Kamal::Git.git? && builder_config["context"].nil?
   end
 
   def clone_directory

--- a/lib/kamal/git.rb
+++ b/lib/kamal/git.rb
@@ -2,36 +2,86 @@ module Kamal::Git
   extend self
 
   def used?
-    system("git rev-parse")
+    git? || fossil?
   end
 
   def user_name
-    `git config user.name`.strip
+    if git?
+      `git config user.name`.strip
+    elsif fossil?
+      `fossil user default 2>/dev/null`.strip
+    else
+      ""
+    end
   end
 
   def email
-    `git config user.email`.strip
+    if git?
+      `git config user.email`.strip
+    elsif fossil?
+      `fossil user default 2>/dev/null`.strip
+    else
+      ""
+    end
   end
 
   def revision
-    `git rev-parse HEAD`.strip
+    if git?
+      `git rev-parse HEAD`.strip
+    elsif fossil?
+      `fossil info`.match(/^checkout:\s+(\S+)/)&.captures&.first.to_s
+    else
+      ""
+    end
   end
 
   def uncommitted_changes
-    `git status --porcelain`.strip
+    if git?
+      `git status --porcelain`.strip
+    elsif fossil?
+      `fossil changes`.strip
+    else
+      ""
+    end
   end
 
   def root
-    `git rev-parse --show-toplevel`.strip
+    if git?
+      `git rev-parse --show-toplevel`.strip
+    elsif fossil?
+      `fossil info`.match(/^local-root:\s+(.+)/)&.captures&.first.to_s.chomp("/").strip
+    else
+      Dir.pwd
+    end
   end
 
   # returns an array of relative path names of files with uncommitted changes
   def uncommitted_files
-    `git ls-files --modified`.lines.map(&:strip)
+    if git?
+      `git ls-files --modified`.lines.map(&:strip)
+    elsif fossil?
+      `fossil changes --classify`.lines.map { |l| l.split(/\s+/, 2).last&.strip }.compact
+    else
+      []
+    end
   end
 
   # returns an array of relative path names of untracked files, including gitignored files
   def untracked_files
-    `git ls-files --others`.lines.map(&:strip)
+    if git?
+      `git ls-files --others`.lines.map(&:strip)
+    elsif fossil?
+      `fossil extras`.lines.map(&:strip)
+    else
+      []
+    end
+  end
+
+  def git?
+    @git ||= system("git rev-parse --git-dir > /dev/null 2>&1")
+  end
+
+  def fossil?
+    @fossil ||= File.exist?(".fslckout") || File.exist?("_FOSSIL_")
   end
 end


### PR DESCRIPTION
## Summary

Kamal currently hardcodes Git for version detection, dirty-deploy warnings, deploy lock attribution, and clone builds. This PR makes `Kamal::Git` VCS-agnostic by adding [Fossil SCM](https://fossil-scm.org) fallbacks to every method.

**2 files changed, +59 −9 lines.**

## Motivation

Fossil is a single-binary SCM used by SQLite, Tcl/Tk, and a growing number of projects that prefer its integrated wiki/tickets/forum and self-contained repository model. Kamal is otherwise VCS-agnostic (Docker builds, SSH deploys) — the only coupling is `Kamal::Git`.

## Approach

Minimal change — no new files, no renames, no new abstractions:

- `Kamal::Git.used?` returns true for both git and fossil checkouts
- Each method tries git first, falls back to fossil equivalents
- `git?` and `fossil?` are public so consumers can check VCS type
- `git_clone?` in builder config requires `git?` specifically (clone builds use git commands with no fossil equivalent)
- Fossil detection uses `.fslckout`/`_FOSSIL_` file presence (`fossil info` exits 0 even outside a checkout, so exit code isn't reliable)

## Fossil command equivalents

| Kamal::Git method | Git command | Fossil equivalent |
|---|---|---|
| `revision` | `git rev-parse HEAD` | `fossil info` checkout hash |
| `uncommitted_changes` | `git status --porcelain` | `fossil changes` |
| `user_name` | `git config user.name` | `fossil user default` |
| `email` | `git config user.email` | `fossil user default` (fossil uses usernames, not emails) |
| `root` | `git rev-parse --show-toplevel` | `fossil info` local-root |
| `uncommitted_files` | `git ls-files --modified` | `fossil changes --classify` |
| `untracked_files` | `git ls-files --others` | `fossil extras` |

## What still works without changes

- `VERSION` env var override (already supported)
- All 13 `Kamal::Git` call sites (no API changes)
- Git users see zero behavior change

## Limitations

- Clone builds (`git_clone?`) remain git-only — fossil has no equivalent of `git clone` + `git reset --hard` for remote builds
- Fossil stores usernames, not emails — `email` returns the fossil username as a fallback
- This is a draft for discussion — happy to adjust the approach based on feedback