### PR TITLE
Handle UTF-8 git user names in deploy locks

### DIFF
--- a/lib/kamal/git.rb
+++ b/lib/kamal/git.rb
@@ -6,7 +6,7 @@ module Kamal::Git
   end
 
   def user_name
-    `git config user.name`.strip
+    `git config user.name`.force_encoding(Encoding::UTF_8).strip
   end
 
   def email

--- a/test/commands/lock_test.rb
+++ b/test/commands/lock_test.rb
@@ -20,6 +20,16 @@ class CommandsLockTest < ActiveSupport::TestCase
       new_command.acquire("Hello", "123").join(" ")
   end
 
+  test "acquire encodes non-ASCII lock details for shell" do
+    Kamal::Git.stubs(:user_name).returns("Сергей Федоров")
+
+    command = new_command.acquire("Hello", "123").join(" ")
+    encoded_details = command.match(/echo "(.*)" > \.kamal\/lock-app-production\/details/m)[1]
+
+    assert_predicate command, :ascii_only?
+    assert_includes Base64.decode64(encoded_details).force_encoding(Encoding::UTF_8), "Locked by: Сергей Федоров"
+  end
+
   test "release" do
     assert_match \
       "rm .kamal/lock-app-production/details && rm -r .kamal/lock-app-production",

--- a/test/git_test.rb
+++ b/test/git_test.rb
@@ -1,6 +1,18 @@
 require "test_helper"
 
 class GitTest < ActiveSupport::TestCase
+  test "user name reads UTF-8 bytes under US-ASCII external encoding" do
+    user_name = +"Сергей Федоров\n"
+    user_name.force_encoding(Encoding::US_ASCII)
+
+    Kamal::Git.expects(:`).with("git config user.name").returns(user_name)
+
+    result = Kamal::Git.user_name
+
+    assert_equal "Сергей Федоров", result
+    assert_predicate result, :valid_encoding?
+  end
+
   test "uncommitted changes exist" do
     Kamal::Git.expects(:`).with("git status --porcelain").returns("M   file\n")
     assert_equal "M   file", Kamal::Git.uncommitted_changes


### PR DESCRIPTION
Fix deploy lock creation when git config user.name contains UTF-8 bytes but Ruby marks command output as US-ASCII.

The lock details are base64-encoded before being passed to SSHKit, but Kamal previously stripped the git config output before normalizing its encoding, which raised Encoding::CompatibilityError for names like Cyrillic Sergey Fedorov under US-ASCII locales.

Tests cover the git user.name encoding path and ensure deploy lock shell commands remain ASCII-only while preserving non-ASCII lock details after decoding.

Tested:
- bin/test test/git_test.rb test/commands/lock_test.rb
- LC_ALL=C LANG=C bin/test test/git_test.rb test/commands/lock_test.rb