### PR TITLE
Let proxy logs '--lines' and '--follow' options work together

### DIFF
--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -215,18 +215,19 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
   def logs
     grep = options[:grep]
     timestamps = !options[:skip_timestamps]
+    since = options[:since]
 
     if options[:follow]
+      lines = options[:lines].presence || ((since || grep) ? nil : 10) # Default to 10 lines if since or grep isn't set
       run_locally do
         proxy = KAMAL.proxy(KAMAL.primary_host)
         info "Following logs on #{KAMAL.primary_host}..."
-        info proxy.follow_logs(host: KAMAL.primary_host, timestamps: timestamps, grep: grep)
-        exec proxy.follow_logs(host: KAMAL.primary_host, timestamps: timestamps, grep: grep)
+        follow_logs = proxy.follow_logs(host: KAMAL.primary_host, timestamps: timestamps, since: since, lines: lines, grep: grep)
+        info follow_logs
+        exec follow_logs
       end
     else
-      since = options[:since]
       lines = options[:lines].presence || ((since || grep) ? nil : 100) # Default to 100 lines if since or grep isn't set
-
       on(KAMAL.proxy_hosts) do |host|
         puts_by_host host, capture(*KAMAL.proxy(host).logs(timestamps: timestamps, since: since, lines: lines, grep: grep)), type: "Proxy"
       end

--- a/lib/kamal/commands/proxy.rb
+++ b/lib/kamal/commands/proxy.rb
@@ -48,13 +48,13 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
 
   def logs(timestamps: true, since: nil, lines: nil, grep: nil, grep_options: nil)
     pipe \
-      docker(:logs, container_name, ("--since #{since}" if since), ("--tail #{lines}" if lines), ("--timestamps" if timestamps), "2>&1"),
+      docker_logs(timestamps: timestamps, since: since, lines: lines),
       ("grep '#{grep}'#{" #{grep_options}" if grep_options}" if grep)
   end
 
-  def follow_logs(host:, timestamps: true, grep: nil, grep_options: nil)
+  def follow_logs(host:, timestamps: true, since: nil, lines: nil, grep: nil, grep_options: nil)
     run_over_ssh pipe(
-      docker(:logs, container_name, ("--timestamps" if timestamps), "--tail", "10", "--follow", "2>&1"),
+      docker_logs(timestamps: timestamps, since: since, lines: lines, follow: true),
       (%(grep "#{grep}"#{" #{grep_options}" if grep_options}) if grep)
     ).join(" "), host: host
   end
@@ -142,5 +142,14 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
         "--restart", "unless-stopped",
         "--volume", "kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy",
         *config.proxy_boot.apps_volume.docker_args
+    end
+
+    def docker_logs(timestamps:, since:, lines:, follow: false)
+      docker :logs, container_name,
+        ("--since #{since}" if since),
+        ("--tail #{lines}" if lines),
+        ("--timestamps" if timestamps),
+        ("--follow" if follow),
+        "2>&1"
     end
 end

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -120,9 +120,9 @@ class CliProxyTest < CliTestCase
 
   test "logs with follow" do
     SSHKit::Backend::Abstract.any_instance.stubs(:exec)
-      .with("ssh -t root@1.1.1.1 -p 22 'docker logs kamal-proxy --timestamps --tail 10 --follow 2>&1'")
+      .with("ssh -t root@1.1.1.1 -p 22 'docker logs kamal-proxy --tail 10 --timestamps --follow 2>&1'")
 
-    assert_match "docker logs kamal-proxy --timestamps --tail 10 --follow", run_command("logs", "--follow")
+    assert_match "docker logs kamal-proxy --tail 10 --timestamps --follow", run_command("logs", "--follow")
   end
 
   test "remove" do

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -89,13 +89,31 @@ class CommandsProxyTest < ActiveSupport::TestCase
 
   test "proxy follow logs" do
     assert_equal \
-      "ssh -t root@1.1.1.1 -p 22 'docker logs kamal-proxy --timestamps --tail 10 --follow 2>&1'",
+      "ssh -t root@1.1.1.1 -p 22 'docker logs kamal-proxy --timestamps --follow 2>&1'",
       new_command.follow_logs(host: @config[:servers].first)
+  end
+
+  test "proxy follow logs since 2h" do
+    assert_equal \
+      "ssh -t root@1.1.1.1 -p 22 'docker logs kamal-proxy --since 2h --timestamps --follow 2>&1'",
+      new_command.follow_logs(host: @config[:servers].first, since: "2h")
+  end
+
+  test "proxy follow logs last n lines" do
+    assert_equal \
+      "ssh -t root@1.1.1.1 -p 22 'docker logs kamal-proxy --tail 15 --timestamps --follow 2>&1'",
+      new_command.follow_logs(host: @config[:servers].first, lines: 15)
+  end 
+
+  test "proxy follow logs without timestamps" do
+    assert_equal \
+      "ssh -t root@1.1.1.1 -p 22 'docker logs kamal-proxy --follow 2>&1'",
+      new_command.follow_logs(host: @config[:servers].first, timestamps: false)
   end
 
   test "proxy follow logs with grep hello!" do
     assert_equal \
-      "ssh -t root@1.1.1.1 -p 22 'docker logs kamal-proxy --timestamps --tail 10 --follow 2>&1 | grep \"hello!\"'",
+      "ssh -t root@1.1.1.1 -p 22 'docker logs kamal-proxy --timestamps --follow 2>&1 | grep \"hello!\"'",
       new_command.follow_logs(host: @config[:servers].first, grep: "hello!")
   end
 

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -103,7 +103,7 @@ class CommandsProxyTest < ActiveSupport::TestCase
     assert_equal \
       "ssh -t root@1.1.1.1 -p 22 'docker logs kamal-proxy --tail 15 --timestamps --follow 2>&1'",
       new_command.follow_logs(host: @config[:servers].first, lines: 15)
-  end 
+  end
 
   test "proxy follow logs without timestamps" do
     assert_equal \


### PR DESCRIPTION
## Description

Currently, when you run `kamal proxy logs --follow --lines 100`, the `lines` option is ignored and a default `10` lines is printed. It's not uncommon to want to print the last n lines and tail the logs in 1 command. Also, `kamal app logs` doesn't ignore the `--lines` option when `--follow` is passed, I see no reason why the proxy logs should be different.
This PR allows `--follow` and `--lines` to work together for proxy logs, just like app logs.