### PR TITLE
Revert PR #1503 and improve handling of restart option

### DIFF
--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -4,7 +4,7 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
   attr_reader :accessory_config
   delegate :service_name, :image, :hosts, :port, :files, :directories, :cmd,
            :network_args, :publish_args, :env_args, :volume_args, :label_args, :option_args,
-           :secrets_io, :secrets_path, :env_directory, :proxy, :running_proxy?, :registry,
+           :restart_policy, :secrets_io, :secrets_path, :env_directory, :proxy, :running_proxy?, :registry,
            to: :accessory_config
 
   def initialize(config, name:)
@@ -16,7 +16,7 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
     docker :run,
       "--name", service_name,
       "--detach",
-      "--restart", "unless-stopped",
+      "--restart", restart_policy,
       *network_args,
       *config.logging_args,
       *publish_args,

--- a/lib/kamal/commands/app.rb
+++ b/lib/kamal/commands/app.rb
@@ -16,7 +16,7 @@ class Kamal::Commands::App < Kamal::Commands::Base
   def run(hostname: nil)
     docker :run,
       "--detach",
-      "--restart unless-stopped",
+      "--restart", role.restart_policy,
       "--name", container_name,
       "--network", "kamal",
       *([ "--hostname", hostname ] if hostname),

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -102,11 +102,11 @@ class Kamal::Configuration::Accessory
   end
 
   def option_args
-    if args = accessory_config["options"]
-      optionize args
-    else
-      []
-    end
+    optionize docker_options.reject { |key, _| key.to_s == "restart" }
+  end
+
+  def restart_policy
+    restart_policy_option || "unless-stopped"
   end
 
   def cmd
@@ -171,6 +171,14 @@ class Kamal::Configuration::Accessory
 
     def specific_volumes
       accessory_config["volumes"] || []
+    end
+
+    def docker_options
+      accessory_config["options"] || {}
+    end
+
+    def restart_policy_option
+      docker_options.find { |key, _| key.to_s == "restart" }&.last
     end
 
     def path_volumes(paths)

--- a/lib/kamal/configuration/role.rb
+++ b/lib/kamal/configuration/role.rb
@@ -44,11 +44,11 @@ class Kamal::Configuration::Role
   end
 
   def option_args
-    if args = specializations["options"]
-      optionize args
-    else
-      []
-    end
+    optionize docker_options.reject { |key, _| key.to_s == "restart" }
+  end
+
+  def restart_policy
+    restart_policy_option || "unless-stopped"
   end
 
   def labels
@@ -215,6 +215,14 @@ class Kamal::Configuration::Role
 
     def role_config
       @role_config ||= config.raw_config.servers.is_a?(Array) ? {} : config.raw_config.servers[name]
+    end
+
+    def docker_options
+      specializations["options"] || {}
+    end
+
+    def restart_policy_option
+      docker_options.find { |key, _| key.to_s == "restart" }&.last
     end
 
     def custom_labels

--- a/lib/kamal/configuration/validator.rb
+++ b/lib/kamal/configuration/validator.rb
@@ -232,8 +232,20 @@ class Kamal::Configuration::Validator
     end
 
     def validate_docker_options!(options)
-      if options
-        error "Cannot set restart policy in docker options, unless-stopped is required" if options["restart"]
+      if restart_policy = options&.find { |key, _| key.to_s == "restart" }
+        validate_restart_policy!(restart_policy.last)
+      end
+    end
+
+    def validate_restart_policy!(restart_policy)
+      with_context("options/restart") do
+        unless restart_policy.is_a?(String)
+          error %(should be a string. Use "no" to disable restarts)
+        end
+
+        unless restart_policy.match?(/\A(?:no|always|unless-stopped|on-failure(?::\d+)?)\z/)
+          error "should be no, always, unless-stopped, on-failure, or on-failure:N"
+        end
       end
     end
 end

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -81,6 +81,14 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
       new_command(:busybox).run.join(" ")
   end
 
+  test "run with custom restart policy" do
+    @config[:accessories]["mysql"]["options"]["restart"] = "on-failure"
+
+    assert_equal \
+      "docker run --name app-mysql --detach --restart on-failure --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
+      new_command(:mysql).run.join(" ")
+  end
+
   test "run in custom network" do
     @config[:accessories]["mysql"]["network"] = "custom"
 
@@ -111,6 +119,17 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
     assert_equal \
       "docker run --rm --network kamal --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0 mysql -u root",
       new_command(:mysql).execute_in_new_container("mysql", "-u", "root").join(" ")
+  end
+
+  test "execute in new container excludes restart policy" do
+    @config[:accessories]["mysql"]["options"]["restart"] = "on-failure"
+
+    command = new_command(:mysql).execute_in_new_container("mysql", "-u", "root").join(" ")
+
+    assert_equal \
+      "docker run --rm --network kamal --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0 mysql -u root",
+      command
+    assert_no_match(/--restart/, command)
   end
 
   test "execute in existing container" do

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -45,6 +45,14 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command(role: "jobs", host: "1.1.1.2").run.join(" ")
   end
 
+  test "run with custom restart policy" do
+    @config[:servers] = { "web" => { "hosts" => [ "1.1.1.1" ], "options" => { "restart" => "on-failure" } } }
+
+    assert_equal \
+      "docker run --detach --restart on-failure --name app-web-999 --network kamal --env KAMAL_CONTAINER_NAME=\"app-web-999\" --env KAMAL_VERSION=\"999\" --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/roles/web.env --log-opt max-size=\"10m\" --label service=\"app\" --label role=\"web\" --label destination dhh/app:999",
+      new_command.run.join(" ")
+  end
+
   test "run with logging config" do
     @config[:logging] = { "driver" => "local", "options" => { "max-size" => "100m", "max-file" => "3" } }
 
@@ -297,6 +305,15 @@ class CommandsAppTest < ActiveSupport::TestCase
     assert_match \
       %r{docker run --rm --name app-web-exec-999-[0-9a-f]{6} --network kamal --env-file .kamal/apps/app/env/roles/web.env --log-opt max-size="10m" --mount "somewhere" --cap-add dhh/app:999 bin/rails db:setup},
       new_command.execute_in_new_container("bin/rails", "db:setup", env: {}).join(" ")
+  end
+
+  test "execute in new container excludes restart policy" do
+    @config[:servers] = { "web" => { "hosts" => [ "1.1.1.1" ], "options" => { "restart" => "on-failure", "mount" => "somewhere" } } }
+
+    command = new_command.execute_in_new_container("bin/rails", "db:setup", env: {}).join(" ")
+
+    assert_match %r{docker run --rm --name app-web-exec-999-[0-9a-f]{6} --network kamal --env-file .kamal/apps/app/env/roles/web.env --log-opt max-size="10m" --mount "somewhere" dhh/app:999 bin/rails db:setup}, command
+    assert_no_match(/--restart/, command)
   end
 
   test "execute in existing container" do

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -307,6 +307,18 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "--cpus", "\"4\"", "--memory", "\"2GB\"" ], @config.accessory(:redis).option_args
   end
 
+  test "restart policy" do
+    @deploy[:accessories]["redis"]["options"]["restart"] = "always"
+    config = Kamal::Configuration.new(@deploy)
+
+    assert_equal "always", config.accessory(:redis).restart_policy
+    assert_equal [ "--cpus", "\"4\"", "--memory", "\"2GB\"" ], config.accessory(:redis).option_args
+  end
+
+  test "default restart policy" do
+    assert_equal "unless-stopped", @config.accessory(:redis).restart_policy
+  end
+
   test "network_args default" do
     assert_equal [ "--network", "kamal" ], @config.accessory(:mysql).network_args
   end
@@ -321,11 +333,13 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "monitoring.example.com" ], @config.accessory(:monitoring).proxy.hosts
   end
 
-  test "can't set restart in options" do
-    @deploy[:accessories]["mysql"]["options"] = { "restart" => "always" }
+  test "invalid boolean restart policy" do
+    @deploy[:accessories]["mysql"]["options"] = { "restart" => false }
 
-    assert_raises Kamal::ConfigurationError, "servers/workers: Cannot set restart policy in docker options, unless-stopped is required" do
+    error = assert_raises Kamal::ConfigurationError do
       Kamal::Configuration.new(@deploy)
     end
+
+    assert_equal %(accessories/mysql/options/restart: should be a string. Use "no" to disable restarts), error.message
   end
 end

--- a/test/configuration/role_test.rb
+++ b/test/configuration/role_test.rb
@@ -278,6 +278,17 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
     assert_equal [ "-t", 30 ], config_with_roles.role(:workers).stop_args
   end
 
+  test "restart policy" do
+    @deploy_with_roles[:servers]["workers"]["options"] = { "restart" => "on-failure:3", "memory" => "2g" }
+
+    assert_equal "on-failure:3", config_with_roles.role(:workers).restart_policy
+    assert_equal [ "--memory", "\"2g\"" ], config_with_roles.role(:workers).option_args
+  end
+
+  test "default restart policy" do
+    assert_equal "unless-stopped", config_with_roles.role(:workers).restart_policy
+  end
+
   test "role specific proxy config" do
     @deploy_with_roles[:proxy] = { "response_timeout" => 15 }
     @deploy_with_roles[:servers]["workers"]["proxy"] = { "response_timeout" => 18 }
@@ -286,12 +297,14 @@ class ConfigurationRoleTest < ActiveSupport::TestCase
     assert_equal "18s", config_with_roles.role(:workers).proxy.deploy_options[:"target-timeout"]
   end
 
-  test "can't set restart in options" do
-    @deploy_with_roles[:servers]["workers"]["options"] = { "restart" => "always" }
+  test "invalid boolean restart policy" do
+    @deploy_with_roles[:servers]["workers"]["options"] = { "restart" => false }
 
-    assert_raises Kamal::ConfigurationError, "servers/workers: Cannot set restart policy in docker options, unless-stopped is required" do
+    error = assert_raises Kamal::ConfigurationError do
       Kamal::Configuration.new(@deploy_with_roles)
     end
+
+    assert_equal %(servers/workers/options/restart: should be a string. Use "no" to disable restarts), error.message
   end
 
   private


### PR DESCRIPTION
Addressing https://github.com/basecamp/kamal/issues/1863

This is useful primarily for init containers.

<img width="1419" height="94" alt="Screenshot 2026-05-27 at 21 47 00" src="https://github.com/user-attachments/assets/afacf06d-7dee-444d-bb2b-422ea1d124af" />
Tested in production and working beautifully now for my init containers by setting their restart policy to `on-failure`.

There's of course a world where an even deeper support for init containers is considered, where they actually are treated as a prerequisite for a successful deployment, but this is a great start and a big improvement (unblocks me to be able to use `kamal`!)