### PR TITLE
Run `git gc --auto` in clone-reset path to bound pack accumulation

### DIFF
--- a/lib/kamal/commands/builder/clone.rb
+++ b/lib/kamal/commands/builder/clone.rb
@@ -9,7 +9,8 @@ module Kamal::Commands::Builder::Clone
       git(:fetch, :origin, path: escaped_build_directory),
       git(:reset, "--hard", Kamal::Git.revision, path: escaped_build_directory),
       git(:clean, "-fdx", path: escaped_build_directory),
-      git(:submodule, :update, "--init", path: escaped_build_directory)
+      git(:submodule, :update, "--init", path: escaped_build_directory),
+      git(:gc, "--auto", "--quiet", path: escaped_build_directory)
     ]
   end
 

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -241,6 +241,14 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     end
   end
 
+  test "clone reset runs git gc --auto to bound pack growth" do
+    command = new_builder_command
+    clone_reset_commands = command.clone_reset_steps.map { |a| a.join(" ") }
+
+    assert clone_reset_commands.any? { |c| c.end_with?(" gc --auto --quiet") },
+      "expected clone_reset_steps to run git gc --auto, got: #{clone_reset_commands.inspect}"
+  end
+
   test "local builder with local registry includes network host driver option" do
     builder = new_builder_command(registry: { "server" => "localhost:5000" })
     assert_equal "local", builder.name


### PR DESCRIPTION
Hi 👋 — first off, thanks for Kamal; it's been a delight to deploy with across several projects.

## The issue

The `kamal-clones` cache (great for fast reused build context) reuses its on-disk git clone across deploys via `fetch + reset --hard + clean -fdx` in `lib/kamal/commands/builder/clone.rb#clone_reset_steps`. This works beautifully for speed: subsequent deploys from the same `service + pwd_sha` slot skip the full re-clone.

But the cached clone never runs `git gc`. So `.git/objects/pack/` accumulates pack files indefinitely as `git fetch` adds new objects on every deploy. On long-lived caches this grows hundreds of MB without bound. On my Mac Mini dev machine I recently hit a 100%-full SSD partly because of this — one `kamal-clones` slot for a Rails app had ballooned past 500 MB across months of deploys.

It's a smaller cousin to #1794 (remote BuildKit volume growing unbounded on the server side) — same hygiene-gap class, but on the client side.

## The fix (one line)

Add `git :gc, "--auto", "--quiet"` to the `clone_reset_steps` array. This lets git decide when to repack based on its own `gc.auto` (default 6700 loose objects) and `gc.autoPackLimit` (default 50 pack files) heuristics:

- **Common case**: no behavior change. `--auto` is a no-op when thresholds aren't crossed, so most deploys feel identical.
- **Threshold crossed**: git automatically repacks; the cache stays bounded by the repo's natural `.git` size rather than growing forever.
- `--quiet` suppresses normal output.

```diff
   def clone_reset_steps
     [
       git(:remote, "set-url", :origin, escaped_root, path: escaped_build_directory),
       git(:fetch, :origin, path: escaped_build_directory),
       git(:reset, "--hard", Kamal::Git.revision, path: escaped_build_directory),
       git(:clean, "-fdx", path: escaped_build_directory),
-      git(:submodule, :update, "--init", path: escaped_build_directory)
+      git(:submodule, :update, "--init", path: escaped_build_directory),
+      git(:gc, "--auto", "--quiet", path: escaped_build_directory)
     ]
   end
```

## Tests

Existing builder tests pass on both `main` and this branch (the two failing tests are pre-existing failures unrelated to this change: `test_hybrid_builder_with_local_registry` and `test_hybrid_build_if_remote_is_set_and_building_multiarch`). The `clone_reset_steps` iteration-based tests now cover the additional step naturally.

## Related broader hygiene

There are two adjacent operator-pain points in the cache lifecycle that this PR doesn't tackle — eviction policy for unused slots (LRU or N-day TTL), and an optional max-total-cache-size cap. Those are bigger architectural asks; happy to draft a separate discussion issue if there's interest. This PR is the smallest impactful step.

Thanks again for your work on Kamal! 🙏