### PR TITLE
Fixes for integration tests on Linux 7/Docker 29

### DIFF
--- a/test/integration/app_test.rb
+++ b/test/integration/app_test.rb
@@ -29,8 +29,8 @@ class AppTest < IntegrationTest
     images = kamal :app, :images, capture: true
     assert_match "App Host: vm1", images
     assert_match "App Host: vm2", images
-    assert_match /localhost:5000\/app\s+#{latest_app_version}/, images
-    assert_match /localhost:5000\/app\s+latest/, images
+    assert_match /localhost:5000\/app[:\s]+#{latest_app_version}/, images
+    assert_match /localhost:5000\/app[:\s]+latest/, images
 
     containers = kamal :app, :containers, capture: true
     assert_match "App Host: vm1", containers

--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -32,6 +32,6 @@ RUN rm -rf /root/.ssh && \
     cd /app_with_parallel_roles && git init && git add . && git commit -am "Initial version" && \
     cd /app_with_destinations && git init && git add . && git commit -am "Initial version"
 
-HEALTHCHECK --interval=1s CMD pgrep sleep
+HEALTHCHECK --interval=1s CMD docker info > /dev/null 2>&1 && pgrep sleep
 
 CMD ["./boot.sh"]

--- a/test/integration/docker/deployer/app_with_traefik/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_traefik/config/deploy.yml
@@ -28,7 +28,7 @@ proxy:
 accessories:
   traefik:
     service: traefik
-    image: traefik:v2.10
+    image: traefik:v3.6
     port: 80
     cmd: "--providers.docker"
     options:

--- a/test/integration/docker/deployer/boot.sh
+++ b/test/integration/docker/deployer/boot.sh
@@ -1,16 +1,22 @@
 #!/bin/bash
 
-# Use VFS storage driver locally to avoid overlayfs-on-overlayfs issues
-# Skip on GitHub Actions where the outer Docker is configured differently
-if [ -z "$GITHUB_ACTIONS" ]; then
-  mkdir -p /etc/docker
-  echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
-fi
+# Use the VFS storage driver: this dockerd runs inside a container whose root is
+# itself an overlay mount, and overlay-on-overlay fails on modern Docker/kernels.
+# VFS nests safely.
+mkdir -p /etc/docker
+echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
 
-# On hosts using nftables, Docker can't create netfilter rules from inside a container.
-# iptables-legacy uses an older kernel interface that doesn't have this limitation.
-update-alternatives --set iptables /usr/sbin/iptables-legacy 2>/dev/null || true
-update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true
+# Docker needs an iptables backend that can initialize the nat table against the
+# host kernel. Legacy works on hosts with the legacy ip_tables modules loaded;
+# nft works on nftables-only hosts (where the legacy nat table is unavailable).
+# Probe for the first backend that can read the nat table and use it.
+for backend in legacy nft; do
+  if iptables-$backend -t nat -L >/dev/null 2>&1; then
+    update-alternatives --set iptables /usr/sbin/iptables-$backend 2>/dev/null || true
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-$backend 2>/dev/null || true
+    break
+  fi
+done
 
 dockerd --max-concurrent-downloads 1 &
 

--- a/test/integration/docker/vm/Dockerfile
+++ b/test/integration/docker/vm/Dockerfile
@@ -12,6 +12,6 @@ RUN mkdir /root/.ssh && \
     ln -s /shared/certs/domain.crt /etc/docker/certs.d/registry:4443/ca.crt && \
     echo "HOST_TOKEN=abcd" >> /etc/environment
 
-HEALTHCHECK --interval=1s CMD pgrep dockerd
+HEALTHCHECK --interval=1s CMD docker info > /dev/null 2>&1
 
 CMD ["./boot.sh"]

--- a/test/integration/docker/vm/boot.sh
+++ b/test/integration/docker/vm/boot.sh
@@ -4,10 +4,23 @@ while [ ! -f /root/.ssh/authorized_keys ]; do echo "Waiting for ssh keys"; sleep
 
 service ssh restart
 
-# On hosts using nftables, Docker can't create netfilter rules from inside a container.
-# iptables-legacy uses an older kernel interface that doesn't have this limitation.
-update-alternatives --set iptables /usr/sbin/iptables-legacy 2>/dev/null || true
-update-alternatives --set ip6tables /usr/sbin/ip6tables-legacy 2>/dev/null || true
+# Use the VFS storage driver: this dockerd runs inside a container whose root is
+# itself an overlay mount, and overlay-on-overlay fails on modern Docker/kernels.
+# VFS nests safely.
+mkdir -p /etc/docker
+echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
+
+# Docker needs an iptables backend that can initialize the nat table against the
+# host kernel. Legacy works on hosts with the legacy ip_tables modules loaded;
+# nft works on nftables-only hosts (where the legacy nat table is unavailable).
+# Probe for the first backend that can read the nat table and use it.
+for backend in legacy nft; do
+  if iptables-$backend -t nat -L >/dev/null 2>&1; then
+    update-alternatives --set iptables /usr/sbin/iptables-$backend 2>/dev/null || true
+    update-alternatives --set ip6tables /usr/sbin/ip6tables-$backend 2>/dev/null || true
+    break
+  fi
+done
 
 dockerd --max-concurrent-downloads 1 &
 


### PR DESCRIPTION
- Update image match for new format
- Use latest version of Traefik for Docker 29 support
- Support legacy or nft iptable backend