### PR TITLE
Worktree safe integration tests

### DIFF
--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -54,7 +54,7 @@ class CliTestCase < ActiveSupport::TestCase
     end
 
     def with_build_directory
-      build_directory = File.join Dir.tmpdir, "kamal-clones", "app-#{pwd_sha}", "kamal"
+      build_directory = File.join Dir.tmpdir, "kamal-clones", "app-#{pwd_sha}", File.basename(Kamal::Git.root)
       FileUtils.mkdir_p build_directory
       FileUtils.touch File.join build_directory, "Dockerfile"
       yield build_directory + "/"

--- a/test/integration/accessory_test.rb
+++ b/test/integration/accessory_test.rb
@@ -55,11 +55,11 @@ class AccessoryTest < IntegrationTest
 
   private
     def assert_accessory_running(name)
-      assert_match /registry:4443\/busybox:1.36.0   "sh -c 'echo \\"Start/, accessory_details(name)
+      assert_match /busybox:1.36.0   "sh -c 'echo \\"Start/, accessory_details(name)
     end
 
     def assert_accessory_not_running(name)
-      assert_no_match /registry:4443\/busybox:1.36.0   "sh -c 'echo \\"Start/, accessory_details(name)
+      assert_no_match /busybox:1.36.0   "sh -c 'echo \\"Start/, accessory_details(name)
     end
 
     def assert_accessory_volume_mount_options(name)

--- a/test/integration/accessory_test.rb
+++ b/test/integration/accessory_test.rb
@@ -94,7 +94,7 @@ class AccessoryTest < IntegrationTest
     end
 
     def netcat_response
-      uri = URI.parse("http://127.0.0.1:12345/up")
+      uri = URI.parse("http://127.0.0.1:#{@http_port}/up")
       http = Net::HTTP.new(uri.host, uri.port)
       request = Net::HTTP::Get.new(uri)
       request["Host"] = "netcat"

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -5,6 +5,7 @@ volumes:
   registry:
   deployer_bundle:
   otel:
+  hub-cache:
 
 services:
   shared:
@@ -22,7 +23,6 @@ services:
     volumes:
       - ../..:/kamal
       - shared:/shared
-      - registry:/registry
       - deployer_bundle:/usr/local/bundle/
       - otel:/tmp/otel
 
@@ -36,6 +36,27 @@ services:
     volumes:
       - shared:/shared
       - registry:/var/lib/registry/
+
+  # Docker Hub pull-through cache. The deployer and vm inner daemons point their
+  # registry-mirrors here (see their boot.sh), so base images (registry:3, nginx,
+  # busybox, traefik, basecamp/kamal-proxy) are fetched from Docker Hub at most
+  # once per run instead of on every test, dodging Hub rate limits.
+  #
+  # The cache fetches from Docker Hub on its own (anonymous by default — separate
+  # from any `docker login` on the host, since Hub's anonymous limit is per-IP).
+  # Export DOCKERHUB_USERNAME and DOCKERHUB_TOKEN (a Hub access token) to have the
+  # cache authenticate its upstream pulls against your account's higher quota.
+  hub-cache:
+    image: registry:3
+    environment:
+      - REGISTRY_PROXY_REMOTEURL=https://registry-1.docker.io
+      - REGISTRY_PROXY_USERNAME=${DOCKERHUB_USERNAME:-}
+      - REGISTRY_PROXY_PASSWORD=${DOCKERHUB_TOKEN:-}
+    volumes:
+      - hub-cache:/var/lib/registry
+    healthcheck:
+      test: [ "CMD", "pgrep", "registry" ]
+      interval: 1s
 
   vm1:
     privileged: true

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -44,7 +44,7 @@ services:
     volumes:
       - shared:/shared
     ports:
-      - "22443:443"
+      - "443"
 
   vm2:
     privileged: true
@@ -70,8 +70,8 @@ services:
     build:
       context: docker/load_balancer
     ports:
-      - "12345:80"
-      - "12443:443"
+      - "80"
+      - "443"
     depends_on:
       - vm1
       - vm2

--- a/test/integration/docker/deployer/app/Dockerfile
+++ b/test/integration/docker/deployer/app/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry:4443/nginx:1-alpine-slim
+FROM nginx:1-alpine-slim
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 

--- a/test/integration/docker/deployer/app/config/deploy.yml
+++ b/test/integration/docker/deployer/app/config/deploy.yml
@@ -34,8 +34,6 @@ output:
     endpoint: http://otel_collector:4318
 proxy:
   host: 127.0.0.1
-  run:
-    registry: registry:4443
 registry:
   server: localhost:5000
 builder:
@@ -46,7 +44,7 @@ builder:
 accessories:
   busybox:
     service: custom-busybox
-    image: registry:4443/busybox:1.36.0
+    image: busybox:1.36.0
     cmd: sh -c 'echo "Starting busybox..."; trap exit term; while true; do sleep 1; done'
     roles:
       - web
@@ -63,6 +61,6 @@ accessories:
         options: "ro"
   busybox2:
     service: custom-busybox
-    image: registry:4443/busybox:1.36.0
+    image: busybox:1.36.0
     cmd: sh -c 'echo "Starting busybox..."; trap exit term; while true; do sleep 1; done'
     host: vm3

--- a/test/integration/docker/deployer/app_with_custom_certificate/Dockerfile
+++ b/test/integration/docker/deployer/app_with_custom_certificate/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry:4443/nginx:1-alpine-slim
+FROM nginx:1-alpine-slim
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 

--- a/test/integration/docker/deployer/app_with_destinations/Dockerfile
+++ b/test/integration/docker/deployer/app_with_destinations/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry:4443/nginx:1-alpine-slim
+FROM nginx:1-alpine-slim
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 

--- a/test/integration/docker/deployer/app_with_destinations/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_destinations/config/deploy.yml
@@ -5,8 +5,6 @@ deploy_timeout: 2
 drain_timeout: 2
 readiness_delay: 0
 proxy:
-  run:
-    registry: registry:4443
   host: localhost
   ssl: false
   healthcheck:

--- a/test/integration/docker/deployer/app_with_parallel_roles/Dockerfile
+++ b/test/integration/docker/deployer/app_with_parallel_roles/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry:4443/nginx:1-alpine-slim
+FROM nginx:1-alpine-slim
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 

--- a/test/integration/docker/deployer/app_with_parallel_roles/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_parallel_roles/config/deploy.yml
@@ -22,8 +22,6 @@ proxy:
     timeout: 1
     path: "/up"
   response_timeout: 2
-  run:
-    registry: registry:4443
 registry:
   server: registry:4443
   username: root

--- a/test/integration/docker/deployer/app_with_proxied_accessory/Dockerfile
+++ b/test/integration/docker/deployer/app_with_proxied_accessory/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry:4443/nginx:1-alpine-slim
+FROM nginx:1-alpine-slim
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 

--- a/test/integration/docker/deployer/app_with_proxied_accessory/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_proxied_accessory/config/deploy.yml
@@ -20,19 +20,17 @@ builder:
 accessories:
   busybox:
     service: custom-busybox
-    image: registry:4443/busybox:1.36.0
+    image: busybox:1.36.0
     cmd: sh -c 'echo "Starting busybox..."; trap exit term; while true; do sleep 1; done'
     host: vm1
   netcat:
     service: netcat
-    image: registry:4443/busybox:1.36.0
+    image: busybox:1.36.0
     cmd: >
       sh -c 'echo "Starting netcat..."; while true; do echo -e "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nHello Ruby" | nc -l -p 80; done'
     host: vm1
     port: 12345:80
     proxy:
-      run:
-        registry: registry:4443
       host: netcat
       ssl: false
       healthcheck:

--- a/test/integration/docker/deployer/app_with_roles/Dockerfile
+++ b/test/integration/docker/deployer/app_with_roles/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry:4443/nginx:1-alpine-slim
+FROM nginx:1-alpine-slim
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 

--- a/test/integration/docker/deployer/app_with_roles/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_roles/config/deploy.yml
@@ -53,7 +53,7 @@ builder:
 accessories:
   busybox:
     service: custom-busybox
-    image: registry:4443/busybox:1.36.0
+    image: busybox:1.36.0
     cmd: sh -c 'echo "Starting busybox..."; trap exit term; while true; do sleep 1; done'
     roles:
       - web

--- a/test/integration/docker/deployer/app_with_traefik/Dockerfile
+++ b/test/integration/docker/deployer/app_with_traefik/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry:4443/nginx:1-alpine-slim
+FROM nginx:1-alpine-slim
 
 COPY default.conf /etc/nginx/conf.d/default.conf
 

--- a/test/integration/docker/deployer/app_with_traefik/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_traefik/config/deploy.yml
@@ -18,7 +18,6 @@ builder:
     COMMIT_SHA: <%= `git rev-parse HEAD` %>
 proxy:
   run:
-    registry: registry:4443
     publish: false
     options:
       label:

--- a/test/integration/docker/deployer/boot.sh
+++ b/test/integration/docker/deployer/boot.sh
@@ -4,7 +4,15 @@
 # itself an overlay mount, and overlay-on-overlay fails on modern Docker/kernels.
 # VFS nests safely.
 mkdir -p /etc/docker
-echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
+# Point this inner daemon at the hub-cache pull-through cache so Docker Hub base
+# images are fetched at most once per run instead of on every test.
+cat > /etc/docker/daemon.json <<'EOF'
+{
+  "storage-driver": "vfs",
+  "registry-mirrors": [ "http://hub-cache:5000" ],
+  "insecure-registries": [ "hub-cache:5000" ]
+}
+EOF
 
 # Docker needs an iptables backend that can initialize the nat table against the
 # host kernel. Legacy works on hosts with the legacy ip_tables modules loaded;

--- a/test/integration/docker/deployer/setup.sh
+++ b/test/integration/docker/deployer/setup.sh
@@ -4,23 +4,14 @@ install_kamal() {
   cd /kamal && gem build kamal.gemspec -o /tmp/kamal.gem && gem install /tmp/kamal.gem
 }
 
-# Push the images to a persistent volume on the registry container
-# This is to work around docker hub rate limits
-push_image_to_registry_4443() {
-  # Check if the image is in the registry without having to pull it
-  if ! stat /registry/docker/registry/v2/repositories/$1/_manifests/tags/$2/current/link > /dev/null; then
-    hub_tag=$1:$2
-    registry_4443_tag=registry:4443/$1:$2
-    docker pull $hub_tag
-    docker tag $hub_tag $registry_4443_tag
-    docker push $registry_4443_tag
-  fi
-}
-
 install_kamal
-push_image_to_registry_4443 nginx 1-alpine-slim
-push_image_to_registry_4443 busybox 1.36.0
-push_image_to_registry_4443 basecamp/kamal-proxy v0.9.2
+
+# Seed the private registry with the proxy image (fetched once via the hub_cache
+# mirror) so the proxy.run.registry option stays exercised by the suite — see
+# app_with_roles, which pulls its proxy from registry:4443 rather than the Hub.
+docker pull basecamp/kamal-proxy:v0.9.2
+docker tag basecamp/kamal-proxy:v0.9.2 registry:4443/basecamp/kamal-proxy:v0.9.2
+docker push registry:4443/basecamp/kamal-proxy:v0.9.2
 
 # .ssh is on a shared volume that persists between runs. Clean it up as the
 # churn of temporary vm IPs can eventually create conflicts.

--- a/test/integration/docker/vm/boot.sh
+++ b/test/integration/docker/vm/boot.sh
@@ -8,7 +8,15 @@ service ssh restart
 # itself an overlay mount, and overlay-on-overlay fails on modern Docker/kernels.
 # VFS nests safely.
 mkdir -p /etc/docker
-echo '{"storage-driver": "vfs"}' > /etc/docker/daemon.json
+# Point this inner daemon at the hub-cache pull-through cache so Docker Hub base
+# images are fetched at most once per run instead of on every test.
+cat > /etc/docker/daemon.json <<'EOF'
+{
+  "storage-driver": "vfs",
+  "registry-mirrors": [ "http://hub-cache:5000" ],
+  "insecure-registries": [ "hub-cache:5000" ]
+}
+EOF
 
 # Docker needs an iptables backend that can initialize the nat table against the
 # host kernel. Legacy works on hosts with the legacy ip_tables modules loaded;

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -1,13 +1,23 @@
 require "net/http"
+require "digest"
 require "test_helper"
 
 class IntegrationTest < ActiveSupport::TestCase
+  # Stable per-worktree Compose project name: the same across repeated runs in a given
+  # worktree (so `down` still tears down the right stack), but unique across worktrees
+  # so two suites can run concurrently without clashing on container/network/volume names.
+  COMPOSE_PROJECT = "kamal-test-#{Digest::SHA256.hexdigest(File.expand_path("../..", __dir__))[0, 8]}"
+
   setup do
     ENV["TEST_ID"] = SecureRandom.hex
     docker_compose "up --build -d"
     wait_for_healthy
     setup_deployer
     deployer_exec("sh -c 'rm -f /tmp/otel/*.json /tmp/kamal-deploy-logs/*'", workdir: "/")
+    # Host ports are published on ephemeral ports (collision-free across worktrees);
+    # discover the ones Compose actually assigned.
+    @http_port = published_port("load_balancer", 80)
+    @https_port = published_port("vm1", 443)
     @app = "app"
   end
 
@@ -24,7 +34,7 @@ class IntegrationTest < ActiveSupport::TestCase
 
   private
     def docker_compose(*commands, capture: false, raise_on_error: true)
-      command = "TEST_ID=#{ENV["TEST_ID"]} docker compose #{commands.join(" ")}"
+      command = "TEST_ID=#{ENV["TEST_ID"]} COMPOSE_PROJECT_NAME=#{COMPOSE_PROJECT} docker compose #{commands.join(" ")}"
       succeeded = false
       if capture || !ENV["DEBUG"]
         result = stdouted { stderred { succeeded = system("cd test/integration && #{command}") } }
@@ -34,6 +44,13 @@ class IntegrationTest < ActiveSupport::TestCase
 
       raise "Command `#{command}` failed with error code `#{$?}`, and output:\n#{result}" if !succeeded && raise_on_error
       result
+    end
+
+    # Returns the ephemeral host port Compose assigned to a service's container port,
+    # e.g. published_port("load_balancer", 80) => 32768.
+    def published_port(service, container_port)
+      docker_compose("port #{service} #{container_port}", capture: true)
+        .lines.first.to_s.strip.split(":").last.to_i
     end
 
     def deployer_exec(*commands, workdir: nil, **options)
@@ -84,7 +101,7 @@ class IntegrationTest < ActiveSupport::TestCase
     end
 
     def app_response(app: @app, cert: nil)
-      uri = cert ? URI.parse("https://#{app_host(app)}:22443/version") : URI.parse("http://#{app_host(app)}:12345/version")
+      uri = cert ? URI.parse("https://#{app_host(app)}:#{@https_port}/version") : URI.parse("http://#{app_host(app)}:#{@http_port}/version")
 
       if cert
         https_response_with_cert(uri, cert)

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -1,5 +1,7 @@
 require "net/http"
 require "digest"
+require "base64"
+require "json"
 require "test_helper"
 
 class IntegrationTest < ActiveSupport::TestCase
@@ -10,6 +12,7 @@ class IntegrationTest < ActiveSupport::TestCase
 
   setup do
     ENV["TEST_ID"] = SecureRandom.hex
+    authenticate_hub_cache
     docker_compose "up --build -d"
     wait_for_healthy
     setup_deployer
@@ -44,6 +47,38 @@ class IntegrationTest < ActiveSupport::TestCase
 
       raise "Command `#{command}` failed with error code `#{$?}`, and output:\n#{result}" if !succeeded && raise_on_error
       result
+    end
+
+    # The hub-cache pull-through cache fetches from Docker Hub on its own, and Hub's
+    # anonymous pull limit is per-IP — easily exhausted by the suite. Reuse the
+    # developer's existing `docker login` so the cache authenticates its upstream
+    # pulls against their account quota. Respects DOCKERHUB_USERNAME/DOCKERHUB_TOKEN
+    # if already set (e.g. in CI); a no-op if no login is found (stays anonymous).
+    def authenticate_hub_cache
+      return if ENV["DOCKERHUB_TOKEN"].to_s.present?
+      username, token = docker_hub_credentials
+      return unless token.present?
+      ENV["DOCKERHUB_USERNAME"] = username
+      ENV["DOCKERHUB_TOKEN"] = token
+    end
+
+    def docker_hub_credentials
+      config_path = File.expand_path("~/.docker/config.json")
+      return [ nil, nil ] unless File.exist?(config_path)
+
+      config = JSON.parse(File.read(config_path))
+      registry = "https://index.docker.io/v1/"
+
+      if (helper = config.dig("credHelpers", registry) || config["credsStore"]).present?
+        creds = JSON.parse(`echo #{registry} | docker-credential-#{helper} get 2>/dev/null`)
+        [ creds["Username"], creds["Secret"] ]
+      elsif (auth = config.dig("auths", registry, "auth")).present?
+        Base64.decode64(auth).split(":", 2)
+      else
+        [ nil, nil ]
+      end
+    rescue
+      [ nil, nil ]
     end
 
     # Returns the ephemeral host port Compose assigned to a service's container port,

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -288,10 +288,10 @@ class MainTest < IntegrationTest
 
     def assert_accumulated_assets(*versions)
       versions.each do |version|
-        assert_equal "200", Net::HTTP.get_response(URI.parse("http://#{app_host}:12345/versions/#{version}")).code
+        assert_equal "200", Net::HTTP.get_response(URI.parse("http://#{app_host}:#{@http_port}/versions/#{version}")).code
       end
 
-      assert_equal "200", Net::HTTP.get_response(URI.parse("http://#{app_host}:12345/versions/.hidden")).code
+      assert_equal "200", Net::HTTP.get_response(URI.parse("http://#{app_host}:#{@http_port}/versions/.hidden")).code
     end
 
     def assert_asset_volume_read_only(version)


### PR DESCRIPTION
- avoid port or container name clashes
- use a mirror to avoid hitting docker hub limits
- reuse docker credentials on the inside docker, so you can use docker login if you hit limits