### PR TITLE
Add a --raw option to exec for unmodified stdout

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -146,36 +146,45 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
   desc "exec [NAME] [CMD...]", "Execute a custom command on servers within the accessory container (use --help to show options)"
   option :interactive, aliases: "-i", type: :boolean, default: false, desc: "Execute command over ssh for an interactive shell (use for console/bash)"
   option :reuse, type: :boolean, default: false, desc: "Reuse currently running container instead of starting a new one"
+  option :raw, type: :boolean, default: false, desc: "Output raw, unmodified stdout"
   def exec(name, *cmd)
-    pre_connect_if_required
+    raw = options[:raw]
 
-    cmd = Kamal::Utils.join_commands(cmd)
-    quiet = options[:quiet]
+    if raw && options[:interactive]
+      raise ArgumentError, "Raw is not compatible with interactive"
+    end
 
-    with_accessory(name) do |accessory, hosts|
-      case
-      when options[:interactive] && options[:reuse]
-        say "Launching interactive command via SSH from existing container...", :magenta
-        run_locally { exec accessory.execute_in_existing_container_over_ssh(cmd) }
+    with_raw_output(raw) do
+      pre_connect_if_required
 
-      when options[:interactive]
-        say "Launching interactive command via SSH from new container...", :magenta
-        on(accessory.hosts.first) { execute *KAMAL.registry.login }
-        run_locally { exec accessory.execute_in_new_container_over_ssh(cmd) }
+      cmd = Kamal::Utils.join_commands(cmd)
+      quiet = options[:quiet]
 
-      when options[:reuse]
-        say "Launching command from existing container...", :magenta
-        on(hosts) do |host|
-          execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{name} accessory"), verbosity: :debug
-          puts_by_host host, capture_with_info(*accessory.execute_in_existing_container(cmd)), quiet: quiet
-        end
+      with_accessory(name) do |accessory, hosts|
+        case
+        when options[:interactive] && options[:reuse]
+          say "Launching interactive command via SSH from existing container...", :magenta
+          run_locally { exec accessory.execute_in_existing_container_over_ssh(cmd) }
 
-      else
-        say "Launching command from new container...", :magenta
-        on(hosts) do |host|
-          execute *KAMAL.registry.login
-          execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{name} accessory"), verbosity: :debug
-          puts_by_host host, capture_with_info(*accessory.execute_in_new_container(cmd)), quiet: quiet
+        when options[:interactive]
+          say "Launching interactive command via SSH from new container...", :magenta
+          on(accessory.hosts.first) { execute *KAMAL.registry.login }
+          run_locally { exec accessory.execute_in_new_container_over_ssh(cmd) }
+
+        when options[:reuse]
+          say "Launching command from existing container...", :magenta
+          on(hosts) do |host|
+            execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{name} accessory"), verbosity: :debug
+            puts_by_host host, capture_with_info(*accessory.execute_in_existing_container(cmd), strip: !raw), quiet: quiet, raw: raw
+          end
+
+        else
+          say "Launching command from new container...", :magenta
+          on(hosts) do |host|
+            execute *KAMAL.registry.login
+            execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{name} accessory"), verbosity: :debug
+            puts_by_host host, capture_with_info(*accessory.execute_in_new_container(cmd), strip: !raw), quiet: quiet, raw: raw
+          end
         end
       end
     end

--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -93,59 +93,68 @@ class Kamal::Cli::App < Kamal::Cli::Base
   option :reuse, type: :boolean, default: false, desc: "Reuse currently running container instead of starting a new one"
   option :env, aliases: "-e", type: :hash, desc: "Set environment variables for the command"
   option :detach, type: :boolean, default: false, desc: "Execute command in a detached container"
+  option :raw, type: :boolean, default: false, desc: "Output raw, unmodified stdout"
   def exec(*cmd)
-    pre_connect_if_required
+    raw = options[:raw]
 
     if (incompatible_options = [ :interactive, :reuse ].select { |key| options[:detach] && options[key] }.presence)
       raise ArgumentError, "Detach is not compatible with #{incompatible_options.join(" or ")}"
+    end
+
+    if raw && (incompatible_options = [ :interactive, :detach ].select { |key| options[key] }.presence)
+      raise ArgumentError, "Raw is not compatible with #{incompatible_options.join(" or ")}"
     end
 
     if cmd.empty?
       raise ArgumentError, "No command provided. You must specify a command to execute."
     end
 
-    cmd = Kamal::Utils.join_commands(cmd)
-    env = options[:env]
-    detach = options[:detach]
-    quiet = options[:quiet]
-    case
-    when options[:interactive] && options[:reuse]
-      say "Get current version of running container...", :magenta unless options[:version]
-      using_version(options[:version] || current_running_version) do |version|
-        say "Launching interactive command with version #{version} via SSH from existing container on #{KAMAL.primary_host}...", :magenta
-        run_locally { exec KAMAL.app(role: KAMAL.primary_role, host: KAMAL.primary_host).execute_in_existing_container_over_ssh(cmd, env: env) }
-      end
+    with_raw_output(raw) do
+      pre_connect_if_required
 
-    when options[:interactive]
-      say "Get most recent version available as an image...", :magenta unless options[:version]
-      using_version(version_or_latest) do |version|
-        say "Launching interactive command with version #{version} via SSH from new container on #{KAMAL.primary_host}...", :magenta
-        on(KAMAL.primary_host) { execute *KAMAL.registry.login }
-        run_locally do
-          exec KAMAL.app(role: KAMAL.primary_role, host: KAMAL.primary_host).execute_in_new_container_over_ssh(cmd, env: env)
+      cmd = Kamal::Utils.join_commands(cmd)
+      env = options[:env]
+      detach = options[:detach]
+      quiet = options[:quiet]
+      case
+      when options[:interactive] && options[:reuse]
+        say "Get current version of running container...", :magenta unless options[:version]
+        using_version(options[:version] || current_running_version) do |version|
+          say "Launching interactive command with version #{version} via SSH from existing container on #{KAMAL.primary_host}...", :magenta
+          run_locally { exec KAMAL.app(role: KAMAL.primary_role, host: KAMAL.primary_host).execute_in_existing_container_over_ssh(cmd, env: env) }
         end
-      end
 
-    when options[:reuse]
-      say "Get current version of running container...", :magenta unless options[:version]
-      using_version(options[:version] || current_running_version) do |version|
-        say "Launching command with version #{version} from existing container...", :magenta
-
-        on_roles(KAMAL.roles, hosts: KAMAL.app_hosts) do |host, role|
-          execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on app version #{version}", role: role), verbosity: :debug
-          puts_by_host host, capture_with_info(*KAMAL.app(role: role, host: host).execute_in_existing_container(cmd, env: env)), quiet: quiet
+      when options[:interactive]
+        say "Get most recent version available as an image...", :magenta unless options[:version]
+        using_version(version_or_latest) do |version|
+          say "Launching interactive command with version #{version} via SSH from new container on #{KAMAL.primary_host}...", :magenta
+          on(KAMAL.primary_host) { execute *KAMAL.registry.login }
+          run_locally do
+            exec KAMAL.app(role: KAMAL.primary_role, host: KAMAL.primary_host).execute_in_new_container_over_ssh(cmd, env: env)
+          end
         end
-      end
 
-    else
-      say "Get most recent version available as an image...", :magenta unless options[:version]
-      using_version(version_or_latest) do |version|
-        say "Launching command with version #{version} from new container...", :magenta
-        on(KAMAL.app_hosts) { execute *KAMAL.registry.login }
+      when options[:reuse]
+        say "Get current version of running container...", :magenta unless options[:version]
+        using_version(options[:version] || current_running_version) do |version|
+          say "Launching command with version #{version} from existing container...", :magenta
 
-        on_roles(KAMAL.roles, hosts: KAMAL.app_hosts) do |host, role|
-          execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on app version #{version}"), verbosity: :debug
-          puts_by_host host, capture_with_info(*KAMAL.app(role: role, host: host).execute_in_new_container(cmd, env: env, detach: detach)), quiet: quiet
+          on_roles(KAMAL.roles, hosts: KAMAL.app_hosts) do |host, role|
+            execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on app version #{version}", role: role), verbosity: :debug
+            puts_by_host host, capture_with_info(*KAMAL.app(role: role, host: host).execute_in_existing_container(cmd, env: env), strip: !raw), quiet: quiet, raw: raw
+          end
+        end
+
+      else
+        say "Get most recent version available as an image...", :magenta unless options[:version]
+        using_version(version_or_latest) do |version|
+          say "Launching command with version #{version} from new container...", :magenta
+          on(KAMAL.app_hosts) { execute *KAMAL.registry.login }
+
+          on_roles(KAMAL.roles, hosts: KAMAL.app_hosts) do |host, role|
+            execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on app version #{version}"), verbosity: :debug
+            puts_by_host host, capture_with_info(*KAMAL.app(role: role, host: host).execute_in_new_container(cmd, env: env, detach: detach), strip: !raw), quiet: quiet, raw: raw
+          end
         end
       end
     end

--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -79,8 +79,14 @@ module Kamal::Cli
       end
 
       def say(message = "", *)
-        super
+        super unless options[:raw]
         KAMAL.log(message.to_s)
+      end
+
+      # Raw output is written straight to stdout for piping, so silence SSHKit's
+      # command echoing that would otherwise corrupt the byte stream.
+      def with_raw_output(raw, &block)
+        raw ? KAMAL.with_verbosity(:error, &block) : block.call
       end
 
       def with_lock

--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -1,26 +1,35 @@
 class Kamal::Cli::Server < Kamal::Cli::Base
   desc "exec", "Run a custom command on the server (use --help to show options)"
   option :interactive, type: :boolean, aliases: "-i", default: false, desc: "Run the command interactively (use for console/bash)"
+  option :raw, type: :boolean, default: false, desc: "Output raw, unmodified stdout"
   def exec(*cmd)
-    pre_connect_if_required
+    raw = options[:raw]
 
-    cmd = Kamal::Utils.join_commands(cmd)
-    hosts = KAMAL.hosts
-    quiet = options[:quiet]
+    if raw && options[:interactive]
+      raise ArgumentError, "Raw is not compatible with interactive"
+    end
 
-    case
-    when options[:interactive]
-      host = KAMAL.primary_host
+    with_raw_output(raw) do
+      pre_connect_if_required
 
-      say "Running '#{cmd}' on #{host} interactively...", :magenta
+      cmd = Kamal::Utils.join_commands(cmd)
+      hosts = KAMAL.hosts
+      quiet = options[:quiet]
 
-      run_locally { exec KAMAL.server.run_over_ssh(cmd, host: host) }
-    else
-      say "Running '#{cmd}' on #{hosts.join(', ')}...", :magenta
+      case
+      when options[:interactive]
+        host = KAMAL.primary_host
 
-      on(hosts) do |host|
-        execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{host}"), verbosity: :debug
-        puts_by_host host, capture_with_info(cmd), quiet: quiet
+        say "Running '#{cmd}' on #{host} interactively...", :magenta
+
+        run_locally { exec KAMAL.server.run_over_ssh(cmd, host: host) }
+      else
+        say "Running '#{cmd}' on #{hosts.join(', ')}...", :magenta
+
+        on(hosts) do |host|
+          execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on #{host}"), verbosity: :debug
+          puts_by_host host, capture_with_info(cmd, strip: !raw), quiet: quiet, raw: raw
+        end
       end
     end
   end

--- a/lib/kamal/sshkit_with_ext.rb
+++ b/lib/kamal/sshkit_with_ext.rb
@@ -19,11 +19,16 @@ class SSHKit::Backend::Abstract
     JSON.pretty_generate(JSON.parse(capture(*args, **kwargs)))
   end
 
-  def puts_by_host(host, output, type: "App", quiet: false)
-    unless quiet
-      puts "#{type} Host: #{host}"
+  def puts_by_host(host, output, type: "App", quiet: false, raw: false)
+    if raw
+      $stdout.binmode
+      $stdout.write(output)
+    else
+      unless quiet
+        puts "#{type} Host: #{host}"
+      end
+      puts "#{output}\n\n"
     end
-    puts "#{output}\n\n"
   end
 
   # Our execution pattern is for the CLI execute args lists returned

--- a/test/cli/server_test.rb
+++ b/test/cli/server_test.rb
@@ -3,7 +3,7 @@ require_relative "cli_test_case"
 class CliServerTest < CliTestCase
   test "running a command with exec" do
     SSHKit::Backend::Abstract.any_instance.stubs(:capture)
-      .with("date", verbosity: 1)
+      .with("date", strip: true, verbosity: 1)
       .returns("Today")
 
     hosts = "1.1.1.1".."1.1.1.4"
@@ -17,7 +17,7 @@ class CliServerTest < CliTestCase
 
   test "running a command with exec multiple arguments" do
     SSHKit::Backend::Abstract.any_instance.stubs(:capture)
-      .with("date -j", verbosity: 1)
+      .with("date -j", strip: true, verbosity: 1)
       .returns("Today")
 
     hosts = "1.1.1.1".."1.1.1.4"
@@ -27,6 +27,22 @@ class CliServerTest < CliTestCase
         assert_match "App Host: #{host}\nToday", output
       end
     end
+  end
+
+  test "running a command with exec --raw writes stdout verbatim" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture)
+      .with("date", strip: false, verbosity: 1)
+      .returns("Today")
+
+    run_command("exec", "date", "--raw").tap do |output|
+      assert_equal "Today" * 4, output
+      assert_no_match(/App Host:/, output)
+      assert_no_match(/Running 'date'/, output)
+    end
+  end
+
+  test "exec --raw is incompatible with --interactive" do
+    assert_raises(ArgumentError) { run_command("exec", "date", "--raw", "--interactive") }
   end
 
   test "bootstrap already installed" do

--- a/test/integration/app_test.rb
+++ b/test/integration/app_test.rb
@@ -48,6 +48,14 @@ class AppTest < IntegrationTest
     assert_match "App Host: vm1", exec_output
     assert_match /1 root      0:\d\d nginx/, exec_output
 
+    binary = "head -c 512 /dev/zero"
+    expected_md5 = deployer_exec(%(sh -c "#{binary} | md5sum"), capture: true)[/\h{32}/]
+    piped_md5 = deployer_exec(
+      %(sh -c "kamal app exec --reuse --raw --primary '#{binary}' | md5sum"),
+      capture: true
+    )[/\h{32}/]
+    assert_equal expected_md5, piped_md5
+
     kamal :app, :maintenance
     assert_app_in_maintenance
 


### PR DESCRIPTION
`kamal app/accessory/server exec` ran the command's stdout through SSHKit's `capture`, which strips leading/trailing whitespace — including NUL bytes and newlines. Piping binary output (e.g. a tar) was silently corrupted as its trailing zero-padding got truncated.

Add `--raw` to emit the command's stdout exactly as produced. It also lowers the logging level so only the command's output is written. `--raw` is incompatible with `--interactive` (and `--detach`).

Fixes #1861.