### PR TITLE
Make builder tests pass regardless of host architecture

### DIFF
--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -46,7 +46,7 @@ class CliBuildTest < CliTestCase
       run_command("push", "--verbose", fixture: :with_remote_builder).tap do |output|
         assert_no_match "Running docker login -u [REDACTED] -p [REDACTED] as ", output
         assert_match "docker buildx inspect kamal-remote-ssh---app-1-1-1-5 | grep -q Endpoint:.*kamal-remote-ssh---app-1-1-1-5-context && docker context inspect kamal-remote-ssh---app-1-1-1-5-context --format '{{.Endpoints.docker.Host}}' | grep -xq ssh://app@1.1.1.5 || (echo no compatible builder && exit 1)", output
-        assert_match "Command: ( export BUILDKIT_NO_CLIENT_TOKEN=\"1\" ; docker buildx build --output=type=registry --platform linux/arm64 --builder kamal-remote-ssh---app-1-1-1-5 -t dhh/app:999 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1 )", output
+        assert_match "Command: ( export BUILDKIT_NO_CLIENT_TOKEN=\"1\" ; docker buildx build --output=type=registry --platform linux/#{remote_arch} --builder kamal-remote-ssh---app-1-1-1-5 -t dhh/app:999 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1 )", output
       end
     end
   end
@@ -350,9 +350,9 @@ class CliBuildTest < CliTestCase
   test "create hybrid" do
     run_command("create", fixture: :with_hybrid_builder).tap do |output|
       assert_match "Running /usr/bin/env true on 1.1.1.5", output
-      assert_match "docker buildx create --platform linux/#{Kamal::Utils.docker_arch} --name kamal-hybrid-docker-container-ssh---app-1-1-1-5 --driver=docker-container", output
+      assert_match "docker buildx create --platform linux/#{local_arch} --name kamal-hybrid-docker-container-ssh---app-1-1-1-5 --driver=docker-container", output
       assert_match "docker context create kamal-hybrid-docker-container-ssh---app-1-1-1-5-context --description 'kamal-hybrid-docker-container-ssh---app-1-1-1-5 host' --docker 'host=ssh://app@1.1.1.5'", output
-      assert_match "docker buildx create --platform linux/#{Kamal::Utils.docker_arch == "amd64" ? "arm64" : "amd64"} --append --name kamal-hybrid-docker-container-ssh---app-1-1-1-5 kamal-hybrid-docker-container-ssh---app-1-1-1-5-context", output
+      assert_match "docker buildx create --platform linux/#{remote_arch} --append --name kamal-hybrid-docker-container-ssh---app-1-1-1-5 kamal-hybrid-docker-container-ssh---app-1-1-1-5-context", output
     end
   end
 

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -275,7 +275,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     )
     assert_equal "hybrid", builder.name
     assert_equal \
-      "docker buildx create --platform linux/amd64 --name kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry --driver=docker-container --driver-opt network=host && docker context create kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry-context --description 'kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry host' --docker 'host=ssh://app@1.1.1.5' && docker buildx create --platform linux/arm64 --append --name kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry --driver-opt network=host kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry-context",
+      "docker buildx create --platform linux/#{local_arch} --name kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry --driver=docker-container --driver-opt network=host && docker context create kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry-context --description 'kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry host' --docker 'host=ssh://app@1.1.1.5' && docker buildx create --platform linux/#{remote_arch} --append --name kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry --driver-opt network=host kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry-context",
       builder.create.join(" ")
   end
 
@@ -286,13 +286,5 @@ class CommandsBuilderTest < ActiveSupport::TestCase
         KAMAL.stubs(:config).returns(config)
         Kamal::Commands::Builder.new(config)
       end
-    end
-
-    def local_arch
-      Kamal::Utils.docker_arch
-    end
-
-    def remote_arch
-      Kamal::Utils.docker_arch == "arm64" ? "amd64" : "arm64"
     end
 end

--- a/test/configuration/validation_test.rb
+++ b/test/configuration/validation_test.rb
@@ -102,8 +102,6 @@ class ConfigurationValidationTest < ActiveSupport::TestCase
   end
 
   test "local registry with remote builder requires ssh url" do
-    remote_arch = Kamal::Utils.docker_arch == "arm64" ? "amd64" : "arm64"
-
     assert_error "Local registry with remote builder requires an SSH URL (e.g., ssh://user@host)",
       registry: { "server" => "localhost:5000" },
       builder: { "arch" => remote_arch, "remote" => "docker-container://remote-builder" }

--- a/test/fixtures/deploy_with_cloud_builder.yml
+++ b/test/fixtures/deploy_with_cloud_builder.yml
@@ -36,5 +36,5 @@ accessories:
 readiness_delay: 0
 
 builder:
-  arch: <%= Kamal::Utils.docker_arch == "arm64" ? "amd64" : "arm64" %>
+  arch: <%= ArchHelper.remote_arch %>
   driver: cloud example_org/cloud_builder

--- a/test/fixtures/deploy_with_local_registry_and_remote_builder.yml
+++ b/test/fixtures/deploy_with_local_registry_and_remote_builder.yml
@@ -8,5 +8,5 @@ registry:
   server: localhost:5000
 
 builder:
-  arch: <%= Kamal::Utils.docker_arch == "arm64" ? "amd64" : "arm64" %>
+  arch: <%= ArchHelper.remote_arch %>
   remote: ssh://app@1.1.1.5

--- a/test/fixtures/deploy_with_local_registry_and_remote_builder_with_port.yml
+++ b/test/fixtures/deploy_with_local_registry_and_remote_builder_with_port.yml
@@ -8,5 +8,5 @@ registry:
   server: localhost:5000
 
 builder:
-  arch: <%= Kamal::Utils.docker_arch == "arm64" ? "amd64" : "arm64" %>
+  arch: <%= ArchHelper.remote_arch %>
   remote: ssh://app@1.1.1.5:2222

--- a/test/fixtures/deploy_with_remote_builder.yml
+++ b/test/fixtures/deploy_with_remote_builder.yml
@@ -36,5 +36,5 @@ accessories:
 readiness_delay: 0
 
 builder:
-  arch: <%= Kamal::Utils.docker_arch == "arm64" ? "amd64" : "arm64" %>
+  arch: <%= ArchHelper.remote_arch %>
   remote: ssh://app@1.1.1.5

--- a/test/fixtures/deploy_with_remote_builder_and_custom_ports.yml
+++ b/test/fixtures/deploy_with_remote_builder_and_custom_ports.yml
@@ -40,5 +40,5 @@ ssh:
   port: 22
 
 builder:
-  arch: <%= Kamal::Utils.docker_arch == "arm64" ? "amd64" : "arm64" %>
+  arch: <%= ArchHelper.remote_arch %>
   remote: ssh://app@1.1.1.5:2122

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -88,7 +88,7 @@ class MainTest < IntegrationTest
     assert_equal "app-#{version}", config[:service_with_version]
     assert_equal [], config[:volume_args]
     assert_equal({ user: "root", port: 22, keepalive: true, keepalive_interval: 30, log_level: :fatal }, config[:ssh_options])
-    assert_equal({ "driver" => "docker", "arch" => "#{Kamal::Utils.docker_arch}", "args" => { "COMMIT_SHA" => version } }, config[:builder])
+    assert_equal({ "driver" => "docker", "arch" => local_arch, "args" => { "COMMIT_SHA" => version } }, config[:builder])
     assert_equal [ "--log-opt", "max-size=\"10m\"" ], config[:logging]
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -36,8 +36,21 @@ module SSHKit
   end
 end
 
+module ArchHelper
+  module_function
+
+  def local_arch
+    Kamal::Utils.docker_arch
+  end
+
+  def remote_arch
+    local_arch == "arm64" ? "amd64" : "arm64"
+  end
+end
+
 class ActiveSupport::TestCase
   include ActiveSupport::Testing::Stream
+  include ArchHelper
   extend Rails::LineFiltering
 
   private


### PR DESCRIPTION
Several builder tests hardcoded `amd64` as the local architecture. On `arm64` hosts (e.g. Apple Silicon), Kamal correctly reverses the local/remote arch split (it builds the host's arch locally and the other remotely), so the generated `docker buildx` commands legitimately differ, and the hardcoded expectations no longer matched. This made `bin/test` fail for any contributor on an ARM machine, even on a clean checkout.

This consolidates the "which arch builds locally vs. on a remote builder" logic into a single `ArchHelper` module in `test_helper.rb`, shared by the test classes and the config fixtures, and removes the duplicated copies of this ternary that had drifted across `builder_test.rb`, `build_test.rb`, `validation_test.rb`, and several fixtures.