### PR TITLE
Require an explicit bind host on accessory ports

### DIFF
--- a/lib/kamal/cli/templates/deploy.yml
+++ b/lib/kamal/cli/templates/deploy.yml
@@ -83,7 +83,7 @@ builder:
 #   db:
 #     image: mysql:8.0
 #     host: 192.168.0.2
-#     port: 3306
+#     port: "127.0.0.1:3306:3306"
 #     env:
 #       clear:
 #         MYSQL_ROOT_HOST: '%'
@@ -97,6 +97,6 @@ builder:
 #   redis:
 #     image: valkey/valkey:8
 #     host: 192.168.0.2
-#     port: 6379
+#     port: "127.0.0.1:6379:6379"
 #     directories:
 #       - data:/data

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -1,3 +1,5 @@
+require "ipaddr"
+
 class Kamal::Configuration::Accessory
   include Kamal::Configuration::Validation
 
@@ -17,6 +19,7 @@ class Kamal::Configuration::Accessory
       with: Kamal::Configuration::Validator::Accessory
 
     ensure_valid_roles
+    ensure_valid_port
 
     @env = initialize_env
     @proxy = initialize_proxy if running_proxy?
@@ -36,9 +39,7 @@ class Kamal::Configuration::Accessory
   end
 
   def port
-    if port = accessory_config["port"]&.to_s
-      port.include?(":") ? port : "#{port}:#{port}"
-    end
+    accessory_config["port"]&.to_s
   end
 
   def network_args
@@ -268,6 +269,38 @@ class Kamal::Configuration::Accessory
 
     def network
       accessory_config["network"] || DEFAULT_NETWORK
+    end
+
+    def ensure_valid_port
+      return unless (port_config = port)
+
+      binding, _protocol = port_config.split("/", 2)
+
+      if binding.start_with?("[")
+        # Bracketed IPv6 host, e.g. [::1]:host:container
+        ip = binding[/\A\[([^\]]+)\]/, 1]
+        require_bind_host! port_config unless ip && valid_ip?(ip)
+      elsif binding.count(":") >= 2
+        # ip:host:container — the leading segment is the bind host
+        require_bind_host! port_config unless valid_ip?(binding.split(":").first)
+      else
+        # No explicit host (port, host:container, or ambiguous ip:port)
+        require_bind_host! port_config
+      end
+    end
+
+    def valid_ip?(str)
+      IPAddr.new(str)
+      true
+    rescue IPAddr::InvalidAddressError, ArgumentError, TypeError
+      false
+    end
+
+    def require_bind_host!(port_config)
+      raise Kamal::ConfigurationError,
+        "accessories/#{name}: port \"#{port_config}\" must specify a bind address. " \
+        "Use \"127.0.0.1:PORT:PORT\" (private), \"0.0.0.0:PORT:PORT\" (public), or " \
+        "\"[::1]:PORT:PORT\" (IPv6)."
     end
 
     def ensure_valid_roles

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -1,3 +1,5 @@
+require "ipaddr"
+
 class Kamal::Configuration::Accessory
   include Kamal::Configuration::Validation
 
@@ -17,6 +19,7 @@ class Kamal::Configuration::Accessory
       with: Kamal::Configuration::Validator::Accessory
 
     ensure_valid_roles
+    ensure_valid_port
 
     @env = initialize_env
     @proxy = initialize_proxy if running_proxy?
@@ -36,9 +39,7 @@ class Kamal::Configuration::Accessory
   end
 
   def port
-    if port = accessory_config["port"]&.to_s
-      port.include?(":") ? port : "#{port}:#{port}"
-    end
+    accessory_config["port"]&.to_s.presence
   end
 
   def network_args
@@ -274,6 +275,43 @@ class Kamal::Configuration::Accessory
 
     def network
       accessory_config["network"] || DEFAULT_NETWORK
+    end
+
+    def ensure_valid_port
+      ensure_bound_publish port, "port"
+
+      # `options` passes flags straight to `docker run`, so publishing through it
+      # has to clear the same bar as `port`.
+      Array(docker_options["publish"]).each { |publish| ensure_bound_publish publish.to_s, "options/publish" }
+    end
+
+    def ensure_bound_publish(port_config, key)
+      return if port_config.blank?
+
+      host = port_config.split("/", 2).first
+
+      bound =
+        if host.start_with?("[")
+          (ip = host[/\A\[([^\]]+)\]/, 1]) && valid_ip?(ip)
+        elsif host.count(":") >= 2
+          valid_ip?(host.split(":").first)
+        end
+
+      require_bind_host! port_config, key unless bound
+    end
+
+    def valid_ip?(str)
+      IPAddr.new(str)
+      true
+    rescue IPAddr::InvalidAddressError, ArgumentError, TypeError
+      false
+    end
+
+    def require_bind_host!(port_config, key)
+      raise Kamal::ConfigurationError,
+        "accessories/#{name}: #{key} \"#{port_config}\" must name a bind address — " \
+        "\"127.0.0.1:PORT:PORT\" to keep it private, \"0.0.0.0:PORT:PORT\" to publish it. " \
+        "Run `kamal accessory reboot #{name}` to rebind an existing container."
     end
 
     def ensure_valid_roles

--- a/lib/kamal/configuration/docs/accessory.yml
+++ b/lib/kamal/configuration/docs/accessory.yml
@@ -66,8 +66,18 @@ accessories:
 
     # Port mappings
     #
-    # See [https://docs.docker.com/network/](https://docs.docker.com/network/), and
-    # especially note the warning about the security implications of exposing ports publicly.
+    # A bind address is required — Kamal will not guess on a security-relevant choice.
+    # Use the full `ip:host:container` form (or the bracketed `[ip]:host:container`
+    # form for IPv6) and choose the bind address explicitly:
+    #
+    #   "127.0.0.1:3306:3306"  binds localhost only (private — the usual choice for
+    #                          databases, caches, and other backing services)
+    #   "0.0.0.0:3306:3306"    binds all interfaces (public — reachable from the
+    #                          internet; only use this when you really mean it)
+    #   "[::1]:3306:3306"      IPv6 localhost
+    #
+    # See [https://docs.docker.com/engine/network/port-publishing/](https://docs.docker.com/engine/network/port-publishing/),
+    # and especially note the security implications of exposing ports publicly.
     port: "127.0.0.1:3306:3306"
 
     # Labels

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -15,7 +15,7 @@ class CliAccessoryTest < CliTestCase
 
     run_command("boot", "mysql").tap do |output|
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.3", output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
     end
   end
 
@@ -35,9 +35,9 @@ class CliAccessoryTest < CliTestCase
       assert_match /docker network create kamal.*on 1.1.1.1/, output
       assert_match /docker network create kamal.*on 1.1.1.2/, output
       assert_match /docker network create kamal.*on 1.1.1.3/, output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
       assert_match "docker run --name custom-box --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --env KAMAL_HOST=\"1.1.1.3\" --env-file .kamal/apps/app/env/accessories/busybox.env --label service=\"custom-box\" other.registry/busybox:latest on 1.1.1.3", output
     end
   end
@@ -223,7 +223,7 @@ class CliAccessoryTest < CliTestCase
     run_command("boot", "redis", "--hosts", "1.1.1.1").tap do |output|
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.1", output
       assert_no_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.2", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
       assert_no_match /docker run --name app-redis .* on 1.1.1.2/, output
     end
   end
@@ -235,7 +235,7 @@ class CliAccessoryTest < CliTestCase
     run_command("boot", "redis", "--hosts", "1.1.1.1,1.1.1.3").tap do |output|
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.1", output
       assert_no_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.3", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
       assert_no_match /docker run --name app-redis .* on 1.1.1.3/, output
     end
   end
@@ -245,7 +245,7 @@ class CliAccessoryTest < CliTestCase
       assert_match "Upgrading all accessories on 1.1.1.3,1.1.1.1,1.1.1.2...", output
       assert_match "docker network create kamal on 1.1.1.3", output
       assert_match "docker container stop app-mysql on 1.1.1.3", output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
       assert_match "Upgraded all accessories on 1.1.1.3,1.1.1.1,1.1.1.2...", output
     end
   end
@@ -255,15 +255,15 @@ class CliAccessoryTest < CliTestCase
       assert_match "Upgrading all accessories on 1.1.1.3...", output
       assert_match "docker network create kamal on 1.1.1.3", output
       assert_match "docker container stop app-mysql on 1.1.1.3", output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
       assert_match "Upgraded all accessories on 1.1.1.3", output
     end
   end
 
   test "boot with web role filter" do
     run_command("boot", "redis", "-r", "web").tap do |output|
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
     end
   end
 

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -15,7 +15,7 @@ class CliAccessoryTest < CliTestCase
 
     run_command("boot", "mysql").tap do |output|
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.3", output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
     end
   end
 
@@ -35,9 +35,9 @@ class CliAccessoryTest < CliTestCase
       assert_match /docker network create kamal.*on 1.1.1.1/, output
       assert_match /docker network create kamal.*on 1.1.1.2/, output
       assert_match /docker network create kamal.*on 1.1.1.3/, output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
       assert_match "docker run --name custom-box --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --env KAMAL_HOST=\"1.1.1.3\" --env-file .kamal/apps/app/env/accessories/busybox.env --label service=\"custom-box\" other.registry/busybox:latest on 1.1.1.3", output
     end
   end
@@ -257,7 +257,7 @@ class CliAccessoryTest < CliTestCase
     run_command("boot", "redis", "--hosts", "1.1.1.1").tap do |output|
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.1", output
       assert_no_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.2", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
       assert_no_match /docker run --name app-redis .* on 1.1.1.2/, output
     end
   end
@@ -269,7 +269,7 @@ class CliAccessoryTest < CliTestCase
     run_command("boot", "redis", "--hosts", "1.1.1.1,1.1.1.3").tap do |output|
       assert_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.1", output
       assert_no_match "docker login private.registry -u [REDACTED] -p [REDACTED] on 1.1.1.3", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
       assert_no_match /docker run --name app-redis .* on 1.1.1.3/, output
     end
   end
@@ -279,7 +279,7 @@ class CliAccessoryTest < CliTestCase
       assert_match "Upgrading all accessories on 1.1.1.3,1.1.1.1,1.1.1.2...", output
       assert_match "docker network create kamal on 1.1.1.3", output
       assert_match "docker container stop app-mysql on 1.1.1.3", output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
       assert_match "Upgraded all accessories on 1.1.1.3,1.1.1.1,1.1.1.2...", output
     end
   end
@@ -289,15 +289,15 @@ class CliAccessoryTest < CliTestCase
       assert_match "Upgrading all accessories on 1.1.1.3...", output
       assert_match "docker network create kamal on 1.1.1.3", output
       assert_match "docker container stop app-mysql on 1.1.1.3", output
-      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
+      assert_match "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env KAMAL_HOST=\"1.1.1.3\" --env MYSQL_ROOT_HOST="%" --env-file .kamal/apps/app/env/accessories/mysql.env --volume $PWD/app-mysql/etc/mysql/my.cnf:/etc/mysql/my.cnf --volume $PWD/app-mysql/data:/var/lib/mysql --label service=\"app-mysql\" private.registry/mysql:5.7 on 1.1.1.3", output
       assert_match "Upgraded all accessories on 1.1.1.3", output
     end
   end
 
   test "boot with web role filter" do
     run_command("boot", "redis", "-r", "web").tap do |output|
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
-      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.1", output
+      assert_match "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env KAMAL_HOST=\"1.1.1.2\" --env-file .kamal/apps/app/env/accessories/redis.env --volume $PWD/app-redis/data:/data --label service=\"app-redis\" redis:latest on 1.1.1.2", output
     end
   end
 

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -14,7 +14,7 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
         "mysql" => {
           "image" => "private.registry/mysql:8.0",
           "host" => "1.1.1.5",
-          "port" => "3306",
+          "port" => "127.0.0.1:3306:3306",
           "env" => {
             "clear" => {
               "MYSQL_ROOT_HOST" => "%"
@@ -31,7 +31,7 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
         "redis" => {
           "image" => "redis:latest",
           "host" => "1.1.1.6",
-          "port" => "6379:6379",
+          "port" => "127.0.0.1:6379:6379",
           "labels" => {
             "cache" => "true"
           },
@@ -61,11 +61,11 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
 
   test "run" do
     assert_equal \
-      "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
+      "docker run --name app-mysql --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
       new_command(:mysql).run.join(" ")
 
     assert_equal \
-      "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 6379:6379 --env SOMETHING=\"else\" --env-file .kamal/apps/app/env/accessories/redis.env --volume /var/lib/redis:/data --label service=\"app-redis\" --label cache=\"true\" redis:latest",
+      "docker run --name app-redis --detach --restart unless-stopped --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:6379:6379 --env SOMETHING=\"else\" --env-file .kamal/apps/app/env/accessories/redis.env --volume /var/lib/redis:/data --label service=\"app-redis\" --label cache=\"true\" redis:latest",
       new_command(:redis).run.join(" ")
 
     assert_equal \
@@ -85,7 +85,7 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
     @config[:accessories]["mysql"]["options"]["restart"] = "on-failure"
 
     assert_equal \
-      "docker run --name app-mysql --detach --restart on-failure --network kamal --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
+      "docker run --name app-mysql --detach --restart on-failure --network kamal --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
       new_command(:mysql).run.join(" ")
   end
 
@@ -93,7 +93,7 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
     @config[:accessories]["mysql"]["network"] = "custom"
 
     assert_equal \
-      "docker run --name app-mysql --detach --restart unless-stopped --network custom --log-opt max-size=\"10m\" --publish 3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
+      "docker run --name app-mysql --detach --restart unless-stopped --network custom --log-opt max-size=\"10m\" --publish 127.0.0.1:3306:3306 --env MYSQL_ROOT_HOST=\"%\" --env-file .kamal/apps/app/env/accessories/mysql.env --label service=\"app-mysql\" --cpus \"4\" --memory \"2GB\" private.registry/mysql:8.0",
       new_command(:mysql).run.join(" ")
   end
 

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -16,7 +16,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
         "mysql" => {
           "image" => "public.registry/mysql:8.0",
           "host" => "1.1.1.5",
-          "port" => "3306",
+          "port" => "127.0.0.1:3306:3306",
           "env" => {
             "clear" => {
               "MYSQL_ROOT_HOST" => "%"
@@ -36,7 +36,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
         "redis" => {
           "image" => "redis:latest",
           "hosts" => [ "1.1.1.6", "1.1.1.7" ],
-          "port" => "6379:6379",
+          "port" => "127.0.0.1:6379:6379",
           "labels" => {
             "cache" => "true"
           },
@@ -56,7 +56,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
           "image" => "monitoring:latest",
           "registry" => { "server" => "other.registry", "username" => "user", "password" => "pw" },
           "role" => "web",
-          "port" => "4321:4321",
+          "port" => "127.0.0.1:4321:4321",
           "labels" => {
             "cache" => "true"
           },
@@ -107,8 +107,56 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
   end
 
   test "port" do
-    assert_equal "3306:3306", @config.accessory(:mysql).port
-    assert_equal "6379:6379", @config.accessory(:redis).port
+    assert_equal "127.0.0.1:3306:3306", @config.accessory(:mysql).port
+    assert_equal "127.0.0.1:6379:6379", @config.accessory(:redis).port
+  end
+
+  test "port with no port config" do
+    @deploy[:accessories]["mysql"].delete("port")
+    assert_nil Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "explicit bind addresses are preserved verbatim" do
+    {
+      "127.0.0.1:3306:3306" => "127.0.0.1:3306:3306",
+      "0.0.0.0:3306:3306" => "0.0.0.0:3306:3306",
+      "192.168.1.1:3306:3306" => "192.168.1.1:3306:3306",
+      "[::1]:3306:3306" => "[::1]:3306:3306",
+      "[::]::3306" => "[::]::3306",
+      "192.168.1.1:3306:3306/tcp" => "192.168.1.1:3306:3306/tcp",
+      "127.0.0.1:3306:3306/udp" => "127.0.0.1:3306:3306/udp"
+    }.each do |port_config, expected|
+      @deploy[:accessories]["mysql"]["port"] = port_config
+      assert_equal expected, Kamal::Configuration.new(@deploy).accessory(:mysql).port, port_config
+    end
+  end
+
+  test "port without an explicit bind address raises an error" do
+    [
+      "3306",
+      "3306:3306",
+      "3306:3306/udp",
+      "127.0.0.1:3306"
+    ].each do |port_config|
+      @deploy[:accessories]["mysql"]["port"] = port_config
+      error = assert_raises(Kamal::ConfigurationError, port_config) do
+        Kamal::Configuration.new(@deploy).accessory(:mysql).port
+      end
+      assert_match "must specify a bind address", error.message
+    end
+  end
+
+  test "port with an invalid bind address raises an error" do
+    [
+      "999.999.999.999:3306:3306",
+      "[not::valid::ip]:3306:3306",
+      "[::1:3306:3306"
+    ].each do |port_config|
+      @deploy[:accessories]["mysql"]["port"] = port_config
+      assert_raises(Kamal::ConfigurationError, port_config) do
+        Kamal::Configuration.new(@deploy).accessory(:mysql).port
+      end
+    end
   end
 
   test "host" do

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -16,7 +16,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
         "mysql" => {
           "image" => "public.registry/mysql:8.0",
           "host" => "1.1.1.5",
-          "port" => "3306",
+          "port" => "127.0.0.1:3306:3306",
           "env" => {
             "clear" => {
               "MYSQL_ROOT_HOST" => "%"
@@ -36,7 +36,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
         "redis" => {
           "image" => "redis:latest",
           "hosts" => [ "1.1.1.6", "1.1.1.7" ],
-          "port" => "6379:6379",
+          "port" => "127.0.0.1:6379:6379",
           "labels" => {
             "cache" => "true"
           },
@@ -56,7 +56,7 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
           "image" => "monitoring:latest",
           "registry" => { "server" => "other.registry", "username" => "user", "password" => "pw" },
           "role" => "web",
-          "port" => "4321:4321",
+          "port" => "127.0.0.1:4321:4321",
           "labels" => {
             "cache" => "true"
           },
@@ -107,8 +107,77 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
   end
 
   test "port" do
-    assert_equal "3306:3306", @config.accessory(:mysql).port
-    assert_equal "6379:6379", @config.accessory(:redis).port
+    assert_equal "127.0.0.1:3306:3306", @config.accessory(:mysql).port
+    assert_equal "127.0.0.1:6379:6379", @config.accessory(:redis).port
+  end
+
+  test "port with no port config" do
+    @deploy[:accessories]["mysql"].delete("port")
+    assert_nil Kamal::Configuration.new(@deploy).accessory(:mysql).port
+  end
+
+  test "explicit bind addresses are preserved verbatim" do
+    {
+      "127.0.0.1:3306:3306" => "127.0.0.1:3306:3306",
+      "0.0.0.0:3306:3306" => "0.0.0.0:3306:3306",
+      "192.168.1.1:3306:3306" => "192.168.1.1:3306:3306",
+      "[::1]:3306:3306" => "[::1]:3306:3306",
+      "[::]::3306" => "[::]::3306",
+      "192.168.1.1:3306:3306/tcp" => "192.168.1.1:3306:3306/tcp",
+      "127.0.0.1:3306:3306/udp" => "127.0.0.1:3306:3306/udp"
+    }.each do |port_config, expected|
+      @deploy[:accessories]["mysql"]["port"] = port_config
+      assert_equal expected, Kamal::Configuration.new(@deploy).accessory(:mysql).port, port_config
+    end
+  end
+
+  test "publishing through options requires a bind address too" do
+    @deploy[:accessories]["mysql"].delete("port")
+    @deploy[:accessories]["mysql"]["options"] = { "publish" => "3306:3306" }
+
+    error = assert_raises(Kamal::ConfigurationError) { Kamal::Configuration.new(@deploy).accessory(:mysql) }
+    assert_match /options\/publish "3306:3306" must name a bind address/, error.message
+  end
+
+  test "a bound publish in options is accepted" do
+    @deploy[:accessories]["mysql"].delete("port")
+    @deploy[:accessories]["mysql"]["options"] = { "publish" => [ "127.0.0.1:3306:3306" ] }
+
+    assert_equal [ "--publish", "\"127.0.0.1:3306:3306\"" ], Kamal::Configuration.new(@deploy).accessory(:mysql).option_args
+  end
+
+  test "a blank port publishes nothing" do
+    @deploy[:accessories]["mysql"]["port"] = ""
+
+    assert_nil Kamal::Configuration.new(@deploy).accessory(:mysql).publish_args
+  end
+
+  test "port without an explicit bind address raises an error" do
+    [
+      "3306",
+      "3306:3306",
+      "3306:3306/udp",
+      "127.0.0.1:3306"
+    ].each do |port_config|
+      @deploy[:accessories]["mysql"]["port"] = port_config
+      error = assert_raises(Kamal::ConfigurationError, port_config) do
+        Kamal::Configuration.new(@deploy).accessory(:mysql).port
+      end
+      assert_match "must name a bind address", error.message
+    end
+  end
+
+  test "port with an invalid bind address raises an error" do
+    [
+      "999.999.999.999:3306:3306",
+      "[not::valid::ip]:3306:3306",
+      "[::1:3306:3306"
+    ].each do |port_config|
+      @deploy[:accessories]["mysql"]["port"] = port_config
+      assert_raises(Kamal::ConfigurationError, port_config) do
+        Kamal::Configuration.new(@deploy).accessory(:mysql).port
+      end
+    end
   end
 
   test "host" do

--- a/test/fixtures/deploy_with_accessories.yml
+++ b/test/fixtures/deploy_with_accessories.yml
@@ -17,7 +17,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.3
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -31,7 +31,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
 

--- a/test/fixtures/deploy_with_accessories_on_independent_server.yml
+++ b/test/fixtures/deploy_with_accessories_on_independent_server.yml
@@ -17,7 +17,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.5
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -31,7 +31,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
 

--- a/test/fixtures/deploy_with_accessories_with_different_registries.yml
+++ b/test/fixtures/deploy_with_accessories_with_different_registries.yml
@@ -18,7 +18,7 @@ accessories:
   mysql:
     image: private.registry/mysql:5.7
     host: 1.1.1.3
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -32,7 +32,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
   busybox:

--- a/test/fixtures/deploy_with_cloud_builder.yml
+++ b/test/fixtures/deploy_with_cloud_builder.yml
@@ -15,7 +15,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.3
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -29,7 +29,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
 

--- a/test/fixtures/deploy_with_hybrid_builder.yml
+++ b/test/fixtures/deploy_with_hybrid_builder.yml
@@ -15,7 +15,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.3
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -29,7 +29,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
 

--- a/test/fixtures/deploy_with_local_registry_and_accessories.yml
+++ b/test/fixtures/deploy_with_local_registry_and_accessories.yml
@@ -16,7 +16,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.3
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -30,7 +30,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
   busybox:

--- a/test/fixtures/deploy_with_proxy.yml
+++ b/test/fixtures/deploy_with_proxy.yml
@@ -18,7 +18,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.3
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -32,7 +32,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
 

--- a/test/fixtures/deploy_with_proxy_roles.yml
+++ b/test/fixtures/deploy_with_proxy_roles.yml
@@ -24,7 +24,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.3
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -38,7 +38,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
 

--- a/test/fixtures/deploy_with_proxy_run_config.yml
+++ b/test/fixtures/deploy_with_proxy_run_config.yml
@@ -25,7 +25,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.3
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -43,7 +43,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
 

--- a/test/fixtures/deploy_with_proxy_run_config_conflicts.yml
+++ b/test/fixtures/deploy_with_proxy_run_config_conflicts.yml
@@ -20,7 +20,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.2
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -37,7 +37,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
 

--- a/test/fixtures/deploy_with_remote_builder.yml
+++ b/test/fixtures/deploy_with_remote_builder.yml
@@ -15,7 +15,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.3
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -29,7 +29,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
 

--- a/test/fixtures/deploy_with_remote_builder_and_custom_ports.yml
+++ b/test/fixtures/deploy_with_remote_builder_and_custom_ports.yml
@@ -15,7 +15,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.3
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -29,7 +29,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
 

--- a/test/fixtures/deploy_with_single_accessory.yml
+++ b/test/fixtures/deploy_with_single_accessory.yml
@@ -17,7 +17,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.5
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'

--- a/test/fixtures/deploy_without_clone.yml
+++ b/test/fixtures/deploy_without_clone.yml
@@ -15,7 +15,7 @@ accessories:
   mysql:
     image: mysql:5.7
     host: 1.1.1.3
-    port: 3306
+    port: "127.0.0.1:3306:3306"
     env:
       clear:
         MYSQL_ROOT_HOST: '%'
@@ -29,7 +29,7 @@ accessories:
     image: redis:latest
     roles:
       - web
-    port: 6379
+    port: "127.0.0.1:6379:6379"
     directories:
       - data:/data
 

--- a/test/integration/docker/deployer/app_with_proxied_accessory/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_proxied_accessory/config/deploy.yml
@@ -29,7 +29,7 @@ accessories:
     cmd: >
       sh -c 'echo "Starting netcat..."; while true; do echo -e "HTTP/1.1 200 OK\r\nContent-Length: 11\r\n\r\nHello Ruby" | nc -l -p 80; done'
     host: vm1
-    port: 12345:80
+    port: "127.0.0.1:12345:80"
     proxy:
       host: netcat
       ssl: false

--- a/test/integration/docker/deployer/app_with_traefik/config/deploy.yml
+++ b/test/integration/docker/deployer/app_with_traefik/config/deploy.yml
@@ -28,7 +28,7 @@ accessories:
   traefik:
     service: traefik
     image: traefik:v3.6
-    port: 80
+    port: "0.0.0.0:80:80"
     cmd: "--providers.docker"
     options:
       volume:


### PR DESCRIPTION
An accessory port like "5432:5432" was passed to Docker as --publish 5432:5432, which Docker expands to 0.0.0.0:5432:5432 — binding every interface, including public ones. This can be a security risk if that's not what was intended.

We could silently default an unspecified host to 127.0.0.1, but that would break accessories where the intention was to bind all interfaces.

Instead we'll require the address to be specified explicitly, and raise a ConfigurationError otherwise. This is a breaking change but we'll fail loudly and force the user to make a choice.

Fixes #1790