### PR TITLE
Diagnose flaky integration tests

### DIFF
--- a/lib/kamal/sshkit_with_ext.rb
+++ b/lib/kamal/sshkit_with_ext.rb
@@ -182,6 +182,7 @@ class SSHKit::Runner::Parallel
     def execute
       threads = hosts.map do |host|
         Thread.new(host) do |h|
+          Thread.current.report_on_exception = false
           backend(h, &block).run
         rescue ::StandardError => e
           e2 = SSHKit::Runner::ExecuteError.new e

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -856,7 +856,7 @@ class CliMainTest < CliTestCase
     def in_dummy_git_repo
       Dir.mktmpdir do |tmpdir|
         Dir.chdir(tmpdir) do
-          `git init`
+          `git init -q -b main`
           yield
         end
       end

--- a/test/configuration/ssh_test.rb
+++ b/test/configuration/ssh_test.rb
@@ -60,7 +60,8 @@ class ConfigurationSshTest < ActiveSupport::TestCase
 
   test "ssh key_data with plain value array" do
     config = Kamal::Configuration.new(@deploy.tap { |c| c.merge!(ssh: { "key_data" => [ "-----BEGIN OPENSSH PRIVATE KEY-----" ] }) })
-    assert_equal [ "-----BEGIN OPENSSH PRIVATE KEY-----" ], config.ssh.options[:key_data]
+    _out, err = capture_io { assert_equal [ "-----BEGIN OPENSSH PRIVATE KEY-----" ], config.ssh.options[:key_data] }
+    assert_match(/Inline key_data usage is deprecated/, err)
   end
 
   test "ssh key_data with array containing one secret string" do

--- a/test/integration/accessory_test.rb
+++ b/test/integration/accessory_test.rb
@@ -82,15 +82,22 @@ class AccessoryTest < IntegrationTest
     end
 
     def assert_netcat_is_up
-      response = netcat_response
-      debug_response_code(response, "200")
-      assert_equal "200", response.code
+      assert_equal "200", wait_for_netcat_response("200")
     end
 
     def assert_netcat_not_found
+      assert_equal "404", wait_for_netcat_response("404")
+    end
+
+    def wait_for_netcat_response(expected, timeout: 20)
+      timeout_at = Time.now + timeout
       response = netcat_response
-      debug_response_code(response, "404")
-      assert_equal "404", response.code
+      while response.code != expected && timeout_at > Time.now
+        sleep 0.1
+        response = netcat_response
+      end
+      debug_response_code(response, expected)
+      response.code
     end
 
     def netcat_response

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -25,6 +25,9 @@ services:
       - shared:/shared
       - deployer_bundle:/usr/local/bundle/
       - otel:/tmp/otel
+    depends_on:
+      shared:
+        condition: service_healthy
 
   registry:
     build:
@@ -36,6 +39,9 @@ services:
     volumes:
       - shared:/shared
       - registry:/var/lib/registry/
+    depends_on:
+      shared:
+        condition: service_healthy
 
   # Docker Hub pull-through cache. The deployer and vm inner daemons point their
   # registry-mirrors here (see their boot.sh), so base images (registry:3, nginx,
@@ -66,6 +72,9 @@ services:
       - shared:/shared
     ports:
       - "443"
+    depends_on:
+      shared:
+        condition: service_healthy
 
   vm2:
     privileged: true
@@ -73,6 +82,9 @@ services:
       context: docker/vm
     volumes:
       - shared:/shared
+    depends_on:
+      shared:
+        condition: service_healthy
 
   vm3:
     privileged: true
@@ -80,6 +92,9 @@ services:
       context: docker/vm
     volumes:
       - shared:/shared
+    depends_on:
+      shared:
+        condition: service_healthy
 
   otel_collector:
     build:

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -13,7 +13,7 @@ class IntegrationTest < ActiveSupport::TestCase
   setup do
     ENV["TEST_ID"] = SecureRandom.hex
     authenticate_hub_cache
-    docker_compose "up --build -d"
+    compose_up_with_retry
     wait_for_healthy
     setup_deployer
     deployer_exec("sh -c 'rm -f /tmp/otel/*.json /tmp/kamal-deploy-logs/*'", workdir: "/")
@@ -182,18 +182,60 @@ class IntegrationTest < ActiveSupport::TestCase
       assert_equal "200", code
     end
 
+    def compose_up_with_retry
+      docker_compose "up --build -d"
+    rescue RuntimeError => e
+      raise if @compose_up_retried
+      @compose_up_retried = true
+      puts "compose up failed, retrying once: #{e.message.lines.first&.strip}"
+      docker_compose "down -t 1", raise_on_error: false
+      retry
+    end
+
     def wait_for_healthy(timeout: 30)
       timeout_at = Time.now + timeout
       loop do
-        result = docker_compose("ps -a | tail -n +2 | grep -v '(healthy)' | wc -l", capture: true)
+        containers = container_statuses
 
-        break if result.split.last == "0" || result == "0"
+        break if containers.all? { |c| c["Health"] == "healthy" }
+
+        broken = containers.select do |c|
+          c["Health"] == "unhealthy" || %w[ exited dead restarting ].include?(c["State"])
+        end
+        if broken.any?
+          dump_container_logs(broken)
+          raise "Container hard error (retry will not help): #{describe_containers(broken)}"
+        end
 
         if timeout_at < Time.now
-          docker_compose("ps -a | tail -n +2 | grep -v '(healthy)'")
-          raise "Container not healthy after #{timeout} seconds" if timeout_at < Time.now
+          starting = containers.reject { |c| c["Health"] == "healthy" }
+          dump_container_logs(starting)
+          raise "Container not healthy after #{timeout} seconds (slow boot, retry may help): #{describe_containers(starting)}"
         end
         sleep 0.1
+      end
+    end
+
+    def container_statuses
+      output = docker_compose("ps -a --format json", capture: true).strip
+      return [] if output.empty?
+
+      if output.start_with?("[")
+        JSON.parse(output)
+      else
+        output.lines.map { |line| JSON.parse(line) }
+      end
+    end
+
+    def describe_containers(containers)
+      containers.map { |c| "#{c["Service"]} (state=#{c["State"]} health=#{c["Health"]} exit=#{c["ExitCode"]})" }.join(", ")
+    end
+
+    def dump_container_logs(containers)
+      containers.each do |c|
+        puts
+        puts "=== #{c["Service"]} (state=#{c["State"]} health=#{c["Health"]} exit=#{c["ExitCode"]}) ==="
+        puts docker_compose("logs --no-color --tail 50 #{c["Service"]}", capture: true, raise_on_error: false)
       end
     end
 

--- a/test/output/file_logger_test.rb
+++ b/test/output/file_logger_test.rb
@@ -5,10 +5,12 @@ class OutputFileLoggerTest < ActiveSupport::TestCase
   setup do
     @dir = Dir.mktmpdir
     @logger = Kamal::Output::FileLogger.new(path: @dir)
+    @original_stdout, $stdout = $stdout, StringIO.new
   end
 
   teardown do
     @logger.close
+    $stdout = @original_stdout
     FileUtils.rm_rf(@dir)
   end
 

--- a/test/output/otel_logger_test.rb
+++ b/test/output/otel_logger_test.rb
@@ -11,10 +11,12 @@ class OutputOtelLoggerTest < ActiveSupport::TestCase
     Kamal::OtelShipper.any_instance.stubs(:start_flush_thread)
     Kamal::OtelShipper.any_instance.stubs(:flush)
     @logger = Kamal::Output::OtelLogger.new(endpoint: "http://localhost:4318", tags: @tags, service: "myapp")
+    @original_stdout, $stdout = $stdout, StringIO.new
   end
 
   teardown do
     @logger.close
+    $stdout = @original_stdout
   end
 
   test "start event includes subcommand in command" do


### PR DESCRIPTION
- Silence expected error output in tests
- Make integration test timeout reasons clearer, so we can work out if we just need to bump the timeouts for github CI