### PR TITLE
CI: use overlay2 storage driver instead of vfs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,14 +76,14 @@ jobs:
           ruby-version: ${{ matrix.ruby-version }}
           bundler-cache: true
 
-      - name: Configure Docker with VFS storage driver
+      - name: Configure Docker with overlay2 storage driver
         run: |
           sudo systemctl stop docker
           sudo systemctl stop docker.socket
           sudo mkdir -p /etc/docker /mnt/docker
           cat <<'EOF' | sudo tee /etc/docker/daemon.json
           {
-            "storage-driver": "vfs",
+            "storage-driver": "overlay2",
             "data-root": "/mnt/docker"
           }
           EOF


### PR DESCRIPTION
We switched the runner to VFS in 7b55ad7a because Docker 29's containerd image store made the integration suite mount overlayfs on overlayfs: the suite runs dockerd inside containers (the deployer and VMs), and the inner overlay2 tried to layer on top of the runner's overlay2, which Linux does not support.

That nesting only happens for the inner dockerds, and they now set VFS themselves in their boot.sh. The runner's own dockerd is not nested, so it can go back to overlay2 and its copy-on-write instead of the full directory copies VFS makes for every layer and container.