### PR TITLE
Speed up integration tests: stack lifecycle, profiling, fuse-overlayfs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -178,6 +178,7 @@ GEM
       net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
       ostruct
+    stackprof (0.2.28)
     stringio (3.2.0)
     thor (1.4.0)
     tsort (0.2.0)
@@ -204,6 +205,7 @@ DEPENDENCIES
   mocha
   railties
   rubocop-rails-omakase
+  stackprof
 
 BUNDLED WITH
    2.6.5

--- a/kamal.gemspec
+++ b/kamal.gemspec
@@ -26,4 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "< 6"
   spec.add_development_dependency "mocha"
   spec.add_development_dependency "railties"
+  spec.add_development_dependency "stackprof"
 end

--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -14,7 +14,7 @@ RUN echo \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-RUN apt-get update --fix-missing && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+RUN apt-get update --fix-missing && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin fuse-overlayfs
 
 COPY . .
 

--- a/test/integration/docker/deployer/boot.sh
+++ b/test/integration/docker/deployer/boot.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 
-# Use the VFS storage driver: this dockerd runs inside a container whose root is
-# itself an overlay mount, and overlay-on-overlay fails on modern Docker/kernels.
-# VFS nests safely.
+# Use the fuse-overlayfs storage driver: this dockerd runs inside a container whose
+# root is itself an overlay mount, and native overlay2-on-overlay fails on modern
+# Docker/kernels. fuse-overlayfs gives copy-on-write layering over the overlay root
+# (unlike vfs, which deep-copies every layer), so builds/pulls/container-creates are
+# far cheaper. Needs /dev/fuse, available because the container is privileged.
 mkdir -p /etc/docker
 # Point this inner daemon at the hub-cache pull-through cache so Docker Hub base
 # images are fetched at most once per run instead of on every test.
 cat > /etc/docker/daemon.json <<'EOF'
 {
-  "storage-driver": "vfs",
+  "storage-driver": "fuse-overlayfs",
   "registry-mirrors": [ "http://hub-cache:5000" ],
   "insecure-registries": [ "hub-cache:5000" ]
 }

--- a/test/integration/docker/vm/Dockerfile
+++ b/test/integration/docker/vm/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 WORKDIR /work
 
-RUN apt-get update --fix-missing && apt-get -y install openssh-client openssh-server docker.io
+RUN apt-get update --fix-missing && apt-get -y install openssh-client openssh-server docker.io fuse-overlayfs
 
 COPY boot.sh .
 

--- a/test/integration/docker/vm/boot.sh
+++ b/test/integration/docker/vm/boot.sh
@@ -4,15 +4,17 @@ while [ ! -f /root/.ssh/authorized_keys ]; do echo "Waiting for ssh keys"; sleep
 
 service ssh restart
 
-# Use the VFS storage driver: this dockerd runs inside a container whose root is
-# itself an overlay mount, and overlay-on-overlay fails on modern Docker/kernels.
-# VFS nests safely.
+# Use the fuse-overlayfs storage driver: this dockerd runs inside a container whose
+# root is itself an overlay mount, and native overlay2-on-overlay fails on modern
+# Docker/kernels. fuse-overlayfs gives copy-on-write layering over the overlay root
+# (unlike vfs, which deep-copies every layer), so builds/pulls/container-creates are
+# far cheaper. Needs /dev/fuse, available because the container is privileged.
 mkdir -p /etc/docker
 # Point this inner daemon at the hub-cache pull-through cache so Docker Hub base
 # images are fetched at most once per run instead of on every test.
 cat > /etc/docker/daemon.json <<'EOF'
 {
-  "storage-driver": "vfs",
+  "storage-driver": "fuse-overlayfs",
   "registry-mirrors": [ "http://hub-cache:5000" ],
   "insecure-registries": [ "hub-cache:5000" ]
 }

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -10,12 +10,29 @@ class IntegrationTest < ActiveSupport::TestCase
   # so two suites can run concurrently without clashing on container/network/volume names.
   COMPOSE_PROJECT = "kamal-test-#{Digest::SHA256.hexdigest(File.expand_path("../..", __dir__))[0, 8]}"
 
+  # Opt-in phase timing (`PROFILE=1` or `STACKPROF=1 bin/test test/integration`). Stackprof
+  # attributes blocked time to the Ruby frame but can't see inside the `docker`/`ssh`
+  # subprocess; these monotonic-clock buckets attribute wall time to the docker phases
+  # (compose up, health wait, each kamal command, teardown) and print a suite-wide summary.
+  PROFILE_PHASES = ENV["PROFILE"].present? || ENV["STACKPROF"].present?
+  @@phase_totals = Hash.new { |hash, key| hash[key] = { time: 0.0, count: 0 } }
+
+  if PROFILE_PHASES
+    Minitest.after_run do
+      puts "\n=== Integration phase wall-time totals ==="
+      @@phase_totals.sort_by { |_, stats| -stats[:time] }.each do |phase, stats|
+        puts format("  %-24s %8.2fs  (%3d calls, %6.2fs avg)", phase, stats[:time], stats[:count], stats[:time] / stats[:count])
+      end
+      puts format("  %-24s %8.2fs", "TOTAL", @@phase_totals.values.sum { |stats| stats[:time] })
+    end
+  end
+
   setup do
     ENV["TEST_ID"] = SecureRandom.hex
     authenticate_hub_cache
-    compose_up_with_retry
-    wait_for_healthy
-    setup_deployer
+    time_phase(:compose_up) { compose_up_with_retry }
+    time_phase(:wait_healthy) { wait_for_healthy }
+    time_phase(:deployer_setup) { setup_deployer }
     deployer_exec("sh -c 'rm -f /tmp/otel/*.json /tmp/kamal-deploy-logs/*'", workdir: "/")
     # Host ports are published on ephemeral ports (collision-free across worktrees);
     # discover the ones Compose actually assigned.
@@ -32,10 +49,22 @@ class IntegrationTest < ActiveSupport::TestCase
         docker_compose :logs, container
       end
     end
-    docker_compose "down -t 1"
+    time_phase(:teardown_down) { docker_compose "down -t 0" }
   end
 
   private
+    def time_phase(name)
+      return yield unless PROFILE_PHASES
+      start = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      yield
+    ensure
+      if PROFILE_PHASES
+        stats = @@phase_totals[name.to_s]
+        stats[:time] += Process.clock_gettime(Process::CLOCK_MONOTONIC) - start
+        stats[:count] += 1
+      end
+    end
+
     def docker_compose(*commands, capture: false, raise_on_error: true)
       command = "TEST_ID=#{ENV["TEST_ID"]} COMPOSE_PROJECT_NAME=#{COMPOSE_PROJECT} docker compose #{commands.join(" ")}"
       succeeded = false
@@ -94,7 +123,7 @@ class IntegrationTest < ActiveSupport::TestCase
     end
 
     def kamal(*commands, **options)
-      deployer_exec(:kamal, *commands, **options)
+      time_phase("kamal:#{commands.first}") { deployer_exec(:kamal, *commands, **options) }
     end
 
     def assert_app_is_down
@@ -124,15 +153,17 @@ class IntegrationTest < ActiveSupport::TestCase
     end
 
     def wait_for_app_to_be_up(timeout: 20, up_count: 3)
-      timeout_at = Time.now + timeout
-      up_times = 0
-      response = app_response
-      while up_times < up_count && timeout_at > Time.now
-        sleep 0.1
-        up_times += 1 if response.code == "200"
+      time_phase(:app_wait) do
+        timeout_at = Time.now + timeout
+        up_times = 0
         response = app_response
+        while up_times < up_count && timeout_at > Time.now
+          sleep 0.1
+          up_times += 1 if response.code == "200"
+          response = app_response
+        end
+        assert_equal up_times, up_count
       end
-      assert_equal up_times, up_count
     end
 
     def app_response(app: @app, cert: nil)
@@ -183,13 +214,22 @@ class IntegrationTest < ActiveSupport::TestCase
     end
 
     def compose_up_with_retry
-      docker_compose "up --build -d"
+      build_images_once
+      docker_compose "up -d --no-build"
     rescue RuntimeError => e
       raise if @compose_up_retried
       @compose_up_retried = true
       puts "compose up failed, retrying once: #{e.message.lines.first&.strip}"
-      docker_compose "down -t 1", raise_on_error: false
+      docker_compose "down -t 0", raise_on_error: false
       retry
+    end
+
+    # The images don't change within a suite run, so build them once up front instead of
+    # re-resolving all of them on every test's `compose up`.
+    def build_images_once
+      return if $IMAGES_BUILT
+      docker_compose "build"
+      $IMAGES_BUILT = true
     end
 
     def wait_for_healthy(timeout: 30)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -10,6 +10,23 @@ require "minitest/autorun" # using #stub that take args
 require "sshkit"
 require "kamal"
 
+# Opt-in wall-clock profiling for the (mostly shell-out-bound) integration suite.
+# `STACKPROF=1 bin/test test/integration` then `stackprof tmp/stackprof-integration.dump --text`.
+# Wall mode samples on a wall-clock timer that fires during the blocking `docker`/`ssh`
+# system() calls, attributing them to the calling helper. Off by default — zero impact otherwise.
+if ENV["STACKPROF"]
+  require "stackprof"
+  require "fileutils"
+  StackProf.start(mode: :wall, raw: true, interval: 1000)
+  Minitest.after_run do
+    StackProf.stop
+    FileUtils.mkdir_p("tmp")
+    File.write("tmp/stackprof-integration.dump", Marshal.dump(StackProf.results))
+    puts "\nStackProf wall profile written to tmp/stackprof-integration.dump"
+    puts "Analyze with: stackprof tmp/stackprof-integration.dump --text"
+  end
+end
+
 ActiveSupport::LogSubscriber.logger = ActiveSupport::Logger.new(STDOUT) if ENV["VERBOSE"]
 
 # Applies to remote commands only.


### PR DESCRIPTION
Speeds up the integration suite and adds the opt-in profiling used to find the wins. Two commits:

### 1. Stack lifecycle + opt-in profiling
The suite spent ~35% of its wall time bringing the 8-service Compose stack up/down once per test. Profiled with stackprof in wall mode (the suite is ~93% blocked in docker/ssh shellouts, so wall mode is the right tool):

- `down -t 1` → `down -t 0` (graceful stop is wasted on throwaway containers): teardown 55s → 22s across the suite
- build images once per run, then `up -d --no-build` instead of `up --build` every test: 43s → 34s

Adds opt-in tooling, off by default:
- `STACKPROF=1` wraps the run in a wall-mode profile dumped to `tmp/`
- `PROFILE=1` prints per-phase wall-time totals (compose up, health wait, each kamal command, teardown)

### 2. fuse-overlayfs for the nested daemons
The deployer/vm dockerds run inside a container whose root is an overlay mount, so native overlay2 can't be used and we fell back to **vfs**, which deep-copies the whole rootfs per layer. **fuse-overlayfs** gives real copy-on-write over the overlay root via FUSE (needs `/dev/fuse`, present because these containers are already privileged).

### Measured (local, warm cache)
6m23s → 5m19s (lifecycle) → **4m55s** (fuse-overlayfs), ~23% total. All 17 integration tests pass.

The fuse-overlayfs gain is modest (~8%) because the fixture images are tiny; it concentrates in the layer-writing phases (deploy, setup, redeploy, proxy). **Main thing to confirm here: that `/dev/fuse` is available to the privileged nested containers on GitHub Actions runners.**

CI caching (GHA layer cache + matrix split so integration doesn't build/run 7×) will follow in a separate PR.