### PR TITLE
Speed up integration tests

### DIFF
--- a/test/integration/docker/deployer/Dockerfile
+++ b/test/integration/docker/deployer/Dockerfile
@@ -14,7 +14,7 @@ RUN echo \
   "$(. /etc/os-release && echo "$VERSION_CODENAME")" stable" | \
   tee /etc/apt/sources.list.d/docker.list > /dev/null
 
-RUN apt-get update --fix-missing && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+RUN apt-get update --fix-missing && apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin fuse-overlayfs
 
 COPY . .
 

--- a/test/integration/docker/deployer/boot.sh
+++ b/test/integration/docker/deployer/boot.sh
@@ -1,14 +1,14 @@
 #!/bin/bash
 
-# Use the VFS storage driver: this dockerd runs inside a container whose root is
-# itself an overlay mount, and overlay-on-overlay fails on modern Docker/kernels.
-# VFS nests safely.
+# This dockerd's root is itself an overlay mount, so overlay2 can't nest. Use
+# fuse-overlayfs for copy-on-write (vfs, the other option that nests, deep-copies
+# every layer). /dev/fuse is available because the container is privileged.
 mkdir -p /etc/docker
 # Point this inner daemon at the hub-cache pull-through cache so Docker Hub base
 # images are fetched at most once per run instead of on every test.
 cat > /etc/docker/daemon.json <<'EOF'
 {
-  "storage-driver": "vfs",
+  "storage-driver": "fuse-overlayfs",
   "registry-mirrors": [ "http://hub-cache:5000" ],
   "insecure-registries": [ "hub-cache:5000" ]
 }

--- a/test/integration/docker/vm/Dockerfile
+++ b/test/integration/docker/vm/Dockerfile
@@ -2,7 +2,7 @@ FROM ubuntu:22.04
 
 WORKDIR /work
 
-RUN apt-get update --fix-missing && apt-get -y install openssh-client openssh-server docker.io
+RUN apt-get update --fix-missing && apt-get -y install openssh-client openssh-server docker.io fuse-overlayfs
 
 COPY boot.sh .
 

--- a/test/integration/docker/vm/boot.sh
+++ b/test/integration/docker/vm/boot.sh
@@ -4,15 +4,15 @@ while [ ! -f /root/.ssh/authorized_keys ]; do echo "Waiting for ssh keys"; sleep
 
 service ssh restart
 
-# Use the VFS storage driver: this dockerd runs inside a container whose root is
-# itself an overlay mount, and overlay-on-overlay fails on modern Docker/kernels.
-# VFS nests safely.
+# This dockerd's root is itself an overlay mount, so overlay2 can't nest. Use
+# fuse-overlayfs for copy-on-write (vfs, the other option that nests, deep-copies
+# every layer). /dev/fuse is available because the container is privileged.
 mkdir -p /etc/docker
 # Point this inner daemon at the hub-cache pull-through cache so Docker Hub base
 # images are fetched at most once per run instead of on every test.
 cat > /etc/docker/daemon.json <<'EOF'
 {
-  "storage-driver": "vfs",
+  "storage-driver": "fuse-overlayfs",
   "registry-mirrors": [ "http://hub-cache:5000" ],
   "insecure-registries": [ "hub-cache:5000" ]
 }

--- a/test/integration/integration_test.rb
+++ b/test/integration/integration_test.rb
@@ -32,7 +32,7 @@ class IntegrationTest < ActiveSupport::TestCase
         docker_compose :logs, container
       end
     end
-    docker_compose "down -t 1"
+    docker_compose "down -t 0"
   end
 
   private
@@ -183,13 +183,20 @@ class IntegrationTest < ActiveSupport::TestCase
     end
 
     def compose_up_with_retry
-      docker_compose "up --build -d"
+      build_images_once
+      docker_compose "up -d --no-build"
     rescue RuntimeError => e
       raise if @compose_up_retried
       @compose_up_retried = true
       puts "compose up failed, retrying once: #{e.message.lines.first&.strip}"
-      docker_compose "down -t 1", raise_on_error: false
+      docker_compose "down -t 0", raise_on_error: false
       retry
+    end
+
+    def build_images_once
+      return if $IMAGES_BUILT
+      docker_compose "build"
+      $IMAGES_BUILT = true
     end
 
     def wait_for_healthy(timeout: 30)


### PR DESCRIPTION
- Only build images once per run
- Switch to fuse-overlayfs from vfs