### PR TITLE
Warn when .kamal/secrets uses unsupported ${VAR:-default} expansion

### DIFF
--- a/lib/kamal/secrets.rb
+++ b/lib/kamal/secrets.rb
@@ -3,6 +3,14 @@ require "dotenv"
 class Kamal::Secrets
   Kamal::Secrets::Dotenv::InlineCommandSubstitution.install!
 
+  # Bash parameter-expansion operators (e.g. ${VAR:-default}, ${VAR:?error}) that
+  # the dotenv parser does not support. dotenv substitutes the variable name and
+  # leaves the operator and default portion in the value verbatim, so we warn the
+  # user rather than letting it happen silently. Plain ${VAR} and $(command) are
+  # fine, and a backslash-escaped \${...} is treated as a literal by dotenv. The
+  # /n flag keeps matching safe on files that contain non-UTF-8 bytes.
+  UNSUPPORTED_EXPANSION = /(?<!\\)\$\{[A-Za-z_][A-Za-z0-9_]*:?[-+?=]/n
+
   def initialize(destination: nil, secrets_path: ".kamal/secrets")
     @destination = destination
     @secrets_path = secrets_path
@@ -36,8 +44,19 @@ class Kamal::Secrets
   private
     def secrets
       @secrets ||= secrets_files.inject({}) do |secrets, secrets_file|
+        warn_on_unsupported_expansion(secrets_file)
         secrets.merge!(::Dotenv.parse(secrets_file, overwrite: true))
       end
+    end
+
+    def warn_on_unsupported_expansion(secrets_file)
+      offending = File.binread(secrets_file).each_line.any? do |line|
+        next false if line.match?(/\A\s*#/n)
+        line.match?(UNSUPPORTED_EXPANSION)
+      end
+      return unless offending
+
+      warn "Kamal secrets: #{secrets_file} uses ${VAR:-default}-style bash parameter expansion, which the secrets parser does not support. Only the variable name is substituted; the rest of the expression (e.g. ':-default}') is left in the value verbatim. Use a plain ${VAR} reference or compute the value with $(command) instead."
     end
 
     def secrets_filenames

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -33,6 +33,34 @@ class SecretsTest < ActiveSupport::TestCase
     end
   end
 
+  test "warns on unsupported parameter expansion" do
+    with_test_secrets("secrets" => "FOO=${BAR:-baz}") do
+      _, stderr = capture_io do
+        Kamal::Secrets.new(secrets_path: ".kamal/secrets").to_h
+      end
+      assert_match(/uses \$\{VAR:-default\}-style bash parameter expansion/, stderr)
+      assert_match(/\.kamal\/secrets/, stderr)
+    end
+  end
+
+  test "does not warn on supported expansions" do
+    with_test_secrets("secrets" => "FOO=bar\nBAZ=${FOO}\nQ=$(echo hi)") do
+      _, stderr = capture_io do
+        Kamal::Secrets.new(secrets_path: ".kamal/secrets").to_h
+      end
+      assert_equal "", stderr
+    end
+  end
+
+  test "does not warn on commented or escaped expansions" do
+    with_test_secrets("secrets" => "# FOO=${BAR:-baz}\nQUX=\\${BAR:-baz}") do
+      _, stderr = capture_io do
+        Kamal::Secrets.new(secrets_path: ".kamal/secrets").to_h
+      end
+      assert_equal "", stderr
+    end
+  end
+
   test "env references" do
     with_test_secrets("secrets" => "SECRET1=$SECRET1") do
       ENV["SECRET1"] = "ABC"


### PR DESCRIPTION
## Problem

`.kamal/secrets` files are parsed with the `dotenv` gem (`::Dotenv.parse(secrets_file, overwrite: true)` in `lib/kamal/secrets.rb`). dotenv's variable substitution supports `$VAR` and `${VAR}`, but **not** bash parameter-expansion defaults like `${VAR:-fallback}`.

dotenv's substitution regex matches only the `${VAR` part, substitutes `VAR`, and leaves the literal `:-fallback}` in the value — silently, with no error or warning. So a line like:

```
KAMAL_REGISTRY_PASSWORD=${REGISTRY_TOKEN:-ghp_abc123}
```

produces a broken value (e.g. `:-ghp_abc123}` when `REGISTRY_TOKEN` is unset, or `<token>:-ghp_abc123}` when it is set). The user then hits a confusing `docker login` failure:

```
Error response from daemon: login attempt ... failed with status: 401 Unauthorized
denied
```

with no hint that the secret value was mangled by an unsupported expansion.

Note that Kamal's own `Kamal::Secrets::Dotenv::InlineCommandSubstitution` handles `$(...)` command substitution, but nothing handles `${...}` parameter expansion, so this failure mode is easy to fall into.

## What this PR does

This PR **only adds a warning** — there is no behavior change and no new expansion support. When a secrets file contains an unsupported `${VAR:-default}`-style parameter expansion, Kamal now prints a clear, actionable warning naming the file and explaining that the expression will be used literally:

```
Kamal secrets: .kamal/secrets uses ${VAR:-default}-style bash parameter expansion,
which the secrets parser does not support. The expression will be left in the value
verbatim. Use a plain ${VAR} reference or compute the value with $(command) instead.
```

## Detection approach

Detection is a regex over the raw file content, run before parsing:

```ruby
UNSUPPORTED_EXPANSION = /\$\{[A-Za-z_][A-Za-z0-9_]*:?[-+?=]/
```

This matches the unsupported operators (`:-`, `-`, `:?`, `:+`, `:=`, etc.) inside `${...}`, while deliberately **not** matching the supported constructs:

- plain `$VAR`
- plain `${VAR}`
- `$(command)` command substitution

The warning uses `Kernel#warn` (to `$stderr`), consistent with the existing deprecation warning in `Kamal::Configuration::Ssh`.

This complements the existing secrets DX papercuts that Kamal already smooths over (e.g. inline command substitution).

## Tests

Added two tests in `test/secrets_test.rb`:

- a secrets file containing `FOO=${BAR:-baz}` emits the warning
- a normal secrets file (`FOO=bar`, `BAZ=${FOO}`, `Q=$(echo hi)`) emits no warning
