### PR TITLE
Reconcile mutually-exclusive keys across merged config layers

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -29,9 +29,59 @@ class Kamal::Configuration
       load_config_files(config_file, *destination_config_file(config_file, destination))
     end
 
+    # Keys a config section may only set one of. The proxy uses host/hosts;
+    # accessories add role/roles/tag/tags (see Validator::Proxy and
+    # Validator::Accessory). When a later layer picks a different key from this
+    # set than the base did, deep_merge would leave both behind and trip the
+    # validator, so we drop the base's keys first.
+    MUTUALLY_EXCLUSIVE_KEYS = %w[ host hosts role roles tag tags ].freeze
+
     private
       def load_config_files(*files)
-        files.inject({}) { |config, file| config.deep_merge! load_config_file(file) }
+        files.inject({}) { |config, file| deep_merge_layer(config, load_config_file(file)) }
+      end
+
+      # Deep merges the next config layer on top of the accumulated config,
+      # reconciling any section that picks a different mutually-exclusive key
+      # than the base before merging.
+      def deep_merge_layer(config, overrides)
+        config = reconcile_mutually_exclusive_keys(config, overrides)
+        config.deep_merge(overrides)
+      end
+
+      # Reconciles the proxy and every accessory section so an override layer
+      # that switches mutually-exclusive keys (e.g. host -> hosts) wins cleanly.
+      # symbolize_keys is shallow, so only the top-level :proxy/:accessories
+      # keys are symbols; the nested host/hosts/... keys are string-keyed.
+      def reconcile_mutually_exclusive_keys(config, overrides)
+        if config[:proxy].is_a?(Hash) && overrides[:proxy].is_a?(Hash)
+          config = config.merge(proxy: reconcile_section(config[:proxy], overrides[:proxy]))
+        end
+
+        if config[:accessories].is_a?(Hash) && overrides[:accessories].is_a?(Hash)
+          accessories = config[:accessories].to_h do |name, accessory|
+            override = overrides[:accessories][name]
+            accessory = reconcile_section(accessory, override) if accessory.is_a?(Hash) && override.is_a?(Hash)
+            [ name, accessory ]
+          end
+          config = config.merge(accessories: accessories)
+        end
+
+        config
+      end
+
+      # Drops the base section's mutually-exclusive keys when the override sets
+      # a different one from the same set, so the merged section keeps only the
+      # override's choice.
+      def reconcile_section(base, override)
+        base_keys = base.keys & MUTUALLY_EXCLUSIVE_KEYS
+        override_keys = override.keys & MUTUALLY_EXCLUSIVE_KEYS
+
+        if override_keys.any? && (base_keys - override_keys).any?
+          base.except(*base_keys)
+        else
+          base
+        end
       end
 
       def load_config_file(file)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -267,6 +267,27 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal "1.1.1.3", config.all_hosts.first
   end
 
+  test "destination yml proxy hosts overrides base proxy host" do
+    dest_config_file = Pathname.new(File.expand_path("fixtures/deploy_with_proxy_host_for_dest.yml", __dir__))
+
+    config = Kamal::Configuration.create_from config_file: dest_config_file, destination: "world"
+    assert_equal [ "myapp.dev", "files.myapp.dev" ], config.proxy.hosts
+  end
+
+  test "destination yml proxy host overrides base proxy hosts" do
+    dest_config_file = Pathname.new(File.expand_path("fixtures/deploy_with_proxy_hosts_for_dest.yml", __dir__))
+
+    config = Kamal::Configuration.create_from config_file: dest_config_file, destination: "world"
+    assert_equal [ "myapp.dev" ], config.proxy.hosts
+  end
+
+  test "destination yml accessory roles overrides base accessory host" do
+    dest_config_file = Pathname.new(File.expand_path("fixtures/deploy_with_accessory_host_for_dest.yml", __dir__))
+
+    config = Kamal::Configuration.create_from config_file: dest_config_file, destination: "world"
+    assert_equal [ "1.1.1.1" ], config.accessory(:mysql).hosts
+  end
+
   test "destination yml config file missing" do
     dest_config_file = Pathname.new(File.expand_path("fixtures/deploy_for_dest.yml", __dir__))
 

--- a/test/fixtures/deploy_with_accessory_host_for_dest.world.yml
+++ b/test/fixtures/deploy_with_accessory_host_for_dest.world.yml
@@ -1,0 +1,4 @@
+accessories:
+  mysql:
+    roles:
+      - web

--- a/test/fixtures/deploy_with_accessory_host_for_dest.yml
+++ b/test/fixtures/deploy_with_accessory_host_for_dest.yml
@@ -1,0 +1,14 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - 1.1.1.1
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64
+accessories:
+  mysql:
+    image: mysql:5.7
+    host: 1.1.1.9

--- a/test/fixtures/deploy_with_proxy_host_for_dest.world.yml
+++ b/test/fixtures/deploy_with_proxy_host_for_dest.world.yml
@@ -1,0 +1,6 @@
+servers:
+  - 1.1.1.1
+proxy:
+  hosts:
+    - myapp.dev
+    - files.myapp.dev

--- a/test/fixtures/deploy_with_proxy_host_for_dest.yml
+++ b/test/fixtures/deploy_with_proxy_host_for_dest.yml
@@ -1,0 +1,10 @@
+service: app
+image: dhh/app
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64
+proxy:
+  ssl: false
+  host: myapp.dev

--- a/test/fixtures/deploy_with_proxy_hosts_for_dest.world.yml
+++ b/test/fixtures/deploy_with_proxy_hosts_for_dest.world.yml
@@ -1,0 +1,4 @@
+servers:
+  - 1.1.1.1
+proxy:
+  host: myapp.dev

--- a/test/fixtures/deploy_with_proxy_hosts_for_dest.yml
+++ b/test/fixtures/deploy_with_proxy_hosts_for_dest.yml
@@ -1,0 +1,12 @@
+service: app
+image: dhh/app
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64
+proxy:
+  ssl: false
+  hosts:
+    - myapp.dev
+    - files.myapp.dev


### PR DESCRIPTION
## What

Reported for the proxy in #1832: set `proxy.host` in `deploy.yml` and `proxy.hosts` in `deploy.<dest>.yml`, and the deploy fails with *"Specify one of 'host' or 'hosts', not both."* The two config layers merge into a single section that holds both keys.

## Why it happens

`load_config_files` deep-merges each layer onto the previous one. Deep merge is additive: when a later layer sets a *different* key from a mutually-exclusive set than the base did, both keys survive — even though the override plainly meant to replace the choice.

The proxy isn't the only section with such a set. `Validator::Accessory` requires exactly one of `host`, `hosts`, `role`, `roles`, `tag`, or `tags`, so an accessory that switches keys across layers hits the same bug from the same cause.

## How

Before merging each layer, reconcile the mutually-exclusive keys: when the incoming layer picks a different key from the set than the base, drop the base's key first. One `MUTUALLY_EXCLUSIVE_KEYS` constant and a small `reconcile_section` helper cover both the proxy and every accessory, so `load_config_files` stays a thin merge.

(`symbolize_keys` is shallow, so the top-level `:proxy`/`:accessories` keys are symbols while the nested `host`/`hosts`/… keys are strings; the reconciliation accounts for that.)

## Tests

New fixtures and cases cover a destination override that switches:

- proxy `host` → `hosts`, and `hosts` → `host`
- an accessory `host` → `roles`

Each merges cleanly and passes validation; each fails on `main`.

Closes #1832.
