### PR TITLE
Add proxy.run.http3 option to enable HTTP/3 (QUIC)

### DIFF
--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -157,6 +157,7 @@ proxy:
     https_port: 8443               # HTTPS port to use (default 443)
     metrics_port: 9090             # Port for Prometheus metrics
     debug: true                    # Debug logging (default: false)
+    http3: true                    # Enable HTTP/3 (QUIC); also publishes the HTTPS port over UDP (default: false)
     log_max_size: "30m"            # Maximum log file size (default: "10m")
     publish: false                 # Publish ports to the host (default: true)
     bind_ips:                      # List of IPs to bind to when publishing ports

--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -21,6 +21,10 @@ class Kamal::Configuration::Proxy::Run
     run_config.fetch("publish", true)
   end
 
+  def http3?
+    run_config.fetch("http3", false)
+  end
+
   def http_port
     run_config.fetch("http_port", DEFAULT_HTTP_PORT)
   end
@@ -40,7 +44,11 @@ class Kamal::Configuration::Proxy::Run
         publish_http = [ bind_ip, http_port, DEFAULT_HTTP_PORT ].compact.join(":")
         publish_https = [ bind_ip, https_port, DEFAULT_HTTPS_PORT ].compact.join(":")
 
-        argumentize "--publish", [ publish_http, publish_https ]
+        ports = [ publish_http, publish_https ]
+        # HTTP/3 (QUIC) runs over UDP on the HTTPS port, so it needs its own publish mapping.
+        ports << "#{publish_https}/udp" if http3?
+
+        argumentize "--publish", ports
       end.join(" ")
     end
   end
@@ -88,7 +96,7 @@ class Kamal::Configuration::Proxy::Run
   end
 
   def run_command_options
-    { debug: debug? || nil, "metrics-port": metrics_port }.compact
+    { debug: debug? || nil, "metrics-port": metrics_port, http3: (true if http3?) }.compact
   end
 
   def docker_options_args

--- a/lib/kamal/configuration/validator/proxy.rb
+++ b/lib/kamal/configuration/validator/proxy.rb
@@ -30,6 +30,10 @@ class Kamal::Configuration::Validator::Proxy < Kamal::Configuration::Validator
           if run_config["bind_ips"].present? || run_config["http_port"].present? || run_config["https_port"].present?
             error "Cannot set http_port, https_port or bind_ips when publish is false"
           end
+
+          if run_config["http3"]
+            error "Cannot enable http3 when publish is false"
+          end
         end
       end
     end

--- a/test/configuration/proxy/run_test.rb
+++ b/test/configuration/proxy/run_test.rb
@@ -56,6 +56,31 @@ class ConfigurationProxyRunTest < ActiveSupport::TestCase
     assert config
   end
 
+  test "http3 is disabled by default" do
+    config = Kamal::Configuration.new(base_deploy)
+    run = Kamal::Configuration::Proxy::Run.new(config, run_config: {})
+
+    assert_not run.http3?
+    assert_equal "--publish 80:80 --publish 443:443", run.publish_args
+    assert_not_includes run.run_command, "--http3"
+  end
+
+  test "http3 adds --http3 and publishes the https port over udp" do
+    config = Kamal::Configuration.new(base_deploy)
+    run = Kamal::Configuration::Proxy::Run.new(config, run_config: { "http3" => true })
+
+    assert run.http3?
+    assert_equal "--publish 80:80 --publish 443:443 --publish 443:443/udp", run.publish_args
+    assert_includes run.run_command, "--http3"
+  end
+
+  test "http3 udp publish honors a custom https port" do
+    config = Kamal::Configuration.new(base_deploy)
+    run = Kamal::Configuration::Proxy::Run.new(config, run_config: { "http3" => true, "https_port" => 8443 })
+
+    assert_equal "--publish 80:80 --publish 8443:443 --publish 8443:443/udp", run.publish_args
+  end
+
   private
     def base_deploy
       {

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -105,6 +105,11 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
     end
   end
 
+  test "http3 cannot be enabled when publish is false" do
+    @deploy[:proxy] = { "host" => "example.com", "run" => { "publish" => false, "http3" => true } }
+    assert_raises(Kamal::ConfigurationError) { config.proxy }
+  end
+
   private
     def config
       Kamal::Configuration.new(@deploy)


### PR DESCRIPTION
## Why

`kamal-proxy` has supported HTTP/3 since [#149](https://github.com/basecamp/kamal-proxy/pull/149) via its `--http3` flag, but Kamal has no way to turn it on:

1. The flag is never passed to `kamal-proxy run`, and
2. the proxy container only publishes **TCP** `80`/`443`, so the QUIC listener on **UDP 443** is unreachable from outside the container.

As a result there's no supported way to serve HTTP/3 with a Kamal-managed proxy. This addresses the HTTP/3 half of #1842.

## What

Adds a `proxy.run.http3` boolean. When enabled, Kamal:

- passes `--http3` to `kamal-proxy run`, and
- additionally publishes the HTTPS port over UDP (e.g. `--publish 443:443/udp`, honouring a custom `https_port`).

```yaml
proxy:
  run:
    http3: true
```

Validation rejects `http3: true` when `publish: false` (there are no host ports to publish).

## Tests

- `test/configuration/proxy/run_test.rb`: `--http3` present and `443:443/udp` published when enabled; absent by default; custom `https_port` reflected in the UDP mapping.
- `test/configuration/proxy_test.rb`: validation error for `http3` + `publish: false`.

All `test/configuration` + `test/cli/proxy_test.rb` pass; RuboCop clean.

## Verification

Verified end-to-end against `basecamp/kamal-proxy:v0.9.2` (the current pinned minimum, which already ships `--http3`):

- Local: proxy booted with `run --http3` + `--publish …/udp`, an HTTP/3 client negotiates `HTTP/3 200` and the response advertises `alt-svc: h3=":443"`.
- Production: rolled out to a live single-droplet deployment — `curl --http3-only` returns `HTTP/3 200`, paired with an HTTPS/SVCB DNS record (`alpn="h3,h2"`) for HTTP/3 on the first connection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
