### PR TITLE
Preserve destination config file extensions

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -47,7 +47,8 @@ class Kamal::Configuration
       end
 
       def destination_config_file(base_config_file, destination)
-        base_config_file.sub_ext(".#{destination}.yml") if destination
+        extension = base_config_file.extname.presence || ".yml"
+        base_config_file.sub_ext(".#{destination}#{extension}") if destination
       end
   end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -267,6 +267,14 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal "1.1.1.3", config.all_hosts.first
   end
 
+  test "destination yaml config merge" do
+    dest_config_file = Pathname.new(File.expand_path("fixtures/deploy_for_dest_yaml.yaml", __dir__))
+
+    config = Kamal::Configuration.create_from config_file: dest_config_file, destination: "world"
+    assert_equal "1.1.1.3", config.all_hosts.first
+    assert_equal "redis://a/b", config.env.clear["REDIS_URL"]
+  end
+
   test "destination yml config file missing" do
     dest_config_file = Pathname.new(File.expand_path("fixtures/deploy_for_dest.yml", __dir__))
 

--- a/test/fixtures/deploy_for_dest_yaml.world.yaml
+++ b/test/fixtures/deploy_for_dest_yaml.world.yaml
@@ -1,0 +1,5 @@
+servers:
+  - 1.1.1.3
+  - 1.1.1.4
+env:
+  REDIS_URL: redis://a/b

--- a/test/fixtures/deploy_for_dest_yaml.yaml
+++ b/test/fixtures/deploy_for_dest_yaml.yaml
@@ -1,0 +1,13 @@
+service: app
+image: dhh/app
+registry:
+  server: registry.digitalocean.com
+  username: <%= "my-user" %>
+  password: <%= "my-password" %>
+builder:
+  arch: amd64
+servers:
+  - 1.1.1.1
+  - 1.1.1.2
+env:
+  REDIS_URL: redis://x/y


### PR DESCRIPTION
## Summary
- Preserve the base config file extension when loading destination-specific config files.
- Keep the existing no-extension fallback on .yml.
- Add regression coverage for a .yaml base config with a matching destination file.

Fixes #1630.

## Testing
- docker run --rm -v "$PWD":/src:ro -w /tmp ruby:3.3 bash -lc 'cp -a /src work && cd work && rm -f Gemfile.lock && gem install bundler:2.6.5 --no-document >/dev/null && bundle install >/tmp/bundle-install.log && bundle exec ruby -Itest test/configuration_test.rb && bundle exec rubocop lib/kamal/configuration.rb test/configuration_test.rb'