### PR TITLE
Fix proxy host overrides in destination configs

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -31,7 +31,11 @@ class Kamal::Configuration
 
     private
       def load_config_files(*files)
-        files.inject({}) { |config, file| config.deep_merge! load_config_file(file) }
+        files.inject({}) do |config, file|
+          file_config = load_config_file(file)
+          remove_replaced_proxy_host_keys(config, file_config)
+          config.deep_merge! file_config
+        end
       end
 
       def load_config_file(file)
@@ -48,6 +52,28 @@ class Kamal::Configuration
 
       def destination_config_file(base_config_file, destination)
         base_config_file.sub_ext(".#{destination}.yml") if destination
+      end
+
+      def remove_replaced_proxy_host_keys(config, override)
+        return unless config.is_a?(Hash) && override.is_a?(Hash)
+
+        override.each do |key, value|
+          existing = config[key]
+
+          if key.to_s == "proxy" && existing.is_a?(Hash) && value.is_a?(Hash)
+            remove_replaced_key(existing, value, "host", "hosts")
+          end
+
+          remove_replaced_proxy_host_keys(existing, value)
+        end
+      end
+
+      def remove_replaced_key(config, override, key, alternate_key)
+        if override.key?(key)
+          config.delete(alternate_key)
+        elsif override.key?(alternate_key)
+          config.delete(key)
+        end
       end
   end
 

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "pathname"
 
 class ConfigurationProxyTest < ActiveSupport::TestCase
   setup do
@@ -31,6 +32,54 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
   test "ssl with both host and hosts" do
     @deploy[:proxy] = { "ssl" => true, host: "example.com", hosts: [ "anotherexample.com" ] }
     assert_raises(Kamal::ConfigurationError) { config.proxy.ssl? }
+  end
+
+  test "destination hosts replace base host" do
+    configuration = config_from_files <<~YAML, <<~YAML
+      service: app
+      image: dhh/app
+      servers:
+        - 1.1.1.1
+      registry:
+        username: dhh
+        password: secret
+      builder:
+        arch: amd64
+      proxy:
+        ssl: false
+        host: myapp.dev
+    YAML
+      proxy:
+        hosts:
+          - myapp.dev
+          - files.myapp.dev
+    YAML
+
+    assert_equal [ "myapp.dev", "files.myapp.dev" ], configuration.proxy.hosts
+  end
+
+  test "destination host replaces base hosts" do
+    configuration = config_from_files <<~YAML, <<~YAML
+      service: app
+      image: dhh/app
+      servers:
+        - 1.1.1.1
+      registry:
+        username: dhh
+        password: secret
+      builder:
+        arch: amd64
+      proxy:
+        ssl: false
+        hosts:
+          - myapp.dev
+          - files.myapp.dev
+    YAML
+      proxy:
+        host: myapp.dev
+    YAML
+
+    assert_equal [ "myapp.dev" ], configuration.proxy.hosts
   end
 
   test "ssl false" do
@@ -108,5 +157,19 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
   private
     def config
       Kamal::Configuration.new(@deploy)
+    end
+
+    def config_from_files(base_config, destination_config)
+      original_destination = ENV["KAMAL_DESTINATION"]
+
+      Dir.mktmpdir do |dir|
+        config_file = Pathname.new(File.join(dir, "deploy.yml"))
+        File.write(config_file, base_config)
+        File.write(config_file.sub_ext(".staging.yml"), destination_config)
+
+        Kamal::Configuration.create_from(config_file: config_file, destination: "staging")
+      end
+    ensure
+      ENV["KAMAL_DESTINATION"] = original_destination
     end
 end


### PR DESCRIPTION
## Summary
- Allows destination config files to replace `proxy.host` with `proxy.hosts`, or the reverse, without leaving both keys in the merged config.
- Preserves the validation error for configs that set both keys in the same proxy config.
- Adds regression coverage for both destination override directions.

Fixes #1832.

## Testing
- `bundle _2.6.5_ exec ruby -Itest test/configuration/proxy_test.rb` in a `ruby:3.4` container
- `bundle _2.6.5_ exec ruby -Itest test/configuration/validation_test.rb` in a `ruby:3.4` container
- `git diff --check`