### PR TITLE
Keep tagged image pruning best effort

### DIFF
--- a/lib/kamal/commands/prune.rb
+++ b/lib/kamal/commands/prune.rb
@@ -10,7 +10,7 @@ class Kamal::Commands::Prune < Kamal::Commands::Base
     pipe \
       docker(:image, :ls, *service_filter, "--format", "'{{.ID}} {{.Repository}}:{{.Tag}}'"),
       grep("-v -w \"#{active_image_list}\""),
-      "while read image tag; do docker rmi $tag; done"
+      "while read image tag; do docker rmi $tag || true; done"
   end
 
   def app_containers(retain:)

--- a/test/cli/prune_test.rb
+++ b/test/cli/prune_test.rb
@@ -11,7 +11,7 @@ class CliPruneTest < CliTestCase
   test "images" do
     run_command("images").tap do |output|
       assert_match "docker image prune --force --filter label=service=app on 1.1.1.", output
-      assert_match "docker image ls --filter label=service=app --format '{{.ID}} {{.Repository}}:{{.Tag}}' | grep -v -w \"$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=app | tr -d '\\n')dhh/app:latest\\|dhh/app:<none>\" | while read image tag; do docker rmi $tag; done on 1.1.1.", output
+      assert_match "docker image ls --filter label=service=app --format '{{.ID}} {{.Repository}}:{{.Tag}}' | grep -v -w \"$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=app | tr -d '\\n')dhh/app:latest\\|dhh/app:<none>\" | while read image tag; do docker rmi $tag || true; done on 1.1.1.", output
     end
   end
 

--- a/test/commands/prune_test.rb
+++ b/test/commands/prune_test.rb
@@ -16,7 +16,7 @@ class CommandsPruneTest < ActiveSupport::TestCase
 
   test "tagged images" do
     assert_equal \
-      "docker image ls --filter label=service=app --format '{{.ID}} {{.Repository}}:{{.Tag}}' | grep -v -w \"$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=app | tr -d '\\n')dhh/app:latest\\|dhh/app:<none>\" | while read image tag; do docker rmi $tag; done",
+      "docker image ls --filter label=service=app --format '{{.ID}} {{.Repository}}:{{.Tag}}' | grep -v -w \"$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=app | tr -d '\\n')dhh/app:latest\\|dhh/app:<none>\" | while read image tag; do docker rmi $tag || true; done",
       new_command.tagged_images.join(" ")
   end
 


### PR DESCRIPTION
## Summary

- Keep tagged image pruning best effort when Docker rejects an image removal.
- Prevent a cleanup conflict from marking an otherwise completed deploy as failed.
- Update command and CLI expectations for the prune command.

## Related Issue

Closes #1799

## Tests

- `docker run --rm --platform linux/amd64 -v "$PWD:/workdir" -v kamal_bundle_cache:/usr/local/bundle -w /workdir ruby:3.4 bash -lc './bin/test test/commands/prune_test.rb test/cli/prune_test.rb'`
- `docker run --rm --platform linux/amd64 -v "$PWD:/workdir" -v kamal_bundle_cache:/usr/local/bundle -w /workdir ruby:3.4 bash -lc 'bundle exec rubocop lib/kamal/commands/prune.rb test/commands/prune_test.rb test/cli/prune_test.rb'`
- Shell simulation confirming the tagged image prune fragment stays successful when `docker rmi` exits nonzero.