### PR TITLE
Merge destination env secrets

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -31,7 +31,23 @@ class Kamal::Configuration
 
     private
       def load_config_files(*files)
-        files.inject({}) { |config, file| config.deep_merge! load_config_file(file) }
+        files.inject({}) { |config, file| merge_config(config, load_config_file(file)) }
+      end
+
+      def merge_config(config, override, parents = [])
+        config.merge(override) do |key, old_value, new_value|
+          if old_value.is_a?(Hash) && new_value.is_a?(Hash)
+            merge_config(old_value, new_value, parents + [ key.to_s ])
+          elsif direct_env_secret_key?(parents, key) && old_value.is_a?(Array) && new_value.is_a?(Array)
+            old_value | new_value
+          else
+            new_value
+          end
+        end
+      end
+
+      def direct_env_secret_key?(parents, key)
+        key.to_s == "secret" && parents == [ "env" ]
       end
 
       def load_config_file(file)

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -267,6 +267,48 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal "1.1.1.3", config.all_hosts.first
   end
 
+  test "destination yml config merges env secrets" do
+    with_test_secrets("secrets-common" => "RAILS_MASTER_KEY=secret123", "secrets.staging" => "DATABASE_URL=postgres://example") do
+      File.write("deploy.yml", <<~YAML)
+        service: app
+        image: dhh/app
+        registry:
+          username: dhh
+          password: secret
+        builder:
+          arch: amd64
+        servers:
+          - 1.1.1.1
+          - 1.1.1.2
+        env:
+          secret:
+            - RAILS_MASTER_KEY
+          tags:
+            web:
+              secret:
+                - RAILS_MASTER_KEY
+      YAML
+
+      File.write("deploy.staging.yml", <<~YAML)
+        servers:
+          - 1.1.1.3
+        env:
+          secret:
+            - DATABASE_URL
+          tags:
+            web:
+              secret:
+                - DATABASE_URL
+      YAML
+
+      config = Kamal::Configuration.create_from config_file: Pathname.new("deploy.yml"), destination: "staging"
+
+      assert_equal [ "1.1.1.3" ], config.all_hosts
+      assert_equal "RAILS_MASTER_KEY=secret123\nDATABASE_URL=postgres://example\n", config.env.secrets_io.read
+      assert_equal "DATABASE_URL=postgres://example\n", config.env_tag("web").env.secrets_io.read
+    end
+  end
+
   test "destination yml config file missing" do
     dest_config_file = Pathname.new(File.expand_path("fixtures/deploy_for_dest.yml", __dir__))
 


### PR DESCRIPTION
## Summary

- Merge destination `env.secret` arrays with base config values.
- Keep ordinary destination array overrides intact, including `servers`.
- Add regression coverage for destination-specific secret env files.

## Related issue

Closes #1749

## Tests

- `docker run --rm --platform linux/amd64 -v "$PWD:/workdir" -v kamal_bundle_cache:/usr/local/bundle -w /workdir -e RUBYOPT=--enable=frozen-string-literal ruby:3.4 bash -lc './bin/test test/configuration_test.rb'`
- `docker run --rm --platform linux/amd64 -v "$PWD:/workdir" -v kamal_bundle_cache:/usr/local/bundle -w /workdir ruby:3.4 bash -lc 'bundle exec rubocop lib/kamal/configuration.rb test/configuration_test.rb'`
- `docker run --rm --platform linux/amd64 -v "$PWD:/workdir" -v kamal_bundle_cache:/usr/local/bundle -v /var/run/docker.sock:/var/run/docker.sock -w /workdir -e RUBYOPT=--enable=frozen-string-literal ruby:3.4 bash -lc 'apt-get update && apt-get install -y docker.io && ./bin/test test/configuration_test.rb test/configuration test/cli/main_test.rb'`