### PR TITLE
Skip proxy remove for stopped accessories

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -111,12 +111,13 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
       with_accessory(name) do |accessory, hosts|
         on(hosts) do
           execute *KAMAL.auditor.record("Stopped #{name} accessory"), verbosity: :debug
+          target = if accessory.running_proxy?
+            capture_with_info(*accessory.container_id_for(container_name: accessory.service_name, only_running: true)).strip
+          end
+
           execute *accessory.stop, raise_on_non_zero_exit: false
 
-          if accessory.running_proxy?
-            target = capture_with_info(*accessory.container_id_for(container_name: accessory.service_name, only_running: true)).strip
-            execute *accessory.remove if target
-          end
+          execute *accessory.remove, raise_on_non_zero_exit: false if target.present?
         end
       end
     end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -90,6 +90,28 @@ class CliAccessoryTest < CliTestCase
     assert_match "docker container stop app-mysql", run_command("stop", "mysql")
   end
 
+  test "stop proxied accessory without running container skips proxy remove" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .returns("\n")
+
+    run_command("stop", "mysql", fixture: :with_proxy_run_config).tap do |output|
+      assert_match "docker container stop app-mysql", output
+      assert_no_match "kamal-proxy remove app-mysql", output
+    end
+  end
+
+  test "stop running proxied accessory removes proxy best effort" do
+    executions = []
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .returns("abc123\n")
+    SSHKit::Backend::Abstract.any_instance.stubs(:execute)
+      .with { |*args| executions << args; true }
+
+    run_command("stop", "mysql", fixture: :with_proxy_run_config)
+
+    assert_includes executions, [ :docker, :exec, "kamal-proxy", "kamal-proxy", :remove, "app-mysql", { raise_on_non_zero_exit: false } ]
+  end
+
   test "restart" do
     Kamal::Cli::Accessory.any_instance.expects(:stop).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:start).with("mysql")
@@ -274,7 +296,7 @@ class CliAccessoryTest < CliTestCase
   end
 
   private
-    def run_command(*command)
-      stdouted { Kamal::Cli::Accessory.start([ *command, "-c", "test/fixtures/deploy_with_accessories_with_different_registries.yml" ]) }
+    def run_command(*command, fixture: :with_accessories_with_different_registries)
+      stdouted { Kamal::Cli::Accessory.start([ *command, "-c", "test/fixtures/deploy_#{fixture}.yml" ]) }
     end
 end


### PR DESCRIPTION
## Summary
- check for a running proxied accessory before stopping the container
- skip `kamal-proxy remove` when that lookup is empty
- keep proxy removal best-effort for normal proxied accessory stops

Fixes #1533.

## Tests
- `BUNDLE_PATH=/tmp/kamal-bundle BUNDLE_APP_CONFIG=/tmp/kamal-bundle-app-config /opt/homebrew/opt/ruby/bin/bundle _2.6.5_ exec ruby -Itest test/cli/accessory_test.rb -n '/stop proxied accessory without running container skips proxy remove|stop running proxied accessory removes proxy best effort/'`
- `BUNDLE_PATH=/tmp/kamal-bundle BUNDLE_APP_CONFIG=/tmp/kamal-bundle-app-config /opt/homebrew/opt/ruby/bin/bundle _2.6.5_ exec ruby -Itest test/cli/accessory_test.rb`
- `BUNDLE_PATH=/tmp/kamal-bundle BUNDLE_APP_CONFIG=/tmp/kamal-bundle-app-config /opt/homebrew/opt/ruby/bin/bundle _2.6.5_ exec ruby -Itest test/commands/accessory_test.rb`
- `BUNDLE_PATH=/tmp/kamal-bundle BUNDLE_APP_CONFIG=/tmp/kamal-bundle-app-config /opt/homebrew/opt/ruby/bin/bundle _2.6.5_ exec ruby -Itest test/cli/app_test.rb`
- `BUNDLE_PATH=/tmp/kamal-bundle BUNDLE_APP_CONFIG=/tmp/kamal-bundle-app-config /opt/homebrew/opt/ruby/bin/bundle _2.6.5_ exec ruby -Itest test/integration/accessory_test.rb`
- `BUNDLE_PATH=/tmp/kamal-bundle BUNDLE_APP_CONFIG=/tmp/kamal-bundle-app-config /opt/homebrew/opt/ruby/bin/bundle _2.6.5_ exec rubocop lib/kamal/cli/accessory.rb test/cli/accessory_test.rb`
- `/opt/homebrew/opt/ruby/bin/ruby -c lib/kamal/cli/accessory.rb`
- `/opt/homebrew/opt/ruby/bin/ruby -c test/cli/accessory_test.rb`
- `git diff --check`