### PR TITLE
Add app remove hooks

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -243,10 +243,14 @@ class Kamal::Cli::App < Kamal::Cli::Base
   desc "remove", "Remove app containers and images from servers"
   def remove
     modify(lock: true) do
+      host_list = KAMAL.app_hosts.join(",")
+
+      run_hook "pre-app-remove", hosts: host_list
       stop
       remove_containers
       remove_images
       remove_app_directories
+      run_hook "post-app-remove", hosts: host_list
     end
   end
 

--- a/lib/kamal/cli/templates/sample_hooks/post-app-remove.sample
+++ b/lib/kamal/cli/templates/sample_hooks/post-app-remove.sample
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+echo "Removed app from $KAMAL_HOSTS..."

--- a/lib/kamal/cli/templates/sample_hooks/pre-app-remove.sample
+++ b/lib/kamal/cli/templates/sample_hooks/pre-app-remove.sample
@@ -1,0 +1,3 @@
+#!/usr/bin/env sh
+
+echo "Removing app from $KAMAL_HOSTS..."

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -313,6 +313,30 @@ class CliAppTest < CliTestCase
     end
   end
 
+  test "remove runs hooks" do
+    Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).returns(true)
+
+    run_command("remove").tap do |output|
+      assert_match %r{/usr/bin/env \.kamal/hooks/pre-app-remove.*docker container prune --force --filter label=service=app.*rm -r \.kamal/proxy/apps-config/app.*\/usr/bin/env \.kamal/hooks/post-app-remove}m, output
+    end
+  end
+
+  test "remove skips hooks" do
+    Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).returns(true)
+
+    run_command("remove", "--skip_hooks").tap do |output|
+      assert_no_match /\.kamal\/hooks\/pre-app-remove/, output
+      assert_no_match /\.kamal\/hooks\/post-app-remove/, output
+    end
+  end
+
+  test "remove raises when pre hook fails" do
+    fail_hook "pre-app-remove"
+
+    error = assert_raises(Kamal::Cli::HookError) { run_command("remove") }
+    assert_equal "Hook `pre-app-remove` failed:\nfailed", error.message
+  end
+
   test "remove with role filter does not remove images or app directories" do
     run_command("remove", "-r", "workers", config: :with_two_roles_one_host).tap do |output|
       assert_match "docker stop", output

--- a/test/integration/app_test.rb
+++ b/test/integration/app_test.rb
@@ -64,6 +64,7 @@ class AppTest < IntegrationTest
 
     kamal :app, :remove
 
+    assert_hooks_ran "pre-app-remove", "post-app-remove"
     assert_app_not_found
     assert_app_directory_removed
   end

--- a/test/integration/docker/deployer/app/.kamal/hooks/post-app-remove
+++ b/test/integration/docker/deployer/app/.kamal/hooks/post-app-remove
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Removed app from ${KAMAL_HOSTS}..."
+mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/post-app-remove

--- a/test/integration/docker/deployer/app/.kamal/hooks/pre-app-remove
+++ b/test/integration/docker/deployer/app/.kamal/hooks/pre-app-remove
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Removing app from ${KAMAL_HOSTS}..."
+mkdir -p /tmp/${TEST_ID} && touch /tmp/${TEST_ID}/pre-app-remove


### PR DESCRIPTION
## Summary

Adds `pre-app-remove` and `post-app-remove` hooks around `kamal app remove`, so cleanup can run before and after app containers, images, and app directories are removed.

Adds sample hook files for new apps and covers the hooks in CLI and integration tests.

Closes #1869

## Testing

- `BUNDLE_PATH=/tmp/kamal-app-remove-hooks-bundle bundle exec ruby -Itest test/cli/app_test.rb`
- `BUNDLE_PATH=/tmp/kamal-app-remove-hooks-bundle bundle exec rubocop lib/kamal/cli/app.rb test/cli/app_test.rb test/integration/app_test.rb`
- `git diff --check`
- `BUNDLE_PATH=/tmp/kamal-app-remove-hooks-bundle bundle exec ruby -Itest test/integration/app_test.rb`
