### PR TITLE
Honor Docker logging driver for default log size

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -28,7 +28,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
             execute *KAMAL.auditor.record("Booted #{name} accessory"), verbosity: :debug
             execute *accessory.ensure_env_directory
             upload! accessory.secrets_io, accessory.secrets_path, mode: "0600"
-            execute *accessory.run(host: host)
+            execute *accessory.run(host: host, default_logging_driver: capture_with_info(*KAMAL.docker.logging_driver).strip)
 
             if accessory.running_proxy?
               target = capture_with_info(*accessory.container_id_for(container_name: accessory.service_name, only_running: true)).strip

--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -128,9 +128,13 @@ class Kamal::Cli::App < Kamal::Cli::Base
         say "Get most recent version available as an image...", :magenta unless options[:version]
         using_version(version_or_latest) do |version|
           say "Launching interactive command with version #{version} via SSH from new container on #{KAMAL.primary_host}...", :magenta
-          on(KAMAL.primary_host) { execute *KAMAL.registry.login }
+          default_logging_driver = nil
+          on(KAMAL.primary_host) do
+            execute *KAMAL.registry.login
+            default_logging_driver = capture_with_info(*KAMAL.docker.logging_driver).strip
+          end
           run_locally do
-            exec KAMAL.app(role: KAMAL.primary_role, host: KAMAL.primary_host).execute_in_new_container_over_ssh(cmd, env: env)
+            exec KAMAL.app(role: KAMAL.primary_role, host: KAMAL.primary_host).execute_in_new_container_over_ssh(cmd, env: env, default_logging_driver: default_logging_driver)
           end
         end
 
@@ -153,7 +157,8 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
           on_roles(KAMAL.roles, hosts: KAMAL.app_hosts) do |host, role|
             execute *KAMAL.auditor.record("Executed cmd '#{cmd}' on app version #{version}"), verbosity: :debug
-            puts_by_host host, capture_with_info(*KAMAL.app(role: role, host: host).execute_in_new_container(cmd, env: env, detach: detach), strip: !raw), quiet: quiet, raw: raw
+            default_logging_driver = capture_with_info(*KAMAL.docker.logging_driver).strip
+            puts_by_host host, capture_with_info(*KAMAL.app(role: role, host: host).execute_in_new_container(cmd, env: env, detach: detach, default_logging_driver: default_logging_driver), strip: !raw), quiet: quiet, raw: raw
           end
         end
       end

--- a/lib/kamal/cli/app/boot.rb
+++ b/lib/kamal/cli/app/boot.rb
@@ -50,7 +50,7 @@ class Kamal::Cli::App::Boot
       execute *app.ensure_env_directory
       upload! role.secrets_io(host), role.secrets_path, mode: "0600"
 
-      execute *app.run(hostname: hostname)
+      execute *app.run(hostname: hostname, default_logging_driver: capture_with_info(*KAMAL.docker.logging_driver).strip)
       if running_proxy?
         endpoint = capture_with_info(*app.container_id_for_version(version)).strip
         raise Kamal::Cli::BootError, "Failed to get endpoint for #{role} on #{host}, did the container boot?" if endpoint.empty?

--- a/lib/kamal/cli/proxy.rb
+++ b/lib/kamal/cli/proxy.rb
@@ -17,7 +17,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
           raise "kamal-proxy version #{version} is too old, run `kamal proxy reboot` in order to update to at least #{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}"
         end
         execute *KAMAL.proxy(host).ensure_apps_config_directory
-        execute *KAMAL.proxy(host).start_or_run
+        execute *KAMAL.proxy(host).start_or_run(default_logging_driver: capture_with_info(*KAMAL.docker.logging_driver).strip)
       end
     end
   end
@@ -88,7 +88,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
     when "get"
 
       on(KAMAL.proxy_hosts) do |host|
-        puts "Host #{host}: #{capture_with_info(*KAMAL.proxy(host).boot_config)}"
+        puts "Host #{host}: #{capture_with_info(*KAMAL.proxy(host).boot_config(default_logging_driver: capture_with_info(*KAMAL.docker.logging_driver).strip))}"
       end
     when "reset"
       on(KAMAL.proxy_hosts) do |host|
@@ -123,7 +123,7 @@ class Kamal::Cli::Proxy < Kamal::Cli::Base
             execute *proxy.remove_container
             execute *proxy.ensure_apps_config_directory
 
-            execute *proxy.run
+            execute *proxy.run(default_logging_driver: capture_with_info(*KAMAL.docker.logging_driver).strip)
           end
           run_hook "post-proxy-reboot", hosts: host_list
         end

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -12,13 +12,13 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
     @accessory_config = config.accessory(name)
   end
 
-  def run(host: nil)
+  def run(host: nil, default_logging_driver: nil)
     docker :run,
       "--name", service_name,
       "--detach",
       "--restart", restart_policy,
       *network_args,
-      *config.logging_args,
+      *config.logging_args(default_logging_driver: default_logging_driver),
       *publish_args,
       *([ "--env", "KAMAL_HOST=\"#{host}\"" ] if host),
       *env_args,

--- a/lib/kamal/commands/app.rb
+++ b/lib/kamal/commands/app.rb
@@ -13,7 +13,7 @@ class Kamal::Commands::App < Kamal::Commands::Base
     @host = host
   end
 
-  def run(hostname: nil)
+  def run(hostname: nil, default_logging_driver: nil)
     docker :run,
       "--detach",
       "--restart", role.restart_policy,
@@ -25,7 +25,7 @@ class Kamal::Commands::App < Kamal::Commands::Base
       "--env", "KAMAL_HOST=\"#{host}\"",
       *([ "--env", "KAMAL_DESTINATION=\"#{config.destination}\"" ] if config.destination),
       *role.env_args(host),
-      *role.logging_args,
+      *role.logging_args(default_logging_driver: default_logging_driver),
       *config.volume_args,
       *role.asset_volume_args,
       *role.label_args,

--- a/lib/kamal/commands/app/execution.rb
+++ b/lib/kamal/commands/app/execution.rb
@@ -7,7 +7,7 @@ module Kamal::Commands::App::Execution
       *command
   end
 
-  def execute_in_new_container(*command, interactive: false, detach: false, env:)
+  def execute_in_new_container(*command, interactive: false, detach: false, env:, default_logging_driver: nil)
     docker :run,
       (docker_interactive_args if interactive),
       ("--detach" if detach),
@@ -16,7 +16,7 @@ module Kamal::Commands::App::Execution
       "--network", "kamal",
       *role&.env_args(host),
       *argumentize("--env", env),
-      *role.logging_args,
+      *role.logging_args(default_logging_driver: default_logging_driver),
       *config.volume_args,
       *role&.option_args,
       config.absolute_image,
@@ -27,8 +27,8 @@ module Kamal::Commands::App::Execution
     run_over_ssh execute_in_existing_container(*command, interactive: true, env: env), host: host
   end
 
-  def execute_in_new_container_over_ssh(*command, env:)
-    run_over_ssh execute_in_new_container(*command, interactive: true, env: env), host: host
+  def execute_in_new_container_over_ssh(*command, env:, default_logging_driver: nil)
+    run_over_ssh execute_in_new_container(*command, interactive: true, env: env, default_logging_driver: default_logging_driver), host: host
   end
 
   private

--- a/lib/kamal/commands/docker.rb
+++ b/lib/kamal/commands/docker.rb
@@ -14,6 +14,10 @@ class Kamal::Commands::Docker < Kamal::Commands::Base
     docker :version
   end
 
+  def logging_driver
+    docker :info, "--format", "'{{.LoggingDriver}}'"
+  end
+
   # Do we have superuser access to install Docker and start system services?
   def superuser?
     [ '[ "${EUID:-$(id -u)}" -eq 0 ] || sudo -nl usermod >/dev/null' ]

--- a/lib/kamal/commands/proxy.rb
+++ b/lib/kamal/commands/proxy.rb
@@ -7,7 +7,7 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
     @proxy_run_config = config.proxy_run(host)
   end
 
-  def run
+  def run(default_logging_driver: nil)
     if proxy_run_config
       docker \
         :run,
@@ -16,11 +16,11 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
         "--detach",
         "--restart", "unless-stopped",
         "--volume", "kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy",
-        *proxy_run_config.docker_options_args,
+        *proxy_run_config.docker_options_args(default_logging_driver: default_logging_driver),
         *proxy_run_config.image,
         *proxy_run_config.run_command
     else
-      pipe boot_config, xargs(docker_run)
+      pipe boot_config(default_logging_driver: default_logging_driver), xargs(docker_run)
     end
   end
 
@@ -32,8 +32,8 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
     docker :container, :stop, name
   end
 
-  def start_or_run
-    combine start, run, by: "||"
+  def start_or_run(default_logging_driver: nil)
+    combine start, run(default_logging_driver: default_logging_driver), by: "||"
   end
 
   def info
@@ -88,12 +88,12 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
     make_directory config.proxy_boot.apps_directory
   end
 
-  def boot_config
-    [ :echo, "#{substitute(read_boot_options)} #{substitute(read_image)}:#{substitute(read_image_version)} #{substitute(read_run_command)}" ]
+  def boot_config(default_logging_driver: nil)
+    [ :echo, "#{substitute(read_boot_options(default_logging_driver: default_logging_driver))} #{substitute(read_image)}:#{substitute(read_image_version)} #{substitute(read_run_command)}" ]
   end
 
-  def read_boot_options
-    read_file(config.proxy_boot.options_file, default: config.proxy_boot.default_boot_options.join(" "))
+  def read_boot_options(default_logging_driver: nil)
+    read_file(config.proxy_boot.options_file, default: config.proxy_boot.default_boot_options(default_logging_driver: default_logging_driver).join(" "))
   end
 
   def read_image

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -225,8 +225,8 @@ class Kamal::Configuration
     end
   end
 
-  def logging_args
-    logging.args
+  def logging_args(default_logging_driver: nil)
+    logging.args(default_logging_driver: default_logging_driver)
   end
 
   def readiness_delay

--- a/lib/kamal/configuration/logging.rb
+++ b/lib/kamal/configuration/logging.rb
@@ -1,4 +1,7 @@
 class Kamal::Configuration::Logging
+  DEFAULT_LOG_MAX_SIZE = "10m"
+  DEFAULT_LOG_MAX_SIZE_DRIVERS = %w[ json-file local ].freeze
+
   delegate :optionize, :argumentize, to: Kamal::Utils
 
   include Kamal::Configuration::Validation
@@ -22,12 +25,18 @@ class Kamal::Configuration::Logging
     self.class.new logging_config: logging_config.deep_merge(other.logging_config)
   end
 
-  def args
+  def args(default_logging_driver: nil)
     if driver.present? || options.present?
       optionize({ "log-driver" => driver }.compact) +
         argumentize("--log-opt", options)
+    elsif self.class.default_log_max_size_driver?(default_logging_driver)
+      argumentize("--log-opt", { "max-size" => DEFAULT_LOG_MAX_SIZE })
     else
-      argumentize("--log-opt", { "max-size" => "10m" })
+      []
     end
+  end
+
+  def self.default_log_max_size_driver?(driver)
+    driver.blank? || DEFAULT_LOG_MAX_SIZE_DRIVERS.include?(driver.to_s.strip)
   end
 end

--- a/lib/kamal/configuration/proxy/boot.rb
+++ b/lib/kamal/configuration/proxy/boot.rb
@@ -18,14 +18,16 @@ class Kamal::Configuration::Proxy::Boot
     end.join(" ")
   end
 
-  def logging_args(max_size)
-    argumentize "--log-opt", "max-size=#{max_size}" if max_size.present?
+  def logging_args(max_size, default_logging_driver: nil, configured: true)
+    if max_size.present? && (configured || Kamal::Configuration::Logging.default_log_max_size_driver?(default_logging_driver))
+      argumentize "--log-opt", "max-size=#{max_size}"
+    end
   end
 
-  def default_boot_options
+  def default_boot_options(default_logging_driver: nil)
     [
       *(publish_args(Kamal::Configuration::Proxy::Run::DEFAULT_HTTP_PORT, Kamal::Configuration::Proxy::Run::DEFAULT_HTTPS_PORT, nil)),
-      *(logging_args(Kamal::Configuration::Proxy::Run::DEFAULT_LOG_MAX_SIZE))
+      *(logging_args(Kamal::Configuration::Proxy::Run::DEFAULT_LOG_MAX_SIZE, default_logging_driver: default_logging_driver, configured: false))
     ]
   end
 

--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -49,8 +49,10 @@ class Kamal::Configuration::Proxy::Run
     run_config.fetch("log_max_size", DEFAULT_LOG_MAX_SIZE)
   end
 
-  def logging_args
-    argumentize "--log-opt", "max-size=#{log_max_size}" if log_max_size.present?
+  def logging_args(default_logging_driver: nil)
+    if log_max_size.present? && (log_max_size_configured? || Kamal::Configuration::Logging.default_log_max_size_driver?(default_logging_driver))
+      argumentize "--log-opt", "max-size=#{log_max_size}"
+    end
   end
 
   def version
@@ -91,11 +93,11 @@ class Kamal::Configuration::Proxy::Run
     { debug: debug? || nil, "metrics-port": metrics_port }.compact
   end
 
-  def docker_options_args
+  def docker_options_args(default_logging_driver: nil)
     [
       *apps_volume_args,
       *publish_args,
-      *logging_args,
+      *logging_args(default_logging_driver: default_logging_driver),
       *("--expose=#{metrics_port}" if metrics_port.present?),
       *options_args
     ].compact
@@ -141,6 +143,10 @@ class Kamal::Configuration::Proxy::Run
   end
 
   private
+    def log_max_size_configured?
+      run_config.key?("log_max_size")
+    end
+
     def format_bind_ip(ip)
       # Ensure IPv6 address inside square brackets - e.g. [::1]
       if ip =~ Resolv::IPv6::Regex && ip !~ /\A\[.*\]\z/

--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -2,7 +2,7 @@ class Kamal::Configuration::Proxy::Run
   MINIMUM_VERSION = "v0.9.2"
   DEFAULT_HTTP_PORT = 80
   DEFAULT_HTTPS_PORT = 443
-  DEFAULT_LOG_MAX_SIZE = "10m"
+  DEFAULT_LOG_MAX_SIZE = Kamal::Configuration::Logging::DEFAULT_LOG_MAX_SIZE
 
   attr_reader :config, :run_config
   delegate :argumentize, :optionize, to: Kamal::Utils

--- a/lib/kamal/configuration/role.rb
+++ b/lib/kamal/configuration/role.rb
@@ -59,8 +59,8 @@ class Kamal::Configuration::Role
     argumentize "--label", labels
   end
 
-  def logging_args
-    logging.args
+  def logging_args(default_logging_driver: nil)
+    logging.args(default_logging_driver: default_logging_driver)
   end
 
   def logging

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -10,6 +10,14 @@ class CliAppTest < CliTestCase
     end
   end
 
+  test "boot skips implicit log max size for unsupported default logging driver" do
+    stub_running("syslog")
+    run_command("boot").tap do |output|
+      assert_match /docker run --detach --restart unless-stopped --name app-web-latest --network kamal --hostname 1.1.1.1-[0-9a-f]{12} /, output
+      assert_no_match /--log-opt max-size/, output
+    end
+  end
+
   test "boot will rename if same version is already running" do
     Object.any_instance.stubs(:sleep)
     run_command("details") # Preheat Kamal const
@@ -25,6 +33,7 @@ class CliAppTest < CliTestCase
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :container, :ls, "--all", "--filter", "'name=^app-web-latest$'", "--quiet")
       .returns("12345678") # running version
+    stub_docker_logging_driver
 
     run_command("boot").tap do |output|
       assert_match /Renaming container .* to .* as already deployed on 1.1.1.1/, output # Rename
@@ -94,6 +103,7 @@ class CliAppTest < CliTestCase
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :container, :ls, "--all", "--filter", "'name=^app-web-latest$'", "--quiet")
       .returns("12345678") # running version
+    stub_docker_logging_driver
 
     run_command("boot", config: :with_assets).tap do |output|
       assert_match "docker tag dhh/app:latest dhh/app:latest", output
@@ -119,6 +129,7 @@ class CliAppTest < CliTestCase
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:sh, "-c", "'docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting'", "|", :head, "-1", "|", "while read line; do echo ${line#app-web-}; done", raise_on_non_zero_exit: false)
       .returns("123") # old version
+    stub_docker_logging_driver
 
     run_command("boot", config: :with_env_tags).tap do |output|
       assert_match "docker tag dhh/app:latest dhh/app:latest", output
@@ -131,6 +142,7 @@ class CliAppTest < CliTestCase
     Object.any_instance.stubs(:sleep)
 
     SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).returns("123") # old version
+    stub_docker_logging_driver
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :container, :ls, "--all", "--filter", "'name=^app-workers-latest$'", "--quiet", "|", :xargs, :docker, :inspect, "--format", "'{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'")
@@ -150,6 +162,7 @@ class CliAppTest < CliTestCase
     Object.any_instance.stubs(:sleep)
 
     SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).returns("123") # old version
+    stub_docker_logging_driver
 
     SSHKit::Backend::Abstract.any_instance.stubs(:execute).returns("")
     SSHKit::Backend::Abstract.any_instance.stubs(:execute)
@@ -175,6 +188,7 @@ class CliAppTest < CliTestCase
     Object.any_instance.stubs(:sleep)
 
     SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).returns("123") # old version
+    stub_docker_logging_driver
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :container, :ls, "--all", "--filter", "'name=^app-workers-latest$'", "--quiet", "|", :xargs, :docker, :inspect, "--format", "'{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'")
@@ -198,6 +212,7 @@ class CliAppTest < CliTestCase
     Object.any_instance.stubs(:sleep)
 
     SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).returns("123") # old version
+    stub_docker_logging_driver
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :container, :ls, "--all", "--filter", "'name=^app-workers-latest$'", "--quiet", "|", :xargs, :docker, :inspect, "--format", "'{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'")
@@ -214,6 +229,7 @@ class CliAppTest < CliTestCase
     Object.any_instance.stubs(:sleep)
 
     SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).returns("123") # old version
+    stub_docker_logging_driver
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :container, :ls, "--all", "--filter", "'name=^app-workers-latest$'", "--quiet", "|", :xargs, :docker, :inspect, "--format", "'{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'")
@@ -255,6 +271,7 @@ class CliAppTest < CliTestCase
 
   test "start" do
     SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).returns("999") # old version
+    stub_docker_logging_driver
 
     run_command("start").tap do |output|
       assert_match "docker start app-web-999", output
@@ -542,6 +559,7 @@ class CliAppTest < CliTestCase
 
   test "boot proxy" do
     SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).returns("123") # old version
+    stub_docker_logging_driver
 
     run_command("boot", config: :with_proxy).tap do |output|
       assert_match /Renaming container .* to .* as already deployed on 1.1.1.1/, output # Rename
@@ -554,6 +572,7 @@ class CliAppTest < CliTestCase
 
   test "boot proxy with role specific config" do
     SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).returns("123") # old version
+    stub_docker_logging_driver
 
     run_command("boot", config: :with_proxy_roles, host: nil).tap do |output|
       assert_match "docker exec kamal-proxy kamal-proxy deploy app-web --target=\"123:80\" --deploy-timeout=\"6s\" --drain-timeout=\"30s\" --target-timeout=\"10s\" --buffer-requests --buffer-responses --log-request-header=\"Cache-Control\" --log-request-header=\"Last-Modified\" --log-request-header=\"User-Agent\"", output
@@ -588,9 +607,10 @@ class CliAppTest < CliTestCase
       end
     end
 
-    def stub_running
+    def stub_running(default_logging_driver = "json-file")
       Object.any_instance.stubs(:sleep)
 
       SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).returns("123") # old version
+      stub_docker_logging_driver(default_logging_driver)
     end
 end

--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -40,6 +40,12 @@ class CliTestCase < ActiveSupport::TestCase
         .with(:docker, :buildx, :inspect, "kamal-local-docker-container")
     end
 
+    def stub_docker_logging_driver(driver = "json-file")
+      SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+        .with(:docker, :info, "--format", "'{{.LoggingDriver}}'")
+        .returns(driver)
+    end
+
     def assert_hook_ran(hook, output, count: 1)
       regexp = ([ "/usr/bin/env .kamal/hooks/#{hook}" ] * count).join(".*")
       assert_match /#{regexp}/m, output

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -454,6 +454,7 @@ class CliMainTest < CliTestCase
         .with(:sh, "-c", "'docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=destination= --filter label=role=#{role} --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=destination= --filter label=role=#{role} --filter status=running --filter status=restarting'", "|", :head, "-1", "|", "while read line; do echo ${line#app-#{role}-}; done", raise_on_non_zero_exit: false)
         .returns("version-to-rollback\n").at_least_once
     end
+    stub_docker_logging_driver
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :container, :ls, "--all", "--filter", "'name=^app-workers-123$'", "--quiet", "|", :xargs, :docker, :inspect, "--format", "'{{if .State.Health}}{{.State.Health.Status}}{{else}}{{.State.Status}}{{end}}'")
@@ -482,6 +483,7 @@ class CliMainTest < CliTestCase
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:sh, "-c", "'docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting --filter ancestor=$(docker image ls --filter reference=dhh/app:latest --format '\\''{{.ID}}'\\'') ; docker ps --latest --format '\\''{{.Names}}'\\'' --filter label=service=app --filter label=destination= --filter label=role=web --filter status=running --filter status=restarting'", "|", :head, "-1", "|", "while read line; do echo ${line#app-web-}; done", raise_on_non_zero_exit: false)
       .returns("").at_least_once
+    stub_docker_logging_driver
 
     run_command("rollback", "123").tap do |output|
       assert_match "docker run --detach --restart unless-stopped --name app-web-123", output

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -49,6 +49,7 @@ class CliProxyTest < CliTestCase
       .with(:docker, :inspect, "kamal-proxy", "--format '{{.Config.Image}}'", "|", :awk, "-F:", "'{print $NF}'")
       .returns(Kamal::Configuration::Proxy::Run::MINIMUM_VERSION)
       .at_least_once
+    stub_docker_logging_driver
 
     run_command("boot").tap do |output|
       assert_match "docker login", output
@@ -173,6 +174,7 @@ class CliProxyTest < CliTestCase
     Object.any_instance.stubs(:sleep)
 
     SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).returns("12345678")
+    stub_docker_logging_driver
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :inspect, "kamal-proxy", "--format '{{.Config.Image}}'", "|", :awk, "-F:", "'{print $NF}'")
@@ -212,6 +214,7 @@ class CliProxyTest < CliTestCase
     Object.any_instance.stubs(:sleep)
 
     SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).returns("12345678")
+    stub_docker_logging_driver
 
     SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
       .with(:docker, :inspect, "kamal-proxy", "--format '{{.Config.Image}}'", "|", :awk, "-F:", "'{print $NF}'")
@@ -389,6 +392,7 @@ class CliProxyTest < CliTestCase
       .with(:echo, "$(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443 --log-opt max-size=10m\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\")")
       .returns("--publish 80:80 --publish 8443:443 --label=foo=bar basecamp/kamal-proxy:v1.0.0")
       .twice
+    stub_docker_logging_driver
 
     run_command("boot_config", "get").tap do |output|
       assert_match "Host 1.1.1.1: --publish 80:80 --publish 8443:443 --label=foo=bar basecamp/kamal-proxy:v1.0.0", output

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -81,6 +81,12 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
       new_command(:busybox).run.join(" ")
   end
 
+  test "run skips implicit log max size for unsupported default logging driver" do
+    assert_equal \
+      "docker run --name custom-busybox --detach --restart unless-stopped --network kamal --env-file .kamal/apps/app/env/accessories/busybox.env --label service=\"custom-busybox\" other.registry/busybox:latest",
+      new_command(:busybox).run(default_logging_driver: "fluentd").join(" ")
+  end
+
   test "run with custom restart policy" do
     @config[:accessories]["mysql"]["options"]["restart"] = "on-failure"
 

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -61,6 +61,12 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command.run.join(" ")
   end
 
+  test "run skips implicit log max size for unsupported default logging driver" do
+    assert_equal \
+      "docker run --detach --restart unless-stopped --name app-web-999 --network kamal --env KAMAL_CONTAINER_NAME=\"app-web-999\" --env KAMAL_VERSION=\"999\" --env KAMAL_HOST=\"1.1.1.1\" --env-file .kamal/apps/app/env/roles/web.env --label service=\"app\" --label role=\"web\" --label destination dhh/app:999",
+      new_command.run(default_logging_driver: "syslog").join(" ")
+  end
+
   test "run with role logging config" do
     @config[:logging] = { "driver" => "local", "options" => { "max-size" => "10m", "max-file" => "3" } }
     @config[:servers] = { "web" => { "hosts" => [ "1.1.1.1" ], "logging" => { "driver" => "local", "options" => { "max-size" => "100m" } } } }
@@ -288,6 +294,12 @@ class CommandsAppTest < ActiveSupport::TestCase
     assert_match \
       %r{docker run --rm --name app-web-exec-999-[0-9a-f]{6} --network kamal --env-file .kamal/apps/app/env/roles/web.env --log-driver "local" --log-opt max-size="100m" --log-opt max-file="3" dhh/app:999 bin/rails db:setup},
       new_command.execute_in_new_container("bin/rails", "db:setup", env: {}).join(" ")
+  end
+
+  test "execute in new container skips implicit log max size for unsupported default logging driver" do
+    assert_match \
+      %r{docker run --rm --name app-web-exec-999-[0-9a-f]{6} --network kamal --env-file .kamal/apps/app/env/roles/web.env dhh/app:999 bin/rails db:setup},
+      new_command.execute_in_new_container("bin/rails", "db:setup", env: {}, default_logging_driver: "fluentd").join(" ")
   end
 
   test "execute in new container with env" do

--- a/test/commands/docker_test.rb
+++ b/test/commands/docker_test.rb
@@ -20,6 +20,10 @@ class CommandsDockerTest < ActiveSupport::TestCase
     assert_equal "docker version", @docker.running?.join(" ")
   end
 
+  test "logging driver" do
+    assert_equal "docker info --format '{{.LoggingDriver}}'", @docker.logging_driver.join(" ")
+  end
+
   test "superuser?" do
     assert_equal '[ "${EUID:-$(id -u)}" -eq 0 ] || sudo -nl usermod >/dev/null', @docker.superuser?.join(" ")
   end

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -27,6 +27,12 @@ class CommandsProxyTest < ActiveSupport::TestCase
       new_command.run.join(" ")
   end
 
+  test "run skips implicit log max size for unsupported default logging driver" do
+    assert_equal \
+      "echo $(cat .kamal/proxy/options 2> /dev/null || echo \"--publish 80:80 --publish 443:443\") $(cat .kamal/proxy/image 2> /dev/null || echo \"basecamp/kamal-proxy\"):$(cat .kamal/proxy/image_version 2> /dev/null || echo \"#{Kamal::Configuration::Proxy::Run::MINIMUM_VERSION}\") $(cat .kamal/proxy/run_command 2> /dev/null || echo \"\") | xargs docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config",
+      new_command.run(default_logging_driver: "syslog").join(" ")
+  end
+
   test "proxy start" do
     assert_equal \
       "docker container start kamal-proxy",
@@ -198,6 +204,20 @@ class CommandsProxyTest < ActiveSupport::TestCase
     assert_equal \
       "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=50m basecamp/kamal-proxy:v0.9.2 kamal-proxy run",
       new_command.run.join(" ")
+  end
+
+  test "run config skips implicit log max size for unsupported default logging driver" do
+    @config[:proxy] = { "run" => { "debug" => true } }
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 basecamp/kamal-proxy:v0.9.2 kamal-proxy run --debug",
+      new_command.run(default_logging_driver: "syslog").join(" ")
+  end
+
+  test "run config keeps configured log max size for unsupported default logging driver" do
+    @config[:proxy] = { "run" => { "log_max_size" => "50m" } }
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=50m basecamp/kamal-proxy:v0.9.2 kamal-proxy run",
+      new_command.run(default_logging_driver: "fluentd").join(" ")
   end
 
   test "debug run config" do

--- a/test/configuration/proxy/boot_test.rb
+++ b/test/configuration/proxy/boot_test.rb
@@ -28,4 +28,16 @@ class ConfigurationProxyBootTest < ActiveSupport::TestCase
     assert_equal ".kamal/proxy/apps-config/app/tls", @proxy_boot_config.tls_directory
     assert_equal "/home/kamal-proxy/.apps-config/app/tls", @proxy_boot_config.tls_container_directory
   end
+
+  test "default boot options keep log max size for supported docker logging driver" do
+    assert_equal \
+      [ "--publish 80:80 --publish 443:443", "--log-opt", "max-size=10m" ],
+      @proxy_boot_config.default_boot_options(default_logging_driver: "json-file")
+  end
+
+  test "default boot options skip log max size for unsupported docker logging driver" do
+    assert_equal \
+      [ "--publish 80:80 --publish 443:443" ],
+      @proxy_boot_config.default_boot_options(default_logging_driver: "fluentd")
+  end
 end

--- a/test/configuration/proxy/run_test.rb
+++ b/test/configuration/proxy/run_test.rb
@@ -29,6 +29,29 @@ class ConfigurationProxyRunTest < ActiveSupport::TestCase
     assert_equal 2, [ run_a, run_b ].uniq.size
   end
 
+  test "implicit log max size is kept for supported docker logging driver" do
+    config = Kamal::Configuration.new(base_deploy)
+    run = Kamal::Configuration::Proxy::Run.new(config, run_config: {})
+
+    assert_equal [ "--log-opt", "max-size=10m" ], run.logging_args(default_logging_driver: "json-file")
+    assert_equal [ "--log-opt", "max-size=10m" ], run.logging_args(default_logging_driver: "local")
+  end
+
+  test "implicit log max size is skipped for unsupported docker logging driver" do
+    config = Kamal::Configuration.new(base_deploy)
+    run = Kamal::Configuration::Proxy::Run.new(config, run_config: {})
+
+    assert_nil run.logging_args(default_logging_driver: "syslog")
+    assert_nil run.logging_args(default_logging_driver: "fluentd")
+  end
+
+  test "configured log max size is kept for unsupported docker logging driver" do
+    config = Kamal::Configuration.new(base_deploy)
+    run = Kamal::Configuration::Proxy::Run.new(config, run_config: { "log_max_size" => "50m" })
+
+    assert_equal [ "--log-opt", "max-size=50m" ], run.logging_args(default_logging_driver: "syslog")
+  end
+
   test "no conflict when global proxy run config is inherited by role proxy" do
     deploy = base_deploy.deep_merge(
       servers: {

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -235,6 +235,17 @@ class ConfigurationTest < ActiveSupport::TestCase
     assert_equal [ "--log-opt", "max-size=\"10m\"" ], @config.logging_args
   end
 
+  test "logging args default with supported docker logging driver" do
+    assert_equal [ "--log-opt", "max-size=\"10m\"" ], @config.logging_args(default_logging_driver: "json-file")
+    assert_equal [ "--log-opt", "max-size=\"10m\"" ], @config.logging_args(default_logging_driver: "json-file\n")
+    assert_equal [ "--log-opt", "max-size=\"10m\"" ], @config.logging_args(default_logging_driver: "local")
+  end
+
+  test "logging args default with unsupported docker logging driver" do
+    assert_equal [], @config.logging_args(default_logging_driver: "syslog")
+    assert_equal [], @config.logging_args(default_logging_driver: "fluentd")
+  end
+
   test "logging args with configured options" do
     config = Kamal::Configuration.new(@deploy.tap { |c| c.merge!(logging: { "options" => { "max-size" => "100m", "max-file" => 5 } }) })
     assert_equal [ "--log-opt", "max-size=\"100m\"", "--log-opt", "max-file=\"5\"" ], config.logging_args


### PR DESCRIPTION
Fixes #1709.

## Summary
- read the target host Docker logging driver before app, proxy, and accessory container starts
- keep Kamal's implicit `max-size=10m` default for `json-file` and `local`
- skip only the implicit `max-size` option for unsupported default drivers such as `syslog` and `fluentd`
- keep explicitly configured logging options unchanged

## Tests
- `bin/test test/configuration_test.rb test/configuration/proxy/run_test.rb test/configuration/proxy/boot_test.rb test/commands/docker_test.rb test/commands/app_test.rb test/commands/accessory_test.rb test/commands/proxy_test.rb test/cli/app_test.rb test/cli/accessory_test.rb test/cli/proxy_test.rb test/cli/main_test.rb`
- `bundle exec rubocop --force-exclusion lib/kamal/configuration/logging.rb lib/kamal/configuration.rb lib/kamal/configuration/role.rb lib/kamal/configuration/proxy/run.rb lib/kamal/configuration/proxy/boot.rb lib/kamal/commands/docker.rb lib/kamal/commands/app.rb lib/kamal/commands/app/execution.rb lib/kamal/commands/accessory.rb lib/kamal/commands/proxy.rb lib/kamal/cli/app/boot.rb lib/kamal/cli/app.rb lib/kamal/cli/accessory.rb lib/kamal/cli/proxy.rb test/configuration_test.rb test/configuration/proxy/run_test.rb test/configuration/proxy/boot_test.rb test/commands/docker_test.rb test/commands/app_test.rb test/commands/accessory_test.rb test/commands/proxy_test.rb test/cli/cli_test_case.rb test/cli/app_test.rb test/cli/accessory_test.rb test/cli/proxy_test.rb test/cli/main_test.rb`
- `git diff --check`
