### PR TITLE
Support directory uploads for accessory files

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -49,7 +49,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
             remote = config[:host_path]
             accessory.ensure_local_file_present(local)
 
-            execute *accessory.make_directory_for(remote)
+            execute *accessory.make_directory_for_upload(local, remote)
             upload! local, remote, **accessory.upload_options(local)
             execute :chmod, config[:mode], remote
             execute :chown, config[:owner], remote if config[:owner]

--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -50,7 +50,7 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
             accessory.ensure_local_file_present(local)
 
             execute *accessory.make_directory_for(remote)
-            upload! local, remote
+            upload! local, remote, **accessory.upload_options(local)
             execute :chmod, config[:mode], remote
             execute :chown, config[:owner], remote if config[:owner]
           end

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -86,9 +86,13 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
   end
 
   def ensure_local_file_present(local_file)
-    if !local_file.is_a?(StringIO) && !Pathname.new(local_file).exist?
+    if !generated_file?(local_file) && !Pathname.new(local_file).exist?
       raise "Missing file: #{local_file}"
     end
+  end
+
+  def upload_options(local_file)
+    local_directory?(local_file) ? { recursive: true } : {}
   end
 
   def pull_image
@@ -112,6 +116,14 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
   end
 
   private
+    def generated_file?(local_file)
+      local_file.is_a?(StringIO)
+    end
+
+    def local_directory?(local_file)
+      !generated_file?(local_file) && Pathname.new(local_file).directory?
+    end
+
     def service_filter
       [ "--filter", "label=service=#{service_name}" ]
     end

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -95,6 +95,10 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
     local_directory?(local_file) ? { recursive: true } : {}
   end
 
+  def make_directory_for_upload(local_file, remote_file)
+    local_directory?(local_file) ? make_directory(remote_file) : make_directory_for(remote_file)
+  end
+
   def pull_image
     docker :image, :pull, image
   end

--- a/lib/kamal/configuration/docs/accessory.yml
+++ b/lib/kamal/configuration/docs/accessory.yml
@@ -89,7 +89,7 @@ accessories:
 
     # Copying files
     #
-    # You can specify files to mount into the container.
+    # You can specify files or directories to mount into the container.
     #
     # They will be uploaded from the local repo to the host and then mounted.
     # ERB files will be evaluated before being copied.

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -56,9 +56,11 @@ class CliAccessoryTest < CliTestCase
 
     SSHKit::Backend::Printer.any_instance.expects(:upload!).with(source, destination, recursive: true)
 
-    stdouted do
+    output = stdouted do
       Kamal::Cli::Accessory.start([ "upload", "mysql", "-c", "test/fixtures/deploy_with_accessory_file_directory.yml" ])
     end
+
+    assert_match "mkdir -p app-mysql/etc/mysql/conf.d", output
   end
 
   test "directories" do

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -50,6 +50,17 @@ class CliAccessoryTest < CliTestCase
     end
   end
 
+  test "upload directory file entry recursively" do
+    source = File.expand_path("test/fixtures/files/mysql/conf.d")
+    destination = "app-mysql/etc/mysql/conf.d"
+
+    SSHKit::Backend::Printer.any_instance.expects(:upload!).with(source, destination, recursive: true)
+
+    stdouted do
+      Kamal::Cli::Accessory.start([ "upload", "mysql", "-c", "test/fixtures/deploy_with_accessory_file_directory.yml" ])
+    end
+  end
+
   test "directories" do
     assert_match "mkdir -p $PWD/app-mysql/data", run_command("directories", "mysql")
   end

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -171,6 +171,16 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
     assert_equal({}, new_command(:mysql).upload_options(StringIO.new("dynamic")))
   end
 
+  test "upload directory command creates full remote directory for local directories" do
+    assert_equal [ :mkdir, "-p", "app-mysql/etc/mysql/conf.d" ],
+      new_command(:mysql).make_directory_for_upload("test/fixtures/files/mysql/conf.d", "app-mysql/etc/mysql/conf.d")
+  end
+
+  test "upload directory command creates parent remote directory for local files" do
+    assert_equal [ :mkdir, "-p", "app-mysql/etc/mysql" ],
+      new_command(:mysql).make_directory_for_upload("test/fixtures/files/my.cnf", "app-mysql/etc/mysql/my.cnf")
+  end
+
   test "logs" do
     assert_equal \
       "docker logs app-mysql --timestamps 2>&1",

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -159,6 +159,18 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
     end
   end
 
+  test "upload options use recursive mode for local directories" do
+    assert_equal({ recursive: true }, new_command(:mysql).upload_options("test/fixtures/files"))
+  end
+
+  test "upload options are empty for local files" do
+    assert_equal({}, new_command(:mysql).upload_options("test/fixtures/files/my.cnf"))
+  end
+
+  test "upload options are empty for generated files" do
+    assert_equal({}, new_command(:mysql).upload_options(StringIO.new("dynamic")))
+  end
+
   test "logs" do
     assert_equal \
       "docker logs app-mysql --timestamps 2>&1",

--- a/test/fixtures/deploy_with_accessory_file_directory.yml
+++ b/test/fixtures/deploy_with_accessory_file_directory.yml
@@ -1,0 +1,19 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64
+
+accessories:
+  mysql:
+    image: mysql:5.7
+    host: 1.1.1.3
+    files:
+      - test/fixtures/files/mysql/conf.d:/etc/mysql/conf.d
+
+readiness_delay: 0

--- a/test/fixtures/files/mysql/conf.d/custom.cnf
+++ b/test/fixtures/files/mysql/conf.d/custom.cnf
@@ -1,0 +1,2 @@
+[mysqld]
+max_connections=200


### PR DESCRIPTION
## Summary
- pass recursive upload options when an accessory `files` source points to a local directory
- keep ordinary file and ERB-generated uploads on the existing upload path
- clarify accessory docs since the examples already include a directory-backed `files` entry

Fixes #1854.

## Tests
- `BUNDLE_PATH=/tmp/kamal-bundle BUNDLE_APP_CONFIG=/tmp/kamal-bundle-app-config /opt/homebrew/opt/ruby/bin/bundle _2.6.5_ exec ruby -Itest test/commands/accessory_test.rb`
- `BUNDLE_PATH=/tmp/kamal-bundle BUNDLE_APP_CONFIG=/tmp/kamal-bundle-app-config /opt/homebrew/opt/ruby/bin/bundle _2.6.5_ exec ruby -Itest test/cli/accessory_test.rb`
- `BUNDLE_PATH=/tmp/kamal-bundle BUNDLE_APP_CONFIG=/tmp/kamal-bundle-app-config /opt/homebrew/opt/ruby/bin/bundle _2.6.5_ exec ruby -Itest test/configuration/accessory_test.rb`
- `BUNDLE_PATH=/tmp/kamal-bundle BUNDLE_APP_CONFIG=/tmp/kamal-bundle-app-config /opt/homebrew/opt/ruby/bin/bundle _2.6.5_ exec rubocop lib/kamal/cli/accessory.rb lib/kamal/commands/accessory.rb test/cli/accessory_test.rb test/commands/accessory_test.rb`
- `git diff --check`

`bin/test` also ran locally and reached the accessory and deploy integration coverage. It finished with 858 runs, 3098 assertions, 3 failures, and 3 errors; the failing cases are in hook performer identity, Docker build-check setup, and builder platform-order expectations that are outside this accessory upload path.
