### PR TITLE
Quote exec command arguments

### DIFF
--- a/lib/kamal/utils.rb
+++ b/lib/kamal/utils.rb
@@ -1,4 +1,5 @@
 require "active_support/core_ext/object/try"
+require "shellwords"
 
 module Kamal::Utils
   extend self
@@ -89,7 +90,13 @@ module Kamal::Utils
   end
 
   def join_commands(commands)
-    commands.map(&:strip).join(" ")
+    commands = commands.map(&:strip)
+
+    if commands.one?
+      commands.first
+    else
+      Shellwords.join(commands)
+    end
   end
 
   def docker_arch

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -380,6 +380,12 @@ class CliAppTest < CliTestCase
     end
   end
 
+  test "exec keeps spaced arguments intact" do
+    run_command("exec", "/app/bin/appServer", "maintenance", "We are upgrading our infrastructure, we will be back soon.").tap do |output|
+      assert_match %r{/app/bin/appServer maintenance We\\ are\\ upgrading\\ our\\ infrastructure,\\ we\\ will\\ be\\ back\\ soon\.}, output
+    end
+  end
+
   test "exec detach" do
     run_command("exec", "--detach", "ruby -v").tap do |output|
       assert_match %r{docker run --detach --name app-web-exec-latest-[0-9a-f]{6} --network kamal --env-file .kamal/apps/app/env/roles/web.env --log-opt max-size="10m" dhh/app:latest ruby -v}, output

--- a/test/utils_test.rb
+++ b/test/utils_test.rb
@@ -52,4 +52,14 @@ class UtilsTest < ActiveSupport::TestCase
     assert_equal "\"https://example.com/\\$2\"",
       Kamal::Utils.escape_shell_value("https://example.com/$2")
   end
+
+  test "join_commands preserves single string commands" do
+    assert_equal "ruby -v", Kamal::Utils.join_commands([ "ruby -v" ])
+  end
+
+  test "join_commands preserves separate arguments" do
+    assert_equal \
+      "/app/bin/appServer maintenance We\\ are\\ upgrading\\ our\\ infrastructure,\\ we\\ will\\ be\\ back\\ soon.",
+      Kamal::Utils.join_commands([ "/app/bin/appServer", "maintenance", "We are upgrading our infrastructure, we will be back soon." ])
+  end
 end


### PR DESCRIPTION
## Summary
- quote multiple exec arguments when Kamal collapses them into a remote shell command
- keep the existing single-string command path unchanged
- add regression coverage for an argument containing spaces

Fixes #1651

## Testing
- `bin/test test/utils_test.rb test/cli/app_test.rb`
- `bin/test test/utils_test.rb test/cli/app_test.rb test/cli/accessory_test.rb test/cli/server_test.rb`
- `bin/test test/commands/app_test.rb test/commands/accessory_test.rb test/utils_test.rb`
- `bundle exec rubocop --parallel`
- `bin/test` (local full-suite run: 857 runs, 3098 assertions, 3 failures, 3 errors; the isolated failures in `test/commands/builder_test.rb:271` and `test/commands/hook_test.rb:36` reproduce on clean `upstream/main` in this environment)