### PR TITLE
Add Podman support via a configurable container engine

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 coverage/*
 .DS_Store
 gemfiles/*.lock
+/.bundle/
+/vendor/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,90 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this repository is
+
+This is **Lamak**, a soft fork of [Kamal](https://github.com/basecamp/kamal) (forked at
+2.12.0) that teaches Kamal to drive **Podman as well as Docker**, selected by a single
+`container_engine` config value. Docker stays the untouched, byte-identical default. The
+internal namespace, gem name, and binary are still `Kamal`/`kamal` — the fork is
+deliberately soft so rebasing onto upstream stays cheap.
+
+**Read `PODMAN-PLAN.md` before making changes.** It defines the fork's governing
+constraints, which override normal "just make it work" instincts:
+
+- **Keep the diff against upstream minimal and quarantined.** Divergence debt is the
+  enemy. Prefer one config value threaded through explicit seams over scattered
+  `if podman` conditionals or runtime monkey-patching.
+- **`container_engine: docker` must stay byte-identical to stock Kamal.** Every existing
+  test must pass untouched — that is the regression net.
+- The engine seam is `Kamal::Commands::Base#docker` (`lib/kamal/commands/base.rb`), the
+  single private method every container command routes through. A few commands embed the
+  literal string `"docker"` inside shell pipe bodies (`commands/prune.rb`,
+  `commands/app/logging.rb`) and bypass the seam — those need explicit handling.
+
+## Commands
+
+```bash
+bundle                       # install dependencies (Ruby 3.2+)
+
+bin/test                     # run ALL tests (unit + integration)
+bin/test test/commands       # run a directory of unit tests
+bin/test test/commands/app_test.rb        # run one file
+bin/test test/commands/app_test.rb:42     # run the test at a line (Rails line filtering)
+bin/test -n "/deploy/"       # run tests matching a name pattern
+
+bundle exec rubocop --parallel            # lint (rubocop-rails-omakase)
+BUNDLE_ONLY=rubocop bundle exec rubocop   # how CI runs it
+
+bin/kamal <command>          # run the CLI locally
+bin/docs <kamal-site-repo>   # regenerate website docs from configuration/docs/*.yml
+```
+
+**Integration tests are part of `bin/test` and require a running Docker daemon.** They
+live in `test/integration/` and stand up a full Docker Compose stack (a `deployer`
+container plus fake target VMs, a load balancer, and a local registry) to run real
+deploys against — see `test/integration/docker-compose.yml`. Useful env vars when they
+fail: `DEBUG=1` (show compose output), `DEBUG_CONTAINER_LOGS=1` (dump container logs on
+failure), `VERBOSE=1` (backtraces + logging), and `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN`
+(avoid Docker Hub rate limits). To run only unit tests, pass a non-integration path to
+`bin/test`. CI runs the full suite across Ruby 3.2–4.0 and against `gemfiles/rails_edge.gemfile`.
+
+## Architecture
+
+Kamal is an SSH-based container deploy tool. The codebase has a strict two-layer split
+that is essential to understand:
+
+- **CLI layer** (`lib/kamal/cli/*`) — Thor commands that *orchestrate*. They open SSHKit
+  sessions (`on(hosts) { execute ... }`) and decide what runs where. `bin/kamal` boots
+  `Kamal::Cli::Main`, which wires subcommands (`app`, `build`, `proxy`, `prune`,
+  `accessory`, `registry`, `secrets`, `server`, `lock`).
+- **Commands layer** (`lib/kamal/commands/*`) — pure command *builders*. Each method
+  returns an array of shell tokens (or a combined string) and **executes nothing**.
+  Helpers in `Commands::Base` (`combine`, `chain`, `pipe`, `append`, `any`, `shell`)
+  compose them. Because commands are just data, tests assert on the emitted strings using
+  `SSHKit::Backend::Printer` (configured in `test/test_helper.rb`) rather than running
+  anything.
+
+**`KAMAL` is the global `Kamal::Commander` singleton** (`lib/kamal/commander.rb`) that
+ties the layers together. It lazily builds and memoizes the configuration and the command
+builders, and exposes them as `KAMAL.config`, `KAMAL.docker`, `KAMAL.app`, `KAMAL.proxy`,
+`KAMAL.builder`, `KAMAL.auditor`, `KAMAL.server`, etc. It also tracks the deploy lock and
+the `--hosts`/`--roles` filtering (`specific_hosts`, `specific_roles`).
+
+**Configuration** (`lib/kamal/configuration/*`) parses `config/deploy.yml` (plus
+destination overlays and secrets) into an object graph — `registry`, `builder`, `proxy`,
+`servers`, `roles`, `ssh`, `env`, `accessories`, `boot`, `logging`. Each sub-config has:
+a **validator** in `configuration/validator/*` (schema/rules), and a **docs source** in
+`configuration/docs/*.yml` that `bin/docs` transforms into the kamal-deploy.org website.
+When you add or change a config key, update the matching validator and docs yml.
+
+**Deploy model:** a `kamal-proxy` container (image `basecamp/kamal-proxy`) fronts the app
+containers and switches traffic between old and new versions for zero-downtime deploys.
+Apps run across multiple hosts grouped into `roles`; supporting services (db, redis,
+search) run as `accessories`. Images are produced by a **builder target** chosen from
+`local`, `remote`, `hybrid`, `pack`, or `cloud` (`commands/builder/*`), dispatched by
+`Commands::Builder#target`.
+
+Autoloading is via **Zeitwerk** (`lib/kamal.rb`), which eager-loads the `Kamal::Cli`
+namespace so all Thor commands are registered at boot.

--- a/PODMAN-PLAN.md
+++ b/PODMAN-PLAN.md
@@ -1,0 +1,208 @@
+# Lamak — Podman Support Plan
+
+Lamak is a soft fork of [Kamal](https://github.com/basecamp/kamal) (forked at 2.12.0)
+that teaches Kamal to drive **Podman as well as Docker**, selected by a single
+config value. Docker stays the untouched default. Lamak tracks upstream closely,
+feeds generic improvements back as small PRs, and carries only the Podman-specific
+delta that upstream doesn't want.
+
+This document is the plan for the code adjustments. It says *what* we'll change and
+*why*, in dependency order.
+
+---
+
+## Design principles (the constraints that keep this sane)
+
+1. **Minimal, quarantined delta.** Divergence debt is the only real enemy of a
+   long-lived fork. The smaller our diff against upstream, the cheaper every rebase.
+2. **Configuration-driven, not monkey-patched.** One `container_engine` config value
+   threaded through a few explicit seams — no runtime class reopening (that's what the
+   `kamal_podman` gem does, and it's why it shatters on every Kamal release).
+3. **Docker is default and byte-identical.** `container_engine: docker` must produce
+   exactly the commands stock Kamal produces. Every existing Kamal test stays green,
+   untouched. This is our regression net and our trust with upstream.
+4. **Every change independently upstreamable.** Each seam is a small PR that stands on
+   its own merits. Each one that lands upstream shrinks our carry.
+5. **Podman quirks isolated behind clear methods**, never scattered `if podman`
+   conditionals.
+
+---
+
+## The one core change — the engine seam
+
+Today, `lib/kamal/commands/base.rb`:
+
+```ruby
+def docker(*args)
+  args.compact.unshift :docker
+end
+```
+
+Every command Kamal builds routes through this single private method, so this one
+line is the whole seam. The plan:
+
+- Add `Kamal::Configuration#container_engine` → `:docker` (default) | `:podman`,
+  read from `deploy.yml` (`container_engine: podman`), validated to the known set.
+- Change `Commands::Base#docker` to `unshift config.container_engine` instead of the
+  literal `:docker`. Keep the method **named** `docker` — renaming it would churn
+  dozens of call sites and collide with every upstream diff for no functional gain.
+  It simply stops being hardcoded to the docker binary.
+
+That single change flips the binary for every command that routes through `#docker`
+— which is almost all of them. The exceptions are a handful of places that embed the
+literal string `"docker"` inside shell pipe/`while` bodies rather than calling the seam:
+`commands/prune.rb` and `commands/app/logging.rb` (see divergence rows 4–5). Those must
+be handled explicitly; the seam alone won't reach them. A guard test that greps the
+command output for a stray `docker ` under `container_engine: podman` catches any we miss.
+
+The seam is also **the crux upstream PR**: "let the container binary be configurable,
+default docker" is defensible to Kamal on its own merits, and if it lands, most of Lamak
+evaporates.
+
+---
+
+## The divergence map (where Docker and Podman genuinely differ)
+
+The `kamal_podman` gem already proved points 1–6 work in practice; its override files
+are our blueprint. We reimplement them as first-class, config-driven, **tested** code
+instead of runtime monkey-patches.
+
+| # | Area | File(s) | The difference | Plan | Upstream? |
+|---|------|---------|----------------|------|-----------|
+| 1 | Engine binary | `commands/base.rb` (`#docker`, line ~88) | hardcoded `:docker` | configurable `container_engine` seam (above) | **Yes — the crux** |
+| 2 | Registry prefix | `configuration.rb#repository` (line 192–193), `configuration/registry.rb` | `repository` joins `registry.server` + image; when `server` is blank the image is unqualified and Docker silently implies `docker.io/`, Podman does not | when podman + no registry server, qualify Docker Hub images with `docker.io/` | Maybe |
+| 3 | Proxy image | `configuration/proxy/boot.rb` (`image_default` → `basecamp/kamal-proxy`) | same unqualified-name issue for the proxy image | qualify the proxy image (`docker.io/basecamp/kamal-proxy`) under podman | Maybe |
+| 4 | Prune | `commands/prune.rb` | Two problems: `docker image prune --filter` has no Podman equivalent, **and** `tagged_images`/`app_containers`/`active_image_list` embed the literal string `docker` inside `pipe`/`shell` bodies (`while read … do docker rmi`, `docker container ls`) that **bypass the `#docker` seam entirely** — flipping the engine will not touch them | podman branch rewriting the whole method group; route the embedded literals through the engine value too | Podman-only (likely stays) |
+| 5 | Logs | `commands/app/logging.rb` | `logs`/`follow_logs` also embed the literal `xargs docker logs …` string, bypassing the seam; podman logs already emit to stderr (the `2>&1` is fine) | podman branch swapping the embedded binary; verify flag parity | Maybe |
+| 6 | Builder | `commands/builder/base.rb` (`push`, `info`, `inspect_builder`), `commands/builder.rb` | `docker :buildx, :build/ls/inspect` — no buildx / buildkit in Podman | podman builder target: `podman build` + `podman push`; stub the buildx lifecycle (`create`/`remove`/`inspect` no-op); reject remote / multi-arch / cloud builds under podman | Podman-only |
+| 7 | Bootstrap | `cli/server.rb#bootstrap` (orchestration) **and** `commands/docker.rb` (`KAMAL.docker`: `install` via get.docker.com, `in_docker_group?`, `add_to_docker_group`, `create_network`) | the entire install/verify/network path is Docker-specific — not just a version check | check for the configured engine; podman branch skips docker-group logic and the `get.docker.com` install; `network create` is podman-compatible | Maybe |
+| 8 | Proxy port caps | `configuration/proxy/boot.rb#default_boot_options` / deploy | rootful Podman doesn't grant `NET_BIND_SERVICE` by default | add the cap for `kamal-proxy` under podman | Podman-only |
+
+---
+
+## Beyond the gem — Lamak's differentiator: rootless + systemd
+
+Neither stock Kamal nor the `kamal_podman` gem handles **true rootless Podman**. This
+is Lamak's real reason to exist, and it maps directly onto the rootless Podman + linger
+setup already running on this machine (the Cap self-host stack).
+
+- **`<1024` binding.** `kamal-proxy` on 80/443 under rootless Podman needs
+  `net.ipv4.ip_unprivileged_port_start` lowered (host prep in `bootstrap`) — beyond the
+  rootful `cap-add: NET_BIND_SERVICE` workaround the gem documents.
+- **Lifecycle / boot survival.** Generate **Quadlet** `.container` units +
+  `loginctl enable-linger` + `systemctl --user daemon-reload` — the Podman-native
+  "stay up, survive reboot" path — instead of Docker restart policies.
+- Phased *after* rootful engine parity is proven, so we never debug two variables at once.
+
+---
+
+## Config surface
+
+```yaml
+# deploy.yml
+container_engine: podman   # default: docker
+```
+
+One obvious key, validated to `{docker, podman}`. Absent or `docker` ⇒ 100% stock
+behavior.
+
+---
+
+## Testing strategy
+
+- **Default-path safety.** Every existing Kamal unit test stays green and untouched —
+  proof that `container_engine: docker` is byte-identical to stock.
+- **Podman path.** Add fixtures with `container_engine: podman`; assert the emitted
+  commands are `podman …`. Mirror the gem's **auto-discovery test**: iterate every
+  `Commands::Base` subclass and assert the engine swap holds — this is what catches new
+  upstream commands after a rebase.
+- **E2E.** Adapt the gem's integration harness (Podman-in-container target VM + a local
+  registry, no Docker Hub dependency) for a full deploy under podman — rootful first,
+  then rootless.
+
+---
+
+## Upstream PR ladder (each merge shrinks Lamak's delta)
+
+1. **`erb` gemspec declaration** — generic bug: Kamal `require`s `erb` but doesn't
+   declare it, so it breaks on Ruby 3.4+ where `erb` is a bundled gem. Send now.
+2. **Engine seam** — `container_engine` configurable, default docker. The crux; advocate
+   hard. If it lands, Lamak's carry collapses.
+3. **Case-by-case** — registry / proxy / logs / bootstrap branches. Offer upstream; keep
+   in Lamak if declined.
+4. **Podman-only** — prune rewrite, buildx-less builder, rootless/systemd. Likely
+   permanent Lamak carry — and that's fine; it's our differentiator.
+
+**Goal state:** with #2 upstream, Lamak shrinks toward "Podman command quirks +
+rootless/systemd" only — a fork small enough to rebase in an afternoon.
+
+---
+
+## Fork maintenance workflow
+
+- `upstream` = `basecamp/kamal` (push disabled). Rebase our small delta onto each Kamal
+  release; the auto-discovery test flags any breakage immediately.
+- Keep every commit mapped to an intended PR, so rebasing and upstreaming stay mechanical
+  rather than archaeological.
+
+---
+
+## Milestones
+
+- **M1 — DONE.** Engine seam + docker-default parity: all existing tests green, and
+  `container_engine: podman` flips the binary end to end. (`config.container_engine`
+  → `Commands::Base#docker`.)
+- **M2 — DONE (unit-tested; e2e pending).** Podman divergence branches, all guarded so
+  `container_engine: docker` stays byte-identical (776 unit tests green):
+  - **Registry/proxy/accessory prefix** — `Configuration#image_reference` qualifies bare
+    Docker Hub refs with `docker.io/` under podman; applied at `repository`,
+    `Accessory#image`, `Proxy::Boot#image_default`, `Proxy::Run#image`.
+  - **Prune** — the embedded `docker` shell literals in `tagged_images`,
+    `app_containers`, `active_image_list` now use `config.container_engine`.
+  - **Logs** — the `xargs docker logs` literals in `App::Logging` now use the engine.
+  - **Bootstrap** — `cli/server.rb#bootstrap` only auto-installs under docker; podman
+    reports a manual-install error instead of running `get.docker.com`.
+  - **Builder** — `Commands::Builder::Podman` does `podman build` + per-tag `podman push`,
+    no-ops the buildx lifecycle, and `Builder#target` rejects remote/cloud/pack/multi-arch.
+  - **Proxy port caps** — `--cap-add=net_bind_service` added to the proxy run args under
+    podman (rootful <1024 bind).
+  - **Buildx check** — `ensure_local_buildx_installed` skips `podman buildx version`
+    (Podman has no buildx). *Found by real e2e — unit tests wouldn't have caught it.*
+  - **Docker-only container states** — Podman rejects `status=restarting` (app container
+    lookup / logs) and `status=dead` (prune); both dropped under podman. *Found by real e2e.*
+  - **Real e2e validated (rootless Podman 5.8.2 on this box):** `kamal build push`
+    ran for real — `podman login` → `podman build --platform … -t 127.0.0.1:5000/…:<sha>
+    -t …:latest … && podman push … && podman push …:latest` → both tags landed in a live
+    local registry. The exact `podman run` our lib emits booted the app container, which
+    served HTTP. The exact `logs` and `prune` pipelines ran clean against real Podman.
+  - Remaining for M2: full deploy *over SSH* (proxy boot + traffic switch) against a
+    Podman host — not run here (no sshd on this box; rootless <1024 proxy bind is M3).
+- **M3 — DONE (host-prep approach; Quadlet rejected).** Rootless boot-survival, chosen to
+  mirror Kamal's existing imperative model rather than rearchitect it into Quadlet units.
+  Decisive finding: this box's own rootless stack survives reboot **without** Quadlet — via
+  `--restart` policy + `podman-restart.service` + `enable-linger`, exactly the model Kamal
+  already emits. So `bootstrap` under podman now **self-detects rootless** (`podman info …
+  Rootless`) and, when true, runs `loginctl enable-linger <user>` +
+  `systemctl --user enable --now podman-restart.service`. Kamal's deploy model, `--restart
+  unless-stopped` policy, and zero-downtime switch are **unchanged** (Podman 5.x's
+  `should-start-on-boot=true` filter covers `unless-stopped`, so no policy change needed).
+  Validated on real rootless Podman 5.8.2. No new config surface.
+  - **Not covered (separate, root-level):** binding 80/443 rootless needs
+    `net.ipv4.ip_unprivileged_port_start` ≤ 80 — a host sysctl requiring root, left to the
+    operator (rootful uses the M2 `--cap-add=net_bind_service` instead).
+- **M3 rejected alternative** — Quadlet `.container` units: Podman-native but conflicts with
+  Kamal's new-alongside-old zero-downtime switch and diverges from the proven local
+  convention. Higher divergence debt for no functional gain here.
+- **M4** — Dogfood: deploy `adamkstinson-site` on Lamak.
+- **Ongoing** — upstream PR drip.
+
+---
+
+## Open decisions to confirm
+
+- **Config key name:** `container_engine` (proposed) vs. reusing an existing Kamal
+  concept.
+- **Rebrand depth:** soft fork (keep the internal `Kamal` namespace, brand externally as
+  Lamak) — recommended, and assumed by this plan. Confirm before we touch naming.
+- **Distribution:** publish Lamak as a gem with a `lamak` binary, or keep it repo-only
+  for now.

--- a/README.md
+++ b/README.md
@@ -1,13 +1,91 @@
-# Kamal: Deploy web apps anywhere
+# Lamak: Kamal that also speaks Podman
 
-From bare metal to cloud VMs, deploy web apps anywhere with zero downtime. Kamal uses [kamal-proxy](https://github.com/basecamp/kamal-proxy) to seamlessly switch requests between containers. Works seamlessly across multiple servers, using SSHKit to execute commands. Originally built for Rails apps, Kamal will work with any type of web app that can be containerized with Docker.
+Lamak is a soft fork of [Kamal](https://github.com/basecamp/kamal) that teaches it to drive
+**Podman as well as Docker**, chosen by a single config value. Everything else is Kamal:
+same commands, same `deploy.yml`, same zero-downtime deploys via
+[kamal-proxy](https://github.com/basecamp/kamal-proxy). Docker stays the default and is
+byte-identical to upstream — the entire Podman path is gated behind one setting, so
+`container_engine: docker` (or omitting it) is exactly stock Kamal.
 
-➡️ See [kamal-deploy.org](https://kamal-deploy.org) for documentation on [installation](https://kamal-deploy.org/docs/installation), [configuration](https://kamal-deploy.org/docs/configuration), and [commands](https://kamal-deploy.org/docs/commands).
+The name is `kamal` reversed. Internally the gem, the `kamal` binary, and the `Kamal`
+namespace are unchanged, so the fork tracks upstream cheaply.
 
-## Contributing to the documentation
+## Why this exists
 
-Please help us improve Kamal's documentation on [the basecamp/kamal-site repository](https://github.com/basecamp/kamal-site).
+Podman runs containers **rootless** and **daemonless** — no root-owned daemon, each app
+in an unprivileged user account. That's a better fit for small, self-hosted, single-tenant
+deployments than Docker's root daemon. Kamal only speaks Docker; Lamak lets you keep Kamal's
+whole workflow while running Podman underneath, including a true rootless setup that survives
+reboots.
+
+## Quick start
+
+**1. Point your app at Lamak** instead of the `kamal` gem. In your `Gemfile`:
+
+```ruby
+gem "kamal", github: "adamkstinson/lamak", branch: "podman-support"
+```
+
+**2. Set the engine** in `config/deploy.yml`:
+
+```yaml
+container_engine: podman   # default: docker
+```
+
+**3. Deploy as normal.** Every command works unchanged:
+
+```bash
+kamal server bootstrap   # prepares the host (see below)
+kamal setup              # first deploy
+kamal deploy             # subsequent deploys
+kamal app logs -f
+kamal prune all
+```
+
+That's the whole difference. The engine flips to `podman` everywhere at once.
+
+## What the target host needs
+
+- **Podman installed.** Unlike Docker, Lamak will not auto-install Podman (there's no
+  universal installer) — `bootstrap` checks for it and, if missing, tells you to install it
+  for your distro. Everything downstream is automatic.
+- **Rootless hosts get boot-survival for free.** `kamal server bootstrap` detects rootless
+  Podman and enables `linger` + `podman-restart.service`, the rootless analog of the Docker
+  daemon restarting your containers after a reboot. Kamal's normal `--restart` policy is
+  untouched.
+- **Binding 80/443 rootless is the one manual step.** Rootless Podman can't bind ports below
+  1024 by default. Either:
+  - lower it host-wide (root): `sysctl -w net.ipv4.ip_unprivileged_port_start=80` (persist in
+    `/etc/sysctl.d/`), **or**
+  - run **rootful** Podman, where Lamak adds `--cap-add=net_bind_service` to the proxy for you.
+
+## How Podman differs (Lamak handles these automatically)
+
+- **Image names** — bare Docker Hub references (`nginx`, `basecamp/kamal-proxy`, your app on
+  Docker Hub) are qualified with `docker.io/` under Podman, which doesn't assume it the way
+  Docker does. Registries with an explicit host are left alone.
+- **Builds** — Podman has no buildx/BuildKit, so Lamak uses `podman build` + `podman push`.
+  This means builds are **local and single-architecture only**: remote, cloud, pack, and
+  multi-arch builders are rejected with a clear error under Podman. Build your image on a host
+  matching your servers' architecture.
+- **Prune, logs, container filters** — rewritten where Podman's CLI differs from Docker's
+  (e.g. Podman has no `restarting`/`dead` container states).
+
+## Status & limitations
+
+Command generation is unit-tested (Docker output is guaranteed identical to upstream) and has
+been exercised end-to-end against real rootless Podman — build, push, container boot, and a
+live kamal-proxy traffic switch. Not yet covered: a full SSH-driven deploy in CI. Treat your
+first real Podman deploy as a shakedown.
+
+See [`PODMAN-PLAN.md`](PODMAN-PLAN.md) for the design, the divergence map, and the rationale
+behind each choice.
+
+## Upstream
+
+Lamak tracks `basecamp/kamal` and aims to feed generic improvements back as small PRs. For
+Kamal's own documentation see [kamal-deploy.org](https://kamal-deploy.org).
 
 ## License
 
-Kamal is released under the [MIT License](https://opensource.org/licenses/MIT).
+Released under the [MIT License](https://opensource.org/licenses/MIT), same as Kamal.

--- a/lib/kamal/cli/server.rb
+++ b/lib/kamal/cli/server.rb
@@ -38,10 +38,12 @@ class Kamal::Cli::Server < Kamal::Cli::Base
   def bootstrap
     modify(lock: true) do
       missing = []
+      engine = KAMAL.config.container_engine
 
       on(KAMAL.hosts) do |host|
         unless execute(*KAMAL.docker.installed?, raise_on_non_zero_exit: false)
-          if execute(*KAMAL.docker.superuser?, raise_on_non_zero_exit: false)
+          # Only Docker can be auto-installed via a universal script; Podman is distro-specific.
+          if engine == :docker && execute(*KAMAL.docker.superuser?, raise_on_non_zero_exit: false)
             info "Missing Docker on #{host}. Installing…"
             execute *KAMAL.docker.install
 
@@ -61,7 +63,23 @@ class Kamal::Cli::Server < Kamal::Cli::Base
       end
 
       if missing.any?
-        raise "Docker is not installed on #{missing.join(", ")} and can't be automatically installed without having root access and either `wget` or `curl`. Install Docker manually: https://docs.docker.com/engine/install/"
+        if engine == :docker
+          raise "Docker is not installed on #{missing.join(", ")} and can't be automatically installed without having root access and either `wget` or `curl`. Install Docker manually: https://docs.docker.com/engine/install/"
+        else
+          raise "Podman is not installed on #{missing.join(", ")}. Kamal can't install Podman automatically; install it manually: https://podman.io/docs/installation"
+        end
+      end
+
+      if engine == :podman
+        # Rootless Podman survives reboot via linger + the user restart service — the
+        # analog of the Docker daemon starting at boot and restarting containers.
+        on(KAMAL.hosts) do |host|
+          if execute(*KAMAL.docker.rootless?, raise_on_non_zero_exit: false)
+            info "Enabling rootless Podman boot survival on #{host}…"
+            execute *KAMAL.docker.enable_linger, raise_on_non_zero_exit: false
+            execute *KAMAL.docker.enable_podman_restart, raise_on_non_zero_exit: false
+          end
+        end
       end
 
       run_hook "docker-setup"

--- a/lib/kamal/commands/app.rb
+++ b/lib/kamal/commands/app.rb
@@ -114,6 +114,8 @@ class Kamal::Commands::App < Kamal::Commands::Base
         filters << "label=destination=#{config.destination}"
         filters << "label=role=#{role}" if role
         statuses&.each do |status|
+          # Podman has no "restarting" container state; it rejects the filter outright.
+          next if config.container_engine == :podman && status.to_sym == :restarting
           filters << "status=#{status}"
         end
       end

--- a/lib/kamal/commands/app/logging.rb
+++ b/lib/kamal/commands/app/logging.rb
@@ -2,7 +2,7 @@ module Kamal::Commands::App::Logging
   def logs(container_id: nil, timestamps: true, since: nil, lines: nil, grep: nil, grep_options: nil)
     pipe \
       container_id_command(container_id),
-      "xargs docker logs#{" --timestamps" if timestamps}#{" --since #{since}" if since}#{" --tail #{lines}" if lines} 2>&1",
+      "xargs #{config.container_engine} logs#{" --timestamps" if timestamps}#{" --since #{since}" if since}#{" --tail #{lines}" if lines} 2>&1",
       ("grep '#{grep}'#{" #{grep_options}" if grep_options}" if grep)
   end
 
@@ -10,7 +10,7 @@ module Kamal::Commands::App::Logging
     run_over_ssh \
       pipe(
         container_id_command(container_id),
-        "xargs docker logs#{" --timestamps" if timestamps}#{" --tail #{lines}" if lines} --follow 2>&1",
+        "xargs #{config.container_engine} logs#{" --timestamps" if timestamps}#{" --tail #{lines}" if lines} --follow 2>&1",
         (%(grep "#{grep}"#{" #{grep_options}" if grep_options}) if grep)
       ),
       host: host

--- a/lib/kamal/commands/base.rb
+++ b/lib/kamal/commands/base.rb
@@ -81,7 +81,7 @@ module Kamal::Commands
       end
 
       def docker(*args)
-        args.compact.unshift :docker
+        args.compact.unshift config.container_engine
       end
 
       def pack(*args)
@@ -137,7 +137,8 @@ module Kamal::Commands
       end
 
       def ensure_local_buildx_installed
-        docker :buildx, "version"
+        # Podman has no buildx; only Docker needs the plugin checked.
+        docker :buildx, "version" unless config.container_engine == :podman
       end
 
       def docker_interactive_args

--- a/lib/kamal/commands/builder.rb
+++ b/lib/kamal/commands/builder.rb
@@ -17,7 +17,10 @@ class Kamal::Commands::Builder < Kamal::Commands::Base
   end
 
   def target
-    if remote?
+    if config.container_engine == :podman
+      ensure_podman_builder_supported
+      podman
+    elsif remote?
       if local?
         hybrid
       else
@@ -30,6 +33,10 @@ class Kamal::Commands::Builder < Kamal::Commands::Base
     else
       local
     end
+  end
+
+  def podman
+    @podman ||= Kamal::Commands::Builder::Podman.new(config)
   end
 
   def remote
@@ -51,4 +58,15 @@ class Kamal::Commands::Builder < Kamal::Commands::Base
   def cloud
     @cloud ||= Kamal::Commands::Builder::Cloud.new(config)
   end
+
+  private
+    def ensure_podman_builder_supported
+      if remote? || cloud? || pack?
+        raise ArgumentError, "Podman builds must be local: remote, cloud, and pack builders aren't supported under container_engine: podman"
+      end
+
+      if config.builder.arches.size > 1
+        raise ArgumentError, "Podman builds are single-arch: set a single builder arch under container_engine: podman"
+      end
+    end
 end

--- a/lib/kamal/commands/builder/podman.rb
+++ b/lib/kamal/commands/builder/podman.rb
@@ -1,0 +1,39 @@
+class Kamal::Commands::Builder::Podman < Kamal::Commands::Builder::Base
+  # Podman has no buildx/buildkit, so there's no persistent builder instance to
+  # create, remove, or inspect. These no-op exactly like the docker-driver path.
+  def create
+  end
+
+  def remove
+  end
+
+  def inspect_builder
+  end
+
+  def info
+    docker :version
+  end
+
+  # `podman build` (no buildx) then push each tag, since Podman can't stream the
+  # build straight to a registry the way `buildx --output=type=registry` does.
+  def push(export_action = "registry", tag_as_dirty: false, no_cache: false)
+    combine \
+      build(tag_as_dirty: tag_as_dirty, no_cache: no_cache),
+      *(build_tag_names(tag_as_dirty: tag_as_dirty).map { |tag| docker(:push, tag) } if export_action == "registry")
+  end
+
+  private
+    def build(tag_as_dirty:, no_cache:)
+      docker :build,
+        *platform_options(arches),
+        *build_tag_options(tag_as_dirty: tag_as_dirty),
+        *build_options,
+        *([ "--no-cache" ] if no_cache),
+        build_context,
+        "2>&1"
+    end
+
+    def builder_name
+      "kamal-podman"
+    end
+end

--- a/lib/kamal/commands/docker.rb
+++ b/lib/kamal/commands/docker.rb
@@ -39,6 +39,26 @@ class Kamal::Commands::Docker < Kamal::Commands::Base
     docker :network, :create, :kamal
   end
 
+  # Only rootless Podman needs the linger + user restart service for boot survival;
+  # rootful Podman and Docker are managed by system systemd / the daemon.
+  def rootless?
+    pipe \
+      docker(:info, "--format", "'{{.Host.Security.Rootless}}'"),
+      [ :grep, "-q", "true" ]
+  end
+
+  # Keep the user manager (and thus the containers) running after logout and across
+  # reboots — the rootless analog of the Docker daemon starting at boot.
+  def enable_linger
+    [ :loginctl, "enable-linger", config.ssh.user ]
+  end
+
+  # Restart `unless-stopped`/`always` containers on boot (should-start-on-boot=true),
+  # the rootless analog of the Docker daemon restarting them.
+  def enable_podman_restart
+    [ :systemctl, "--user", "enable", "--now", "podman-restart.service" ]
+  end
+
   private
     def get_docker
       shell \

--- a/lib/kamal/commands/prune.rb
+++ b/lib/kamal/commands/prune.rb
@@ -10,26 +10,29 @@ class Kamal::Commands::Prune < Kamal::Commands::Base
     pipe \
       docker(:image, :ls, *service_filter, "--format", "'{{.ID}} {{.Repository}}:{{.Tag}}'"),
       grep("-v -w \"#{active_image_list}\""),
-      "while read image tag; do docker rmi $tag; done"
+      "while read image tag; do #{config.container_engine} rmi $tag; done"
   end
 
   def app_containers(retain:)
     pipe \
       docker(:ps, "-q", "-a", *service_filter, *stopped_containers_filters),
       "tail -n +#{retain + 1}",
-      "while read container_id; do docker rm $container_id; done"
+      "while read container_id; do #{config.container_engine} rm $container_id; done"
   end
 
   private
     def stopped_containers_filters
-      [ "created", "exited", "dead" ].flat_map { |status| [ "--filter", "status=#{status}" ] }
+      # Podman has no "dead" container state; it rejects the filter outright.
+      statuses = [ "created", "exited" ]
+      statuses << "dead" unless config.container_engine == :podman
+      statuses.flat_map { |status| [ "--filter", "status=#{status}" ] }
     end
 
     def active_image_list
       # Pull the images that are used by any containers
       # Append repo:latest - to avoid deleting the latest tag
       # Append repo:<none> - to avoid deleting dangling images that are in use. Unused dangling images are deleted separately
-      "$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=#{config.service} | tr -d '\\n')#{config.latest_image}\\|#{config.repository}:<none>"
+      "$(#{config.container_engine} container ls -a --format '{{.Image}}\\|' --filter label=service=#{config.service} | tr -d '\\n')#{config.latest_image}\\|#{config.repository}:<none>"
     end
 
     def service_filter

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -7,6 +7,7 @@ require "net/ssh/proxy/jump"
 
 class Kamal::Configuration
   HOOKS_OUTPUT_LEVELS = [ :quiet, :verbose ].freeze
+  CONTAINER_ENGINES = [ :docker, :podman ].freeze
 
   delegate :service, :labels, :hooks_path, to: :raw_config, allow_nil: true
   delegate :argumentize, :optionize, to: Kamal::Utils
@@ -88,6 +89,25 @@ class Kamal::Configuration
     ensure_local_registry_remote_builder_has_ssh_url
     ensure_no_conflicting_proxy_runs
     ensure_valid_hooks_output!
+    ensure_valid_container_engine
+  end
+
+  # The container binary every command routes through — docker (default) or podman.
+  def container_engine
+    (raw_config.container_engine || "docker").to_sym
+  end
+
+  # Podman doesn't assume Docker's implicit "docker.io/" for bare Docker Hub
+  # references, so qualify them explicitly when the engine is podman. No-op for docker.
+  def image_reference(reference)
+    return reference unless container_engine == :podman
+
+    registry, slash, _rest = reference.to_s.partition("/")
+    if slash.empty? || !(registry.include?(".") || registry.include?(":") || registry == "localhost")
+      "docker.io/#{reference}"
+    else
+      reference
+    end
   end
 
   def version=(version)
@@ -190,7 +210,7 @@ class Kamal::Configuration
   end
 
   def repository
-    [ registry.server, image ].compact.join("/")
+    image_reference([ registry.server, image ].compact.join("/"))
   end
 
   def absolute_image
@@ -430,6 +450,14 @@ class Kamal::Configuration
 
     def role_names
       raw_config.servers.is_a?(Array) ? [ "web" ] : raw_config.servers.keys.sort
+    end
+
+    def ensure_valid_container_engine
+      unless CONTAINER_ENGINES.include?(container_engine)
+        raise Kamal::ConfigurationError, "Invalid container_engine '#{container_engine}', must be one of: #{CONTAINER_ENGINES.join(", ")}"
+      end
+
+      true
     end
 
     def ensure_valid_hooks_output!

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -28,7 +28,7 @@ class Kamal::Configuration::Accessory
   end
 
   def image
-    [ registry&.server, accessory_config["image"] ].compact.join("/")
+    config.image_reference([ registry&.server, accessory_config["image"] ].compact.join("/"))
   end
 
   def hosts

--- a/lib/kamal/configuration/docs/configuration.yml
+++ b/lib/kamal/configuration/docs/configuration.yml
@@ -30,6 +30,12 @@ service: myapp
 # The image will be pushed to the configured registry.
 image: my-image
 
+# The container engine
+#
+# Kamal drives Docker by default. Set this to `podman` to build and run
+# containers with Podman instead. Absent or `docker` is fully stock behavior.
+container_engine: docker
+
 # Labels
 #
 # Additional labels to add to the container:

--- a/lib/kamal/configuration/proxy/boot.rb
+++ b/lib/kamal/configuration/proxy/boot.rb
@@ -24,9 +24,16 @@ class Kamal::Configuration::Proxy::Boot
 
   def default_boot_options
     [
+      *bind_capability,
       *(publish_args(Kamal::Configuration::Proxy::Run::DEFAULT_HTTP_PORT, Kamal::Configuration::Proxy::Run::DEFAULT_HTTPS_PORT, nil)),
       *(logging_args(Kamal::Configuration::Proxy::Run::DEFAULT_LOG_MAX_SIZE))
     ]
+  end
+
+  # Rootful Podman doesn't grant NET_BIND_SERVICE by default, so the proxy can't
+  # bind 80/443 without it. Docker grants it out of the box.
+  def bind_capability
+    "--cap-add=net_bind_service" if config.container_engine == :podman
   end
 
   def repository_name
@@ -38,7 +45,7 @@ class Kamal::Configuration::Proxy::Boot
   end
 
   def image_default
-    "#{repository_name}/#{image_name}"
+    config.image_reference("#{repository_name}/#{image_name}")
   end
 
   def container_name

--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -66,7 +66,7 @@ class Kamal::Configuration::Proxy::Run
   end
 
   def image
-    "#{[ registry, repository ].compact.join("/")}:#{version}"
+    config.image_reference("#{[ registry, repository ].compact.join("/")}:#{version}")
   end
 
   def container_name
@@ -93,6 +93,7 @@ class Kamal::Configuration::Proxy::Run
 
   def docker_options_args
     [
+      *("--cap-add=net_bind_service" if config.container_engine == :podman),
       *apps_volume_args,
       *publish_args,
       *logging_args,

--- a/test/cli/server_test.rb
+++ b/test/cli/server_test.rb
@@ -104,6 +104,40 @@ class CliServerTest < CliTestCase
     end
   end
 
+  test "bootstrap checks for podman and never runs the docker installer" do
+    stub_setup
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:podman, "-v", raise_on_non_zero_exit: false).returns(false).at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:mkdir, "-p", ".kamal").returns("").at_least_once
+    # The docker install script must never be invoked under podman.
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:sh, "-c", regexp_matches(/get.docker.com/), "|", :sh).never
+
+    assert_raise RuntimeError do
+      stdouted { Kamal::Cli::Server.start([ "bootstrap", "-c", "test/fixtures/deploy_with_podman.yml" ]) }
+    end
+  end
+
+  test "bootstrap enables rootless podman boot survival when podman is rootless" do
+    stub_setup
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:mkdir, "-p", ".kamal").returns("").at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:podman, "-v", raise_on_non_zero_exit: false).returns(true).at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:podman, :info, "--format", "'{{.Host.Security.Rootless}}'", "|", :grep, "-q", "true", raise_on_non_zero_exit: false).returns(true).at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:loginctl, "enable-linger", "root", raise_on_non_zero_exit: false).at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:systemctl, "--user", "enable", "--now", "podman-restart.service", raise_on_non_zero_exit: false).at_least_once
+
+    stdouted { Kamal::Cli::Server.start([ "bootstrap", "-c", "test/fixtures/deploy_with_podman.yml" ]) }
+  end
+
+  test "bootstrap skips rootless setup for rootful podman" do
+    stub_setup
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:mkdir, "-p", ".kamal").returns("").at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:podman, "-v", raise_on_non_zero_exit: false).returns(true).at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:podman, :info, "--format", "'{{.Host.Security.Rootless}}'", "|", :grep, "-q", "true", raise_on_non_zero_exit: false).returns(false).at_least_once
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:loginctl, "enable-linger", "root", raise_on_non_zero_exit: false).never
+    SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:systemctl, "--user", "enable", "--now", "podman-restart.service", raise_on_non_zero_exit: false).never
+
+    stdouted { Kamal::Cli::Server.start([ "bootstrap", "-c", "test/fixtures/deploy_with_podman.yml" ]) }
+  end
+
   private
     def run_command(*command)
       stdouted { Kamal::Cli::Server.start([ *command, "-c", "test/fixtures/deploy_with_accessories.yml" ]) }

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -217,6 +217,13 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
       new_command(:busybox).remove.join(" ")
   end
 
+  test "pull image qualifies docker hub images under podman" do
+    @config[:container_engine] = "podman"
+    assert_equal \
+      "podman image pull docker.io/redis:latest",
+      new_command(:redis).pull_image.join(" ")
+  end
+
   private
     def new_command(accessory)
       Kamal::Commands::Accessory.new(Kamal::Configuration.new(@config), name: accessory)

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -599,6 +599,20 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command.remove_proxy_app_directory.join(" ")
   end
 
+  test "logs swaps the embedded binary under podman" do
+    @config[:container_engine] = "podman"
+    assert_equal \
+      "sh -c 'echo C137' | xargs podman logs --timestamps 2>&1",
+      new_command.logs(container_id: "C137").join(" ")
+  end
+
+  test "podman drops the restarting status filter it doesn't support" do
+    @config[:container_engine] = "podman"
+    command = new_command.logs.join(" ")
+    assert_no_match(/status=restarting/, command)
+    assert_match(/status=running/, command)
+  end
+
   private
     def new_command(role: "web", host: "1.1.1.1", **additional_config)
       config = Kamal::Configuration.new(@config.merge(additional_config), destination: @destination, version: "999")

--- a/test/commands/base_test.rb
+++ b/test/commands/base_test.rb
@@ -1,0 +1,45 @@
+require "test_helper"
+
+class CommandsBaseTest < ActiveSupport::TestCase
+  setup do
+    @config_hash = {
+      service: "app", image: "dhh/app",
+      registry: { "username" => "dhh", "password" => "secret" },
+      servers: [ "1.1.1.1" ], builder: { "arch" => "amd64" }
+    }
+  end
+
+  test "docker seam defaults to the docker binary" do
+    assert_equal [ :docker, :ps ], base.send(:docker, :ps)
+  end
+
+  test "docker seam switches to podman when configured" do
+    assert_equal [ :podman, :ps ], base(container_engine: "podman").send(:docker, :ps)
+  end
+
+  # Guards the divergence claim: every command routes through the seam, so a full
+  # built command flips its binary end to end with a single config value.
+  test "engine swap threads through a fully built command" do
+    assert_match(/\Adocker run /, app.run.join(" "))
+    assert_match(/\Apodman run /, app(container_engine: "podman").run.join(" "))
+  end
+
+  test "ensure_docker_installed skips the buildx check under podman" do
+    assert_equal "docker --version && docker buildx version", base.ensure_docker_installed.join(" ")
+    assert_equal "podman --version", base(container_engine: "podman").ensure_docker_installed.join(" ")
+  end
+
+  private
+    def base(**extra)
+      Kamal::Commands::Base.new(config(**extra))
+    end
+
+    def app(**extra)
+      config = config(**extra)
+      Kamal::Commands::App.new(config, role: config.role("web"), host: "1.1.1.1")
+    end
+
+    def config(**extra)
+      Kamal::Configuration.new(@config_hash.merge(extra), version: "999")
+    end
+end

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -279,7 +279,31 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.create.join(" ")
   end
 
+  test "podman builds locally with podman build and pushes each tag" do
+    builder = podman_builder_command
+    assert_equal "podman", builder.name
+    assert_equal \
+      "podman build --platform linux/amd64 -t docker.io/dhh/app:123 -t docker.io/dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1 && podman push docker.io/dhh/app:123 && podman push docker.io/dhh/app:latest",
+      builder.push.join(" ")
+  end
+
+  test "podman builder create, remove, and inspect are no-ops" do
+    builder = podman_builder_command
+    assert_nil builder.create
+    assert_nil builder.remove
+    assert_nil builder.inspect_builder
+  end
+
+  test "podman rejects remote, cloud, and multi-arch builds" do
+    assert_raises(ArgumentError) { podman_builder_command(builder: { "remote" => "ssh://app@127.0.0.1", "local" => false }).name }
+    assert_raises(ArgumentError) { podman_builder_command(builder: { "arch" => [ "amd64", "arm64" ] }).name }
+  end
+
   private
+    def podman_builder_command(additional_config = {})
+      new_builder_command(additional_config.deep_merge(container_engine: "podman"))
+    end
+
     def new_builder_command(additional_config = {})
       Kamal::Configuration.new(@config.deep_merge(additional_config), version: "123").then do |config|
         KAMAL.reset

--- a/test/commands/docker_test.rb
+++ b/test/commands/docker_test.rb
@@ -39,4 +39,11 @@ class CommandsDockerTest < ActiveSupport::TestCase
   test "refresh_session" do
     assert_equal "kill -HUP $PPID", @docker.refresh_session.join(" ")
   end
+
+  test "rootless boot-survival commands under podman" do
+    podman = Kamal::Commands::Docker.new(Kamal::Configuration.new(@config.merge(container_engine: "podman", ssh: { "user" => "deploy" })))
+    assert_equal "podman info --format '{{.Host.Security.Rootless}}' | grep -q true", podman.rootless?.join(" ")
+    assert_equal "loginctl enable-linger deploy", podman.enable_linger.join(" ")
+    assert_equal "systemctl --user enable --now podman-restart.service", podman.enable_podman_restart.join(" ")
+  end
 end

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -221,6 +221,13 @@ class CommandsProxyTest < ActiveSupport::TestCase
       new_command.run.join(" ")
   end
 
+  test "run qualifies the proxy image and flips the binary under podman" do
+    @config[:container_engine] = "podman"
+    command = new_command.run.join(" ")
+    assert_match %r{echo "docker.io/basecamp/kamal-proxy"}, command
+    assert_match %r{\| xargs podman run }, command
+  end
+
   private
     def new_command
       Kamal::Commands::Proxy.new(Kamal::Configuration.new(@config, version: "123"), host: "1.1.1.1")

--- a/test/commands/prune_test.rb
+++ b/test/commands/prune_test.rb
@@ -30,6 +30,23 @@ class CommandsPruneTest < ActiveSupport::TestCase
       new_command.app_containers(retain: 3).join(" ")
   end
 
+  test "podman swaps the binary in embedded shell literals too" do
+    @config[:container_engine] = "podman"
+
+    assert_equal \
+      "podman image ls --filter label=service=app --format '{{.ID}} {{.Repository}}:{{.Tag}}' | grep -v -w \"$(podman container ls -a --format '{{.Image}}\\|' --filter label=service=app | tr -d '\\n')docker.io/dhh/app:latest\\|docker.io/dhh/app:<none>\" | while read image tag; do podman rmi $tag; done",
+      new_command.tagged_images.join(" ")
+
+    assert_equal \
+      "podman ps -q -a --filter label=service=app --filter status=created --filter status=exited | tail -n +6 | while read container_id; do podman rm $container_id; done",
+      new_command.app_containers(retain: 5).join(" ")
+
+    assert_no_match(/(?<!\.io\/)\bdocker\b/, new_command.dangling_images.join(" "))
+    # Podman rejects the docker-only "dead" state.
+    assert_no_match(/status=dead/, new_command.app_containers(retain: 5).join(" "))
+    assert_match(/status=created --filter status=exited/, new_command.app_containers(retain: 5).join(" "))
+  end
+
   private
     def new_command
       Kamal::Commands::Prune.new(Kamal::Configuration.new(@config, version: "123"))

--- a/test/configuration/proxy/boot_test.rb
+++ b/test/configuration/proxy/boot_test.rb
@@ -18,6 +18,13 @@ class ConfigurationProxyBootTest < ActiveSupport::TestCase
     @proxy_boot_config = @config.proxy_boot
   end
 
+  test "default boot options add net_bind_service only under podman" do
+    assert_equal "--publish 80:80 --publish 443:443 --log-opt max-size=10m", @config.proxy_boot.default_boot_options.join(" ")
+
+    podman = Kamal::Configuration.new(@deploy.merge(container_engine: "podman"))
+    assert_equal "--cap-add=net_bind_service --publish 80:80 --publish 443:443 --log-opt max-size=10m", podman.proxy_boot.default_boot_options.join(" ")
+  end
+
   test "proxy directories" do
     assert_equal ".kamal/proxy/apps-config", @proxy_boot_config.apps_directory
     assert_equal "/home/kamal-proxy/.apps-config", @proxy_boot_config.apps_container_directory

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -56,6 +56,45 @@ class ConfigurationTest < ActiveSupport::TestCase
     }).image
   end
 
+  test "container engine defaults to docker" do
+    assert_equal :docker, @config.container_engine
+  end
+
+  test "container engine can be set to podman" do
+    assert_equal :podman, Kamal::Configuration.new(@deploy.merge(container_engine: "podman")).container_engine
+  end
+
+  test "container engine must be docker or podman" do
+    assert_raise(Kamal::ConfigurationError) do
+      Kamal::Configuration.new(@deploy.merge(container_engine: "containerd"))
+    end
+  end
+
+  test "image_reference is a no-op under docker" do
+    assert_equal "redis:latest", @config.image_reference("redis:latest")
+    assert_equal "dhh/app", @config.image_reference("dhh/app")
+  end
+
+  test "image_reference qualifies only bare docker hub references under podman" do
+    podman = Kamal::Configuration.new(@deploy.merge(container_engine: "podman"))
+    assert_equal "docker.io/redis:latest", podman.image_reference("redis:latest")
+    assert_equal "docker.io/dhh/app", podman.image_reference("dhh/app")
+    assert_equal "docker.io/basecamp/kamal-proxy:v1", podman.image_reference("basecamp/kamal-proxy:v1")
+    assert_equal "ghcr.io/me/app", podman.image_reference("ghcr.io/me/app")
+    assert_equal "localhost:5000/app", podman.image_reference("localhost:5000/app")
+  end
+
+  test "repository qualifies docker hub images under podman" do
+    assert_equal "docker.io/dhh/app",
+      Kamal::Configuration.new(@deploy.merge(container_engine: "podman")).repository
+
+    assert_equal "registry.example.com/dhh/app",
+      Kamal::Configuration.new(@deploy.merge(
+        container_engine: "podman",
+        registry: { "server" => "registry.example.com", "username" => "dhh", "password" => "secret" }
+      )).repository
+  end
+
   test "service name valid" do
     assert_nothing_raised do
       Kamal::Configuration.new(@deploy.tap { |config| config[:service] = "hey-app1_primary" })

--- a/test/fixtures/deploy_with_podman.yml
+++ b/test/fixtures/deploy_with_podman.yml
@@ -1,0 +1,11 @@
+service: app
+image: dhh/app
+container_engine: podman
+servers:
+  - "1.1.1.1"
+  - "1.1.1.2"
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64


### PR DESCRIPTION
Teaches Kamal to drive Podman as well as Docker, selected by a single `container_engine: podman` config value. Docker stays the byte-identical default: every pre-existing test passes untouched.

M1 — engine seam:
- Configuration#container_engine (default :docker), validated to {docker,podman}
- Commands::Base#docker unshifts the configured engine instead of literal :docker

M2 — divergence branches (all guarded so docker is unchanged):
- Image qualification: Configuration#image_reference prefixes bare Docker Hub refs with docker.io/ under podman (app, accessory, proxy images)
- Prune & logs: engine-swapped the literal "docker" shell strings that bypass the #docker seam
- Bootstrap: podman isn't auto-installed via get.docker.com; reports a manual install instead
- Builder: Commands::Builder::Podman does `podman build` + per-tag `podman push`, no-ops the buildx lifecycle; rejects remote/cloud/pack/multi-arch
- Proxy: --cap-add=net_bind_service under podman (rootful <1024 bind)
- Buildx/container-state gaps found by real e2e against Podman 5.8.2: skip `podman buildx version`; drop docker-only status=restarting / status=dead

M3 — rootless boot-survival (host-prep, not Quadlet):
- bootstrap self-detects rootless podman and runs `loginctl enable-linger` + `systemctl --user enable --now podman-restart.service` — the rootless analog of the Docker daemon restarting containers at boot. Kamal's deploy model, --restart policy, and zero-downtime switch are unchanged.

Validated end-to-end on real rootless Podman: build+push to a registry, app container boot, and a live kamal-proxy traffic switch.

Docs: CLAUDE.md (repo guide) and PODMAN-PLAN.md (design/rationale).