### PR TITLE
Preserve dollar signs in command substitution output in secrets files

### DIFF
--- a/lib/kamal/secrets/dotenv/inline_command_substitution.rb
+++ b/lib/kamal/secrets/dotenv/inline_command_substitution.rb
@@ -15,7 +15,19 @@ class Kamal::Secrets::Dotenv::InlineCommandSubstitution
 
   class << self
     def install!
-      ::Dotenv::Parser.substitutions.map! { |sub| sub == ::Dotenv::Substitutions::Command ? self : sub }
+      substitutions = ::Dotenv::Parser.substitutions
+      substitutions.map! { |sub| sub == ::Dotenv::Substitutions::Command ? self : sub }
+
+      # Run variable substitution before command substitution, so command
+      # output is inserted literally. Otherwise a "$word" in the output --
+      # common in passwords and tokens -- is treated as a reference to a
+      # (usually undefined) variable and silently dropped. This matches
+      # POSIX shell semantics, where the output of command substitution is
+      # not subject to further expansion. Variable references inside the
+      # command itself are still substituted in #call before execution.
+      if substitutions.delete(::Dotenv::Substitutions::Variable)
+        substitutions.unshift(::Dotenv::Substitutions::Variable)
+      end
     end
 
     def call(value, env, overwrite: false)

--- a/test/secrets_test.rb
+++ b/test/secrets_test.rb
@@ -26,6 +26,29 @@ class SecretsTest < ActiveSupport::TestCase
     end
   end
 
+  test "command interpolation preserves dollar signs in the output" do
+    # The command outputs pa$1wor$D. Built with tr because "$word" in the
+    # command text itself is substituted before running.
+    with_test_secrets("secrets" => "SECRET=$(echo 'paX1worXD' | tr X '$')") do
+      assert_equal "pa$1wor$D", Kamal::Secrets.new(secrets_path: ".kamal/secrets")["SECRET"]
+    end
+  end
+
+  test "command interpolation still substitutes variables in the command" do
+    with_test_secrets("secrets" => "SECRET1=ABC\nSECRET2=$(echo ${SECRET1}DEF)") do
+      assert_equal "ABCDEF", Kamal::Secrets.new(secrets_path: ".kamal/secrets")["SECRET2"]
+    end
+  end
+
+  test "inline kamal secrets commands preserve dollar signs in extracted values" do
+    # Single-quoted so the stored value matches what an inlined
+    # "kamal secrets fetch" returns: shell-escaped JSON.
+    secrets_json = { "vault/password" => "pa$1wor$D" }.to_json.shellescape
+    with_test_secrets("secrets" => "SECRETS='#{secrets_json}'\nPASSWORD=$(kamal secrets extract vault/password ${SECRETS})") do
+      assert_equal "pa$1wor$D", Kamal::Secrets.new(secrets_path: ".kamal/secrets")["PASSWORD"]
+    end
+  end
+
   test "variable references" do
     with_test_secrets("secrets" => "SECRET1=ABC\nSECRET2=${SECRET1}DEF") do
       assert_equal "ABC", Kamal::Secrets.new(secrets_path: ".kamal/secrets")["SECRET1"]


### PR DESCRIPTION
## Problem

Secret values produced by `$(...)` command substitution in `.kamal/secrets*` files are corrupted when they contain `$`. Dotenv runs its substitutions in the order `[Command, Variable]`, so after a command substitution executes, its output receives a variable-substitution pass: any `$word` sequence in the output is treated as a reference to a (usually undefined) variable and silently replaced with an empty string.

This affects the officially documented secrets patterns, including adapter fetch/extract:

```bash
SECRETS=$(kamal secrets fetch --adapter aws_secrets_manager myapp/database)
DB_PASSWORD=$(kamal secrets extract myapp/database/password ${SECRETS})
```

If the stored password is `pa$1wor$D`, the deployed value is `pa` — the deploy succeeds and the corruption only surfaces later as downstream authentication failures, which makes it very hard to trace back. Passwords and tokens containing `$` are common.

Minimal reproduction (no vault needed):

```bash
# .kamal/secrets -- command outputs pa$1wor$D
SECRET=$(echo 'paX1worXD' | tr X '$')
```

`kamal secrets print` → `SECRET=pa`

## Fix

Run variable substitution before command substitution, so command output is inserted literally. This matches POSIX shell semantics, where the result of command substitution is not subject to further expansion.

Variable references inside the command text itself (e.g. `${SECRETS}` in the extract pattern above) are unaffected: `InlineCommandSubstitution#call` already substitutes variables in the command string before executing it, and the parser-level variable pass now simply runs before commands execute instead of after.

The behavior change: command *output* containing `$FOO` is no longer expanded against other secrets/env. Relying on that was indistinguishable from the corruption above, so this should be strictly less surprising.

## Tests

- command output containing `$` is preserved
- variables in the command text are still substituted
- the inline `kamal secrets extract ${SECRETS}` pattern preserves `$` in extracted values

Full suite passes (the two `linux/amd64`/`linux/arm64` builder-test failures on an arm64 host are pre-existing and unrelated).
