### PR TITLE
Check destination before eager loading sub-configs

### DIFF
--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -58,6 +58,8 @@ class Kamal::Configuration
 
     validate! raw_config, example: validation_yml.symbolize_keys, context: "", with: Kamal::Configuration::Validator::Configuration
 
+    ensure_destination_if_required
+
     @secrets = Kamal::Secrets.new(destination: destination, secrets_path: secrets_path)
 
     # Eager load config to validate it, these are first as they have dependencies later on
@@ -77,7 +79,6 @@ class Kamal::Configuration
     @ssh = Ssh.new(config: self)
     @sshkit = Sshkit.new(config: self)
 
-    ensure_destination_if_required
     ensure_required_keys_present
     ensure_valid_kamal_version
     ensure_retain_containers_valid

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -295,10 +295,10 @@ class ConfigurationTest < ActiveSupport::TestCase
     @deploy.delete(:builder)
     @deploy[:require_destination] = true
 
-error = assert_raises(ArgumentError) do
-  Kamal::Configuration.new(@deploy)
-end
-assert_equal "You must specify a destination", error.message
+    error = assert_raises(ArgumentError) do
+      Kamal::Configuration.new(@deploy)
+    end
+    assert_equal "You must specify a destination", error.message
   end
 
   test "to_h" do

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -295,9 +295,10 @@ class ConfigurationTest < ActiveSupport::TestCase
     @deploy.delete(:builder)
     @deploy[:require_destination] = true
 
-    assert_raises(ArgumentError, "You must specify a destination") do
-      Kamal::Configuration.new(@deploy)
-    end
+error = assert_raises(ArgumentError) do
+  Kamal::Configuration.new(@deploy)
+end
+assert_equal "You must specify a destination", error.message
   end
 
   test "to_h" do

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -295,10 +295,9 @@ class ConfigurationTest < ActiveSupport::TestCase
     @deploy.delete(:builder)
     @deploy[:require_destination] = true
 
-    error = assert_raises(ArgumentError) do
+    assert_raises(ArgumentError, "You must specify a destination") do
       Kamal::Configuration.new(@deploy)
     end
-    assert_equal "You must specify a destination", error.message
   end
 
   test "to_h" do

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -287,6 +287,20 @@ class ConfigurationTest < ActiveSupport::TestCase
     end
   end
 
+  test "destination check precedes sub-config validation" do
+    # A destination-only key (builder.arch) lives only in the destination file, so
+    # the base config is incomplete. The missing-destination guard must run before
+    # the sub-configs validate themselves, otherwise "Builder arch not set" masks
+    # the real cause.
+    @deploy.delete(:builder)
+    @deploy[:require_destination] = true
+
+    error = assert_raises(ArgumentError) do
+      Kamal::Configuration.new(@deploy)
+    end
+    assert_equal "You must specify a destination", error.message
+  end
+
   test "to_h" do
     expected_config = \
       { roles: [ "web" ],


### PR DESCRIPTION
## Check destination before eager loading sub-configs

### Problem

When a project sets `require_destination: true` and the user runs a command without `-d <destination>`, Kamal raises a confusing, unrelated error instead of telling the user the destination is missing.

This happens whenever a required sub-config key lives only in the per-destination file. Because Kamal eager-loads and validates every sub-config during `Configuration#initialize` *before* checking the destination, the first incomplete sub-config raises and masks the real cause. Depending on your layout the masking error varies (builder arch, servers, registry, …).

**Example — misleading config**

`deploy.yml` (base, no `builder.arch` — it lives in the destination files):

```yaml
service: app
image: dhh/app
registry:
  server: registry.digitalocean.com
  username: <%= ENV["REGISTRY_USER"] %>
  password: <%= ENV["REGISTRY_PASSWORD"] %>
require_destination: true
```

`deploy.production.yml`:

```yaml
builder:
  arch: amd64
servers:
  - 1.1.1.1
```

**Misleading message** — running any command without `-d`:

```console
$ kamal lock release
  ERROR (Kamal::ConfigurationError): builder: Builder arch not set
```

The user has no idea this actually means "you forgot `-d production`".

**After this change:**

```console
$ kamal lock release
  ERROR (ArgumentError): You must specify a destination
```

### Root cause

In `Kamal::Configuration#initialize`, the eager-loaded sub-configs (`Servers`, `Registry`, `Builder`, …) validate themselves during construction, and one of them raises before `ensure_destination_if_required` runs at the end of the method.

`ensure_destination_if_required` only depends on `@destination` and `raw_config.require_destination`, both available right after the top-level `validate!` — so the guard can safely run much earlier.

### Fix

Move `ensure_destination_if_required` to run immediately after the top-level `validate!`, before the sub-configs are eager-loaded. The missing-destination error now surfaces first, regardless of which destination-only sub-config happens to be incomplete. The generic top-level `validate!` stays where it is.

### Tests

- Added a regression test (`test/configuration_test.rb`): base config missing a destination-only key (`builder.arch`) + `require_destination: true` + no destination → raises `ArgumentError, "You must specify a destination"`. Confirmed it fails on `main` with the old `Kamal::ConfigurationError: builder: Builder arch not set` and passes with the fix.
- Full suite green: `855 runs, 3116 assertions, 0 failures, 0 errors, 0 skips`.
