### PR TITLE
Respect --hosts when following accessory logs

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -204,10 +204,12 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
       timestamps = !options[:skip_timestamps]
 
       if options[:follow]
-        run_locally do
-          info "Following logs on #{hosts}..."
-          info accessory.follow_logs(timestamps: timestamps, grep: grep, grep_options: grep_options)
-          exec accessory.follow_logs(timestamps: timestamps, grep: grep, grep_options: grep_options)
+        if hosts.any?
+          run_locally do
+            info "Following logs on #{hosts.first}..."
+            info accessory.follow_logs(host: hosts.first, timestamps: timestamps, grep: grep, grep_options: grep_options)
+            exec accessory.follow_logs(host: hosts.first, timestamps: timestamps, grep: grep, grep_options: grep_options)
+          end
         end
       else
         since = options[:since]

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -47,11 +47,13 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
       ("grep '#{grep}'#{" #{grep_options}" if grep_options}" if grep)
   end
 
-  def follow_logs(timestamps: true, grep: nil, grep_options: nil)
+  def follow_logs(host:, timestamps: true, grep: nil, grep_options: nil)
     run_over_ssh \
-      pipe \
+      pipe(
         docker(:logs, service_name, ("--timestamps" if timestamps), "--tail", "10", "--follow", "2>&1"),
         (%(grep "#{grep}"#{" #{grep_options}" if grep_options}) if grep)
+      ),
+      host: host
   end
 
   def execute_in_existing_container(*command, interactive: false)
@@ -81,8 +83,8 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
     run_over_ssh execute_in_new_container(*command, interactive: true)
   end
 
-  def run_over_ssh(command)
-    super command, host: hosts.first
+  def run_over_ssh(command, host: hosts.first)
+    super command, host: host
   end
 
   def ensure_local_file_present(local_file)

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -174,6 +174,26 @@ class CliAccessoryTest < CliTestCase
     assert_match "docker logs app-mysql --timestamps --tail 10 --follow 2>&1 | grep \"hey\" -C 2", run_command("logs", "mysql", "--follow", "--grep", "hey", "--grep-options", "-C 2")
   end
 
+  test "logs with follow defaults to first host" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:exec)
+      .with("ssh -t root@1.1.1.1 -p 22 'docker logs app-redis --timestamps --tail 10 --follow 2>&1'")
+
+    assert_match "ssh -t root@1.1.1.1 -p 22 'docker logs app-redis", run_command("logs", "redis", "--follow")
+  end
+
+  test "logs with follow respects hosts" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:exec)
+      .with("ssh -t root@1.1.1.2 -p 22 'docker logs app-redis --timestamps --tail 10 --follow 2>&1'")
+
+    assert_match "ssh -t root@1.1.1.2 -p 22 'docker logs app-redis", run_command("logs", "redis", "--follow", "--hosts", "1.1.1.2")
+  end
+
+  test "logs with follow does nothing when accessory does not run on the hosts" do
+    SSHKit::Backend::Abstract.any_instance.expects(:exec).never
+
+    run_command("logs", "mysql", "--follow", "--hosts", "1.1.1.1")
+  end
+
   test "remove with confirmation" do
     Kamal::Cli::Accessory.any_instance.expects(:stop).with("mysql")
     Kamal::Cli::Accessory.any_instance.expects(:remove_container).with("mysql")

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -180,11 +180,11 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
   test "follow logs" do
     assert_equal \
       "ssh -t root@1.1.1.5 -p 22 'docker logs app-mysql --timestamps --tail 10 --follow 2>&1'",
-      new_command(:mysql).follow_logs
+      new_command(:mysql).follow_logs(host: "1.1.1.5")
 
     assert_equal \
       "ssh -t root@1.1.1.5 -p 22 'docker logs app-mysql --tail 10 --follow 2>&1'",
-      new_command(:mysql).follow_logs(timestamps: false)
+      new_command(:mysql).follow_logs(host: "1.1.1.5", timestamps: false)
   end
 
   test "remove container" do


### PR DESCRIPTION
`kamal accessory logs <name> --follow` ignored the --hosts filter and always followed the accessory's first configured host. The follow path built its command through `run_over_ssh` which defaulted to `hosts.first` on the accessory's full, unfiltered host list, so `--hosts` had no effect.

Fix this by threading hosts passed from the CLI through `follow_logs` and `run_over_ssh`, aligning with the existing app/proxy's `follow_logs(host:)`.

Unlike app/proxy, the accessory host is an intersection of the filter and the accessory's configured hosts, so it can be empty when given a host the accessory doesn't run on. Guard the follow branch with `if hosts.any?` so it no-ops cleanly instead of shelling out to a malformed `ssh root@`, matching the non-follow branch's behaviour on an empty host list.
