### PR TITLE
Add idle service configuration for kamal-proxy

### DIFF
--- a/lib/kamal/cli/prune.rb
+++ b/lib/kamal/cli/prune.rb
@@ -25,9 +25,27 @@ class Kamal::Cli::Prune < Kamal::Cli::Base
     raise "retain must be at least 1" if retain < 1
 
     modify(lock: true) do
-      on(KAMAL.hosts) do
+      on(KAMAL.hosts) do |host|
+        protected_ids = []
+        if KAMAL.config.any_service_use_proxy_idle?
+          # Prune is service-wide even with --roles. Protect sibling roles too.
+          roles = KAMAL.config.roles.select { |role| role.running_proxy? && role.hosts.include?(host.to_s) }
+          if roles.any?
+            begin
+              json = capture_with_info(*KAMAL.proxy(host).services)
+              containers = KAMAL.prune.registered_containers(json, services: roles.map(&:container_prefix))
+              protected_ids = capture_with_info(*KAMAL.prune.inspect_registered_containers(containers)).lines.map(&:strip)
+              unless protected_ids.size == containers.size && protected_ids.all? { |id| id.match?(/\A[0-9a-f]{64}\z/) }
+                raise ArgumentError, "Invalid container inspection result"
+              end
+            rescue SSHKit::Command::Failed, JSON::ParserError, KeyError, ArgumentError => e
+              warn "Skipping container prune on #{host}: cannot verify proxy targets (#{e.class})"
+              next
+            end
+          end
+        end
         execute *KAMAL.auditor.record("Pruned containers"), verbosity: :debug
-        execute *KAMAL.prune.app_containers(retain: retain)
+        execute *KAMAL.prune.app_containers(retain: retain, protected_ids: protected_ids)
       end
     end
   end

--- a/lib/kamal/commands/proxy.rb
+++ b/lib/kamal/commands/proxy.rb
@@ -40,6 +40,10 @@ class Kamal::Commands::Proxy < Kamal::Commands::Base
     docker :ps, "--filter", "'name=^#{container_name}$'"
   end
 
+  def services
+    docker :exec, container_name, "kamal-proxy", :list, "--json"
+  end
+
   def version
     pipe \
       docker(:inspect, container_name, "--format '{{.Config.Image}}'"),

--- a/lib/kamal/commands/prune.rb
+++ b/lib/kamal/commands/prune.rb
@@ -13,11 +13,42 @@ class Kamal::Commands::Prune < Kamal::Commands::Base
       "while read image tag; do docker rmi $tag; done"
   end
 
-  def app_containers(retain:)
+  def app_containers(retain:, protected_ids: [])
+    unless protected_ids.all? { |id| id.is_a?(String) && id.match?(/\A[0-9a-f]{64}\z/) }
+      raise ArgumentError, "Invalid protected container ID"
+    end
     pipe \
-      docker(:ps, "-q", "-a", *service_filter, *destination_filter, *stopped_containers_filters),
+      docker(:ps, "-q", "-a", *("--no-trunc" if protected_ids.any?), *service_filter, *destination_filter, *stopped_containers_filters),
+      ("grep -F -x -v #{protected_ids.uniq.map { |id| "-e #{id}" }.join(' ')}" if protected_ids.any?),
       "tail -n +#{retain + 1}",
       "while read container_id; do docker rm $container_id; done"
+  end
+
+  # Read only the services managed by these app roles. Other services may use
+  # non-Docker endpoints. Include readers and rollout targets even when disabled.
+  def registered_containers(json, services:)
+    descriptions = JSON.parse(json)
+    raise ArgumentError, "Invalid proxy service list" unless descriptions.is_a?(Hash)
+
+    services.flat_map do |name|
+      description = descriptions.fetch(name)
+      raise ArgumentError, "Invalid proxy service" unless description.is_a?(Hash)
+      active = description.fetch("targets")
+      raise ArgumentError, "Missing active targets" unless active.is_a?(Array) && active.any?
+      rollout = description.fetch("rollout", {})
+      raise ArgumentError, "Invalid rollout" unless rollout.is_a?(Hash)
+      lists = [ active, description.fetch("read_targets", []), rollout.fetch("targets", []), rollout.fetch("read_targets", []) ]
+      raise ArgumentError, "Invalid target lists" unless lists.all? { |list| list.is_a?(Array) }
+      lists.flatten.map do |target|
+        match = target.is_a?(String) && target.match(/\A([a-zA-Z0-9][a-zA-Z0-9_.-]*):[0-9]+\z/)
+        raise ArgumentError, "Invalid container target" unless match
+        match[1]
+      end
+    end.uniq
+  end
+
+  def inspect_registered_containers(containers)
+    docker :inspect, "--format", "'{{.Id}}'", *containers
   end
 
   private

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -121,6 +121,10 @@ class Kamal::Configuration
     servers.roles
   end
 
+  def any_role_use_proxy_idle?
+    roles.any? { |role| role.proxy&.idle? }
+  end
+
   def role(name)
     roles.detect { |r| r.name == name.to_s }
   end

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -121,6 +121,10 @@ class Kamal::Configuration
     servers.roles
   end
 
+  def any_service_use_proxy_idle?
+    (roles + accessories).any? { |service| service.proxy&.idle? }
+  end
+
   def role(name)
     roles.detect { |r| r.name == name.to_s }
   end

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -121,8 +121,8 @@ class Kamal::Configuration
     servers.roles
   end
 
-  def any_role_use_proxy_idle?
-    roles.any? { |role| role.proxy&.idle? }
+  def any_service_use_proxy_idle?
+    (roles + accessories).any? { |service| service.proxy&.idle? }
   end
 
   def role(name)

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -148,6 +148,18 @@ proxy:
       - X-Request-ID
       - X-Request-Start
 
+  # Idle
+  #
+  # Stop the application container after a period without requests and start it
+  # again when the next request arrives. Both values are in seconds.
+  #
+  # Enabling idle access automatically mounts the Docker socket into kamal-proxy.
+  # This grants the proxy control over Docker on the host, so only enable it in
+  # environments where the proxy container is trusted with that access.
+  idle:
+    timeout: 300        # Stop the container after 5 minutes without requests
+    wake_timeout: 30    # Maximum time to wait for the container to become healthy
+
   # Run configuration
   #
   # These options are used when booting the proxy container.

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -148,6 +148,19 @@ proxy:
       - X-Request-ID
       - X-Request-Start
 
+  # Idle
+  #
+  # Stop the application container after a period without requests and start it
+  # again when the next request arrives. Both values are in seconds.
+  #
+  # Enabling idle access automatically mounts the Docker socket into kamal-proxy
+  # and adds the socket's numeric group ID to the container. This grants the proxy
+  # control over Docker on the host, so only enable it in environments where the
+  # proxy container is trusted with that access.
+  idle:
+    timeout: 300        # Stop the container after 5 minutes without requests
+    wake_timeout: 30    # Maximum time to wait for the container to become healthy
+
   # Run configuration
   #
   # These options are used when booting the proxy container.
@@ -158,6 +171,7 @@ proxy:
     metrics_port: 9090             # Port for Prometheus metrics
     debug: true                    # Debug logging (default: false)
     log_max_size: "30m"            # Maximum log file size (default: "10m")
+    docker_socket: /var/run/docker.sock # Docker socket used by idle mode (default shown)
     publish: false                 # Publish ports to the host (default: true)
     bind_ips:                      # List of IPs to bind to when publishing ports
       - 0.0.0.0

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -153,9 +153,10 @@ proxy:
   # Stop the application container after a period without requests and start it
   # again when the next request arrives. Both values are in seconds.
   #
-  # Enabling idle access automatically mounts the Docker socket into kamal-proxy.
-  # This grants the proxy control over Docker on the host, so only enable it in
-  # environments where the proxy container is trusted with that access.
+  # Enabling idle access automatically mounts the Docker socket into kamal-proxy
+  # and adds the socket's numeric group ID to the container. This grants the proxy
+  # control over Docker on the host, so only enable it in environments where the
+  # proxy container is trusted with that access.
   idle:
     timeout: 300        # Stop the container after 5 minutes without requests
     wake_timeout: 30    # Maximum time to wait for the container to become healthy
@@ -170,6 +171,7 @@ proxy:
     metrics_port: 9090             # Port for Prometheus metrics
     debug: true                    # Debug logging (default: false)
     log_max_size: "30m"            # Maximum log file size (default: "10m")
+    docker_socket: /var/run/docker.sock # Docker socket used by idle mode (default shown)
     publish: false                 # Publish ports to the host (default: true)
     bind_ips:                      # List of IPs to bind to when publishing ports
       - 0.0.0.0

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -157,6 +157,15 @@ proxy:
   # and adds the socket's numeric group ID to the container. This grants the proxy
   # control over Docker on the host, so only enable it in environments where the
   # proxy container is trusted with that access.
+  #
+  # While idle mode is configured, container pruning protects registered app
+  # targets (including sleeping, read, and rollout targets) before applying the
+  # retention limit. If proxy targets cannot be verified, container pruning is
+  # skipped on that host with a warning. Deploy changes that disable idle mode
+  # before pruning with that configuration.
+  #
+  # Protection uses Kamal's deploy lock. Direct Docker pruning or concurrent
+  # changes made through the proxy CLI do not participate in this protection.
   idle:
     timeout: 300        # Stop the container after 5 minutes without requests
     wake_timeout: 30    # Maximum time to wait for the container to become healthy

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -14,11 +14,17 @@ class Kamal::Configuration::Proxy
     @role_name = role_name
     @secrets = secrets
     validate! @proxy_config, with: Kamal::Configuration::Validator::Proxy, context: context
-    @run = Kamal::Configuration::Proxy::Run.new(config, run_config: @proxy_config["run"], context: "#{context}/run") if @proxy_config && @proxy_config["run"].present?
+    if @proxy_config["run"].present? || idle?
+      @run = Kamal::Configuration::Proxy::Run.new(config, run_config: @proxy_config["run"] || {}, context: "#{context}/run")
+    end
   end
 
   def app_port
     proxy_config.fetch("app_port", 80)
+  end
+
+  def idle?
+    proxy_config.dig("idle", "timeout").present?
   end
 
   def ssl?
@@ -90,6 +96,8 @@ class Kamal::Configuration::Proxy
       "tls-redirect": proxy_config.dig("ssl_redirect"),
       "log-request-header": proxy_config.dig("logging", "request_headers") || DEFAULT_LOG_REQUEST_HEADERS,
       "log-response-header": proxy_config.dig("logging", "response_headers"),
+      "idle-timeout": seconds_duration(proxy_config.dig("idle", "timeout")),
+      "idle-wake-timeout": seconds_duration(proxy_config.dig("idle", "wake_timeout")),
       "error-pages": error_pages
     }.compact
   end

--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+
 class Kamal::Configuration::Proxy::Run
   MINIMUM_VERSION = "v0.9.2"
   DEFAULT_HTTP_PORT = 80
@@ -93,7 +95,7 @@ class Kamal::Configuration::Proxy::Run
   end
 
   def docker_socket
-    DEFAULT_DOCKER_SOCKET if config.any_role_use_proxy_idle?
+    run_config.fetch("docker_socket", DEFAULT_DOCKER_SOCKET) if config.any_role_use_proxy_idle?
   end
 
   def docker_options_args
@@ -130,7 +132,12 @@ class Kamal::Configuration::Proxy::Run
   end
 
   def docker_socket_volume_args
-    [ "--volume=#{docker_socket}:#{docker_socket}" ] if docker_socket
+    if docker_socket
+      socket_mount = Shellwords.escape("#{docker_socket}:#{docker_socket}")
+      socket_path = Shellwords.escape(docker_socket)
+
+      [ "--volume=#{socket_mount}", "--group-add", %("$(stat -c %g #{socket_path})") ]
+    end
   end
 
   def app_directory

--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -95,7 +95,7 @@ class Kamal::Configuration::Proxy::Run
   end
 
   def docker_socket
-    run_config.fetch("docker_socket", DEFAULT_DOCKER_SOCKET) if config.any_role_use_proxy_idle?
+    run_config.fetch("docker_socket", DEFAULT_DOCKER_SOCKET) if config.any_service_use_proxy_idle?
   end
 
   def docker_options_args

--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -1,8 +1,11 @@
+require "shellwords"
+
 class Kamal::Configuration::Proxy::Run
   MINIMUM_VERSION = "v0.9.2"
   DEFAULT_HTTP_PORT = 80
   DEFAULT_HTTPS_PORT = 443
   DEFAULT_LOG_MAX_SIZE = "10m"
+  DEFAULT_DOCKER_SOCKET = "/var/run/docker.sock"
 
   attr_reader :config, :run_config
   delegate :argumentize, :optionize, to: Kamal::Utils
@@ -88,12 +91,17 @@ class Kamal::Configuration::Proxy::Run
   end
 
   def run_command_options
-    { debug: debug? || nil, "metrics-port": metrics_port }.compact
+    { debug: debug? || nil, "metrics-port": metrics_port, "docker-socket": docker_socket }.compact
+  end
+
+  def docker_socket
+    run_config.fetch("docker_socket", DEFAULT_DOCKER_SOCKET) if config.any_service_use_proxy_idle?
   end
 
   def docker_options_args
     [
       *apps_volume_args,
+      *docker_socket_volume_args,
       *publish_args,
       *logging_args,
       *("--expose=#{metrics_port}" if metrics_port.present?),
@@ -121,6 +129,15 @@ class Kamal::Configuration::Proxy::Run
 
   def apps_volume_args
     [ apps_volume.docker_args ]
+  end
+
+  def docker_socket_volume_args
+    if docker_socket
+      socket_mount = Shellwords.escape("#{docker_socket}:#{docker_socket}")
+      socket_path = Shellwords.escape(docker_socket)
+
+      [ "--volume=#{socket_mount}", "--group-add", %("$(stat -c %g #{socket_path})") ]
+    end
   end
 
   def app_directory

--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -3,6 +3,7 @@ class Kamal::Configuration::Proxy::Run
   DEFAULT_HTTP_PORT = 80
   DEFAULT_HTTPS_PORT = 443
   DEFAULT_LOG_MAX_SIZE = "10m"
+  DEFAULT_DOCKER_SOCKET = "/var/run/docker.sock"
 
   attr_reader :config, :run_config
   delegate :argumentize, :optionize, to: Kamal::Utils
@@ -88,12 +89,17 @@ class Kamal::Configuration::Proxy::Run
   end
 
   def run_command_options
-    { debug: debug? || nil, "metrics-port": metrics_port }.compact
+    { debug: debug? || nil, "metrics-port": metrics_port, "docker-socket": docker_socket }.compact
+  end
+
+  def docker_socket
+    DEFAULT_DOCKER_SOCKET if config.any_role_use_proxy_idle?
   end
 
   def docker_options_args
     [
       *apps_volume_args,
+      *docker_socket_volume_args,
       *publish_args,
       *logging_args,
       *("--expose=#{metrics_port}" if metrics_port.present?),
@@ -121,6 +127,10 @@ class Kamal::Configuration::Proxy::Run
 
   def apps_volume_args
     [ apps_volume.docker_args ]
+  end
+
+  def docker_socket_volume_args
+    [ "--volume=#{docker_socket}:#{docker_socket}" ] if docker_socket
   end
 
   def app_directory

--- a/lib/kamal/configuration/validator/proxy.rb
+++ b/lib/kamal/configuration/validator/proxy.rb
@@ -21,6 +21,18 @@ class Kamal::Configuration::Validator::Proxy < Kamal::Configuration::Validator
         end
       end
 
+      if idle_config = config["idle"]
+        if idle_config["timeout"].blank?
+          error "Idle timeout is required"
+        elsif idle_config["timeout"] <= 0
+          error "Idle timeout must be greater than zero"
+        end
+
+        if idle_config["wake_timeout"].present? && idle_config["wake_timeout"] <= 0
+          error "Idle wake timeout must be greater than zero"
+        end
+      end
+
       if run_config = config["run"]
         if run_config["bind_ips"].present?
           ensure_valid_bind_ips(config["bind_ips"])

--- a/test/cli/prune_protected_targets_test.rb
+++ b/test/cli/prune_protected_targets_test.rb
@@ -1,0 +1,76 @@
+require_relative "cli_test_case"
+
+class PruneProtectedTargetsTest < CliTestCase
+  test "protects sleeping active and rollout targets" do
+    stub_list({ "app-web" => { "targets" => [ "abc123:80" ], "read_targets" => [], "rollout" => { "targets" => [ "def456:80" ], "read_targets" => [] } } }.to_json)
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).with(:docker, :inspect, "--format", "'{{.Id}}'", "abc123", "def456").returns("#{'a' * 64}\n#{'b' * 64}\n")
+    output = run_prune
+    assert_includes output, "#{'a' * 64}"
+    assert_includes output, "#{'b' * 64}"
+    assert_includes output, "--no-trunc"
+  end
+
+  test "malformed JSON skips container deletion" do
+    stub_list("not json")
+    assert_skipped
+  end
+
+  test "missing service skips container deletion" do
+    stub_list("{}")
+    assert_skipped
+  end
+
+  test "empty targets skip container deletion" do
+    stub_list({ "app-web" => { "targets" => [] } }.to_json)
+    assert_skipped
+  end
+
+  test "proxy command failure skips container deletion" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).with(:docker, :exec, "kamal-proxy", "kamal-proxy", :list, "--json").raises(SSHKit::Command::Failed, "proxy unavailable")
+    assert_skipped
+  end
+
+  test "invalid target cannot reach the shell" do
+    stub_list({ "app-web" => { "targets" => [ "$(touch /tmp/unsafe):80" ] } }.to_json)
+    assert_skipped
+  end
+
+  test "inspect failure skips container deletion" do
+    stub_list({ "app-web" => { "targets" => [ "abc123:80" ] } }.to_json)
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).with(:docker, :inspect, "--format", "'{{.Id}}'", "abc123").raises(SSHKit::Command::Failed, "missing container")
+    assert_skipped
+  end
+
+  test "incomplete inspection skips container deletion" do
+    stub_list({ "app-web" => { "targets" => [ "abc123:80" ] } }.to_json)
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).with(:docker, :inspect, "--format", "'{{.Id}}'", "abc123").returns("")
+    assert_skipped
+  end
+
+  test "worker-only prune still protects a sleeping sibling web role" do
+    stub_list({ "app-web" => { "targets" => [ "abc123:80" ] } }.to_json)
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).with(:docker, :inspect, "--format", "'{{.Id}}'", "abc123").returns("#{'a' * 64}\n")
+    assert_includes run_prune("--roles", "workers"), "#{'a' * 64}"
+  end
+
+  test "host without proxied roles does not need the proxy" do
+    SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info).with(:docker, :exec, "kamal-proxy", "kamal-proxy", :list, "--json").never
+    output = stdouted { Kamal::Cli::Prune.start([ "containers", "-c", "test/fixtures/deploy_with_idle_prune.yml", "--hosts", "1.1.1.2" ]) }
+    assert_includes output, "docker rm"
+  end
+
+  private
+    def stub_list(json)
+      SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info).with(:docker, :exec, "kamal-proxy", "kamal-proxy", :list, "--json").returns(json)
+    end
+
+    def run_prune(*args)
+      stdouted { Kamal::Cli::Prune.start([ "containers", "-c", "test/fixtures/deploy_with_idle_prune.yml", "--hosts", "1.1.1.1", *args ]) }
+    end
+
+    def assert_skipped
+      output = run_prune
+      assert_includes output, "Skipping container prune"
+      assert_not_includes output, "docker rm"
+    end
+end

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -169,6 +169,14 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command.deploy(target: "172.1.0.2").join(" ")
   end
 
+  test "deploy with idle" do
+    @config[:proxy] = { "idle" => { "timeout" => 300, "wake_timeout" => 30 } }
+
+    assert_equal \
+      "docker exec kamal-proxy kamal-proxy deploy app-web --target=\"172.1.0.2:80\" --deploy-timeout=\"30s\" --drain-timeout=\"30s\" --buffer-requests --buffer-responses --log-request-header=\"Cache-Control\" --log-request-header=\"Last-Modified\" --log-request-header=\"User-Agent\" --idle-timeout=\"300s\" --idle-wake-timeout=\"30s\"",
+      new_command.deploy(target: "172.1.0.2").join(" ")
+  end
+
   test "remove" do
     assert_equal \
       "docker exec kamal-proxy kamal-proxy remove app-web",

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -221,6 +221,14 @@ class CommandsProxyTest < ActiveSupport::TestCase
       new_command.run.join(" ")
   end
 
+  test "idle mounts and configures the Docker socket" do
+    @config[:proxy] = { "idle" => { "timeout" => 300 } }
+
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --volume=/var/run/docker.sock:/var/run/docker.sock --publish 80:80 --publish 443:443 --log-opt max-size=10m basecamp/kamal-proxy:v0.9.2 kamal-proxy run --docker-socket \"/var/run/docker.sock\"",
+      new_command.run.join(" ")
+  end
+
   private
     def new_command
       Kamal::Commands::Proxy.new(Kamal::Configuration.new(@config, version: "123"), host: "1.1.1.1")

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -221,6 +221,46 @@ class CommandsProxyTest < ActiveSupport::TestCase
       new_command.run.join(" ")
   end
 
+  test "idle mounts and configures the Docker socket" do
+    @config[:proxy] = { "idle" => { "timeout" => 300 } }
+
+    assert_equal \
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --volume=/var/run/docker.sock:/var/run/docker.sock --group-add \"$(stat -c %g /var/run/docker.sock)\" --publish 80:80 --publish 443:443 --log-opt max-size=10m basecamp/kamal-proxy:v0.9.2 kamal-proxy run --docker-socket \"/var/run/docker.sock\"",
+      new_command.run.join(" ")
+  end
+
+  test "idle mounts, configures and looks up the group for a custom Docker socket" do
+    @config[:proxy] = {
+      "idle" => { "timeout" => 300 },
+      "run" => { "docker_socket" => "/run/user/1000/docker.sock" }
+    }
+
+    command = new_command.run.join(" ")
+    assert_includes command, "--volume=/run/user/1000/docker.sock:/run/user/1000/docker.sock"
+    assert_includes command, "--group-add \"$(stat -c %g /run/user/1000/docker.sock)\""
+    assert_includes command, "kamal-proxy run --docker-socket \"/run/user/1000/docker.sock\""
+  end
+
+  test "Docker socket path is shell escaped" do
+    @config[:proxy] = {
+      "idle" => { "timeout" => 300 },
+      "run" => { "docker_socket" => "/run/docker socket's.sock" }
+    }
+
+    command = new_command.run.join(" ")
+    assert_includes command, "--volume=/run/docker\\ socket\\'s.sock:/run/docker\\ socket\\'s.sock"
+    assert_includes command, "--group-add \"$(stat -c %g /run/docker\\ socket\\'s.sock)\""
+  end
+
+  test "Docker socket access is not added when idle is disabled" do
+    @config[:proxy] = { "run" => { "docker_socket" => "/run/user/1000/docker.sock" } }
+
+    command = new_command.run.join(" ")
+    assert_no_match(/--volume=.*docker\.sock/, command)
+    assert_no_match(/--group-add/, command)
+    assert_no_match(/--docker-socket/, command)
+  end
+
   private
     def new_command
       Kamal::Commands::Proxy.new(Kamal::Configuration.new(@config, version: "123"), host: "1.1.1.1")

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -225,8 +225,40 @@ class CommandsProxyTest < ActiveSupport::TestCase
     @config[:proxy] = { "idle" => { "timeout" => 300 } }
 
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --volume=/var/run/docker.sock:/var/run/docker.sock --publish 80:80 --publish 443:443 --log-opt max-size=10m basecamp/kamal-proxy:v0.9.2 kamal-proxy run --docker-socket \"/var/run/docker.sock\"",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --volume=/var/run/docker.sock:/var/run/docker.sock --group-add \"$(stat -c %g /var/run/docker.sock)\" --publish 80:80 --publish 443:443 --log-opt max-size=10m basecamp/kamal-proxy:v0.9.2 kamal-proxy run --docker-socket \"/var/run/docker.sock\"",
       new_command.run.join(" ")
+  end
+
+  test "idle mounts, configures and looks up the group for a custom Docker socket" do
+    @config[:proxy] = {
+      "idle" => { "timeout" => 300 },
+      "run" => { "docker_socket" => "/run/user/1000/docker.sock" }
+    }
+
+    command = new_command.run.join(" ")
+    assert_includes command, "--volume=/run/user/1000/docker.sock:/run/user/1000/docker.sock"
+    assert_includes command, "--group-add \"$(stat -c %g /run/user/1000/docker.sock)\""
+    assert_includes command, "kamal-proxy run --docker-socket \"/run/user/1000/docker.sock\""
+  end
+
+  test "Docker socket path is shell escaped" do
+    @config[:proxy] = {
+      "idle" => { "timeout" => 300 },
+      "run" => { "docker_socket" => "/run/docker socket's.sock" }
+    }
+
+    command = new_command.run.join(" ")
+    assert_includes command, "--volume=/run/docker\\ socket\\'s.sock:/run/docker\\ socket\\'s.sock"
+    assert_includes command, "--group-add \"$(stat -c %g /run/docker\\ socket\\'s.sock)\""
+  end
+
+  test "Docker socket access is not added when idle is disabled" do
+    @config[:proxy] = { "run" => { "docker_socket" => "/run/user/1000/docker.sock" } }
+
+    command = new_command.run.join(" ")
+    assert_no_match(/--volume=.*docker\.sock/, command)
+    assert_no_match(/--group-add/, command)
+    assert_no_match(/--docker-socket/, command)
   end
 
   private

--- a/test/commands/prune_protection_test.rb
+++ b/test/commands/prune_protection_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+require "open3"
+
+class PruneProtectionTest < ActiveSupport::TestCase
+  test "protected current target survives newer stopped containers without consuming retention" do
+    current, newer, oldest = %w[a b c].map { |c| c * 64 }
+    config = Kamal::Configuration.new({ service: "app", image: "dhh/app", servers: [ "1.1.1.1" ], registry: { "username" => "dhh", "password" => "secret" }, builder: { "arch" => "amd64" } }, version: "123")
+    command = Kamal::Commands::Prune.new(config).app_containers(retain: 1, protected_ids: [ current ]).join(" ")
+    # Fake Docker returns creation order: failed release, sleeping current, old history.
+    script = "docker() { case \"$1\" in ps) printf '%s\\n' #{newer} #{current} #{oldest} ;; rm) printf '%s\\n' \"$2\" ;; esac; }; #{command}"
+    output, error, status = Open3.capture3("bash", "-c", script)
+    assert status.success?, error
+    assert_equal [ oldest ], output.lines.map(&:strip)
+    assert_includes command, "--no-trunc"
+  end
+
+  test "reject invalid protected IDs before generating a shell command" do
+    config = stub
+    assert_raises(ArgumentError) { Kamal::Commands::Prune.new(config).app_containers(retain: 1, protected_ids: [ "$(whoami)" ]) }
+  end
+
+  test "extracts all registered targets and ignores unrelated services" do
+    json = {
+      "app-web" => { "targets" => [ "active:80" ], "read_targets" => [ "reader:80" ],
+        "rollout" => { "enabled" => false, "targets" => [ "rollout:80" ], "read_targets" => [ "rollout-reader:80", "reader:80" ] } },
+      "unrelated" => { "targets" => [ "[::1]:80" ] }
+    }.to_json
+    assert_equal %w[active reader rollout rollout-reader], Kamal::Commands::Prune.new(stub).registered_containers(json, services: [ "app-web" ])
+  end
+
+  test "malformed target lists fail closed" do
+    [ nil, "not a list", [ nil ], [ "--unsafe:80" ] ].each do |targets|
+      json = { "app-web" => { "targets" => targets } }.to_json
+      assert_raises(ArgumentError) { Kamal::Commands::Prune.new(stub).registered_containers(json, services: [ "app-web" ]) }
+    end
+  end
+end

--- a/test/configuration/proxy/run_test.rb
+++ b/test/configuration/proxy/run_test.rb
@@ -70,6 +70,20 @@ class ConfigurationProxyRunTest < ActiveSupport::TestCase
     assert_equal "/run/user/1000/docker.sock", Kamal::Configuration.new(deploy).proxy.run.docker_socket
   end
 
+  test "accessory idle uses the default Docker socket" do
+    deploy = base_deploy.deep_merge(
+      accessories: {
+        "review" => {
+          "image" => "dhh/review",
+          "host" => "1.1.1.1",
+          "proxy" => { "host" => "review.example.com", "idle" => { "timeout" => 300 } }
+        }
+      }
+    )
+
+    assert_equal "/var/run/docker.sock", Kamal::Configuration.new(deploy).accessory(:review).proxy.run.docker_socket
+  end
+
   test "Docker socket lifecycle is disabled without idle" do
     deploy = base_deploy.deep_merge(proxy: { "run" => { "docker_socket" => "/run/user/1000/docker.sock" } })
 

--- a/test/configuration/proxy/run_test.rb
+++ b/test/configuration/proxy/run_test.rb
@@ -56,6 +56,40 @@ class ConfigurationProxyRunTest < ActiveSupport::TestCase
     assert config
   end
 
+  test "idle uses the default Docker socket" do
+    deploy = base_deploy.deep_merge(proxy: { "idle" => { "timeout" => 300 } })
+
+    assert_equal "/var/run/docker.sock", Kamal::Configuration.new(deploy).proxy.run.docker_socket
+  end
+
+  test "idle uses a custom Docker socket" do
+    deploy = base_deploy.deep_merge(
+      proxy: { "idle" => { "timeout" => 300 }, "run" => { "docker_socket" => "/run/user/1000/docker.sock" } }
+    )
+
+    assert_equal "/run/user/1000/docker.sock", Kamal::Configuration.new(deploy).proxy.run.docker_socket
+  end
+
+  test "accessory idle uses the default Docker socket" do
+    deploy = base_deploy.deep_merge(
+      accessories: {
+        "review" => {
+          "image" => "dhh/review",
+          "host" => "1.1.1.1",
+          "proxy" => { "host" => "review.example.com", "idle" => { "timeout" => 300 } }
+        }
+      }
+    )
+
+    assert_equal "/var/run/docker.sock", Kamal::Configuration.new(deploy).accessory(:review).proxy.run.docker_socket
+  end
+
+  test "Docker socket lifecycle is disabled without idle" do
+    deploy = base_deploy.deep_merge(proxy: { "run" => { "docker_socket" => "/run/user/1000/docker.sock" } })
+
+    assert_nil Kamal::Configuration.new(deploy).proxy.run.docker_socket
+  end
+
   private
     def base_deploy
       {

--- a/test/configuration/proxy/run_test.rb
+++ b/test/configuration/proxy/run_test.rb
@@ -56,6 +56,26 @@ class ConfigurationProxyRunTest < ActiveSupport::TestCase
     assert config
   end
 
+  test "idle uses the default Docker socket" do
+    deploy = base_deploy.deep_merge(proxy: { "idle" => { "timeout" => 300 } })
+
+    assert_equal "/var/run/docker.sock", Kamal::Configuration.new(deploy).proxy.run.docker_socket
+  end
+
+  test "idle uses a custom Docker socket" do
+    deploy = base_deploy.deep_merge(
+      proxy: { "idle" => { "timeout" => 300 }, "run" => { "docker_socket" => "/run/user/1000/docker.sock" } }
+    )
+
+    assert_equal "/run/user/1000/docker.sock", Kamal::Configuration.new(deploy).proxy.run.docker_socket
+  end
+
+  test "Docker socket lifecycle is disabled without idle" do
+    deploy = base_deploy.deep_merge(proxy: { "run" => { "docker_socket" => "/run/user/1000/docker.sock" } })
+
+    assert_nil Kamal::Configuration.new(deploy).proxy.run.docker_socket
+  end
+
   private
     def base_deploy
       {

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -105,6 +105,34 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
     end
   end
 
+  test "idle configuration" do
+    @deploy[:proxy] = { "idle" => { "timeout" => 300, "wake_timeout" => 30 } }
+
+    assert_predicate config.proxy, :idle?
+    assert_equal "300s", config.proxy.deploy_options[:"idle-timeout"]
+    assert_equal "30s", config.proxy.deploy_options[:"idle-wake-timeout"]
+  end
+
+  test "idle configuration requires integer durations" do
+    @deploy[:proxy] = { "idle" => { "timeout" => "300" } }
+
+    assert_raises(Kamal::ConfigurationError) { config }
+  end
+
+  test "idle configuration requires positive durations" do
+    @deploy[:proxy] = { "idle" => { "timeout" => 0 } }
+
+    error = assert_raises(Kamal::ConfigurationError) { config }
+    assert_equal "proxy: Idle timeout must be greater than zero", error.message
+  end
+
+  test "idle configuration requires a timeout" do
+    @deploy[:proxy] = { "idle" => { "wake_timeout" => 30 } }
+
+    error = assert_raises(Kamal::ConfigurationError) { config }
+    assert_equal "proxy: Idle timeout is required", error.message
+  end
+
   private
     def config
       Kamal::Configuration.new(@deploy)

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -122,13 +122,15 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
   test "idle configuration requires positive durations" do
     @deploy[:proxy] = { "idle" => { "timeout" => 0 } }
 
-    assert_raises(Kamal::ConfigurationError, "Idle timeout must be greater than zero") { config }
+    error = assert_raises(Kamal::ConfigurationError) { config }
+    assert_equal "proxy: Idle timeout must be greater than zero", error.message
   end
 
   test "idle configuration requires a timeout" do
     @deploy[:proxy] = { "idle" => { "wake_timeout" => 30 } }
 
-    assert_raises(Kamal::ConfigurationError, "Idle timeout is required") { config }
+    error = assert_raises(Kamal::ConfigurationError) { config }
+    assert_equal "proxy: Idle timeout is required", error.message
   end
 
   private

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -105,6 +105,32 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
     end
   end
 
+  test "idle configuration" do
+    @deploy[:proxy] = { "idle" => { "timeout" => 300, "wake_timeout" => 30 } }
+
+    assert_predicate config.proxy, :idle?
+    assert_equal "300s", config.proxy.deploy_options[:"idle-timeout"]
+    assert_equal "30s", config.proxy.deploy_options[:"idle-wake-timeout"]
+  end
+
+  test "idle configuration requires integer durations" do
+    @deploy[:proxy] = { "idle" => { "timeout" => "300" } }
+
+    assert_raises(Kamal::ConfigurationError) { config }
+  end
+
+  test "idle configuration requires positive durations" do
+    @deploy[:proxy] = { "idle" => { "timeout" => 0 } }
+
+    assert_raises(Kamal::ConfigurationError, "Idle timeout must be greater than zero") { config }
+  end
+
+  test "idle configuration requires a timeout" do
+    @deploy[:proxy] = { "idle" => { "wake_timeout" => 30 } }
+
+    assert_raises(Kamal::ConfigurationError, "Idle timeout is required") { config }
+  end
+
   private
     def config
       Kamal::Configuration.new(@deploy)

--- a/test/fixtures/deploy_with_idle_prune.yml
+++ b/test/fixtures/deploy_with_idle_prune.yml
@@ -1,0 +1,16 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    hosts: [1.1.1.1]
+  workers:
+    hosts: [1.1.1.1, 1.1.1.2]
+    proxy: false
+proxy:
+  idle:
+    timeout: 60
+registry:
+  username: dhh
+  password: secret
+builder:
+  arch: amd64


### PR DESCRIPTION
## Summary

Add opt-in idle service configuration for basecamp/kamal-proxy#228, including protection against pruning containers that are sleeping but still serving as registered proxy targets.

This continues the work started by @martijnenco in #1800. Thank you for providing the original configuration approach.

## Behavior

```yaml
proxy:
  idle:
    timeout: 300
    wake_timeout: 30
```

When a role or accessory enables idle mode, Kamal passes idle timeouts to the proxy and mounts the configured Docker socket with its numeric host group ID. Without idle configuration, the existing run/deploy commands and pruning behavior are unchanged.

Direct Docker access is opt-in and grants host-level container control, following the approach agreed in basecamp/kamal-proxy#222.

### Protect sleeping containers from pruning

A sleeping current container is `exited`, just like obsolete deployment history. With `retain_containers: 1`, a newer stopped sibling-role container or a failed new deployment can otherwise cause pruning to remove the still-current target.

While idle mode is configured, pruning now reads `kamal-proxy list --json` for the host's configured proxied app roles, resolves active/read/rollout targets to full Docker container IDs, and excludes those IDs before applying the retention limit. It also protects sibling roles when `--roles` restricts the invocation. The existing service/destination deploy lock covers lookup and deletion.

If listing, validation, or container inspection fails, the host's container prune is skipped with a warning. Hosts without proxied app roles retain normal pruning behavior. Accessory containers use separate service labels and are not included in app container pruning.

Deploy configuration changes that disable idle mode before pruning with the new configuration. Direct Docker pruning and concurrent direct proxy CLI changes are outside Kamal's lock/protection.

## Validation

- Prune command/CLI tests: 22 runs, 66 assertions, no failures/errors. Includes a shell-pipeline regression test for preserving an older current target while removing obsolete history, worker-only pruning, readers/rollout targets, malformed responses, and lookup failures.
- Command/CLI/configuration tests, including the previously blocked Docker-dependent builder files: 660 runs, 2457 assertions, no failures/errors.
- Docker Engine 29.7.2: ran the generated prune/inspect commands against isolated, real stopped containers. Without protection the current container was deleted; with protection it survived newer sibling-role history, a newer same-role failed-release fixture, and the default retention of five. Obsolete history was removed and the protected container could be restarted. Proxy-list JSON was supplied as a fixture, so this verifies Docker pruning and ID resolution, not the complete HTTP sleep/wake path.
- RuboCop on changed Ruby files and `git diff --check` pass.

Earlier idle run/deploy behavior was validated with Docker and a Rails app on a 2 GB Ubuntu VPS; that validation predates this prune protection. Earlier results: https://docs.komagata.org/6456


### HTTP sleep/wake and prune verification (2026-09-10)

Verified Kamal commit `69c91aba` with kamal-proxy commit `25977def` using an isolated Docker network and the proxy's example HTTP upstream. The test used actual proxy RPC/JSON output, Kamal-generated deploy arguments, and Kamal's target parsing, Docker inspection, and prune command generation.

Both newer sibling-role history and a newer same-role stopped-container fixture passed: HTTP 200 → automatic idle stop → prune preserves the sleeping current target and removes obsolete history → HTTP wakes that same container and returns 200 → automatic sleep again. Prune itself did not wake the application. This was a local Docker component integration test, not a full SSH-based `kamal deploy` or a real failed application rollout. Test containers/network were removed afterward.

