### PR TITLE
feat: Show health check result on failure

### DIFF
--- a/lib/kamal/cli/app/boot.rb
+++ b/lib/kamal/cli/app/boot.rb
@@ -54,13 +54,24 @@ class Kamal::Cli::App::Boot
       if running_proxy?
         endpoint = capture_with_info(*app.container_id_for_version(version)).strip
         raise Kamal::Cli::BootError, "Failed to get endpoint for #{role} on #{host}, did the container boot?" if endpoint.empty?
-        execute *app.deploy(target: endpoint)
+        begin
+          execute *app.deploy(target: endpoint)
+        rescue SSHKit::Command::Failed
+          show_health_check_response(endpoint) if role.proxy.healthcheck_debug?
+          raise
+        end
       else
         Kamal::Cli::Healthcheck::Poller.wait_for_healthy { capture_with_info(*app.status(version: version)) }
       end
     rescue => e
       error "Failed to boot #{role} on #{host}"
       raise e
+    end
+
+    def show_health_check_response(endpoint)
+      response = capture_with_info(*app.health_check_response(target: endpoint), raise_on_non_zero_exit: false)
+      error "Health check response:\n#{response}" if response.present?
+    rescue StandardError
     end
 
     def stop_new_version

--- a/lib/kamal/cli/app/boot.rb
+++ b/lib/kamal/cli/app/boot.rb
@@ -71,7 +71,8 @@ class Kamal::Cli::App::Boot
     def show_health_check_response(endpoint)
       response = capture_with_info(*app.health_check_response(target: endpoint), raise_on_non_zero_exit: false)
       error "Health check response:\n#{response}" if response.present?
-    rescue StandardError
+    rescue StandardError => e
+      info "Could not fetch health check response: #{e.class}: #{e.message}"
     end
 
     def stop_new_version

--- a/lib/kamal/commands/app/proxy.rb
+++ b/lib/kamal/commands/app/proxy.rb
@@ -21,6 +21,16 @@ module Kamal::Commands::App::Proxy
     remove_directory config.proxy_boot.app_directory
   end
 
+  def health_check_response(target:)
+    health_check_path = role.proxy.proxy_config.dig("healthcheck", "path") || "/up"
+    app_port = role.proxy.app_port
+
+    pipe \
+      docker(:inspect, "--format", "'{{.NetworkSettings.Networks.kamal.IPAddress}}'", target),
+      [ :xargs, "-I{}", :curl, "-s", "-o", "-", "-w", "'\\n%{http_code}'", "--max-time", "5",
+        "http://{}:#{app_port}#{health_check_path}" ]
+  end
+
   def create_ssl_directory
     make_directory(File.join(config.proxy_boot.tls_directory, role.name))
   end

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -118,6 +118,7 @@ proxy:
   # Set `debug` to true to log the HTTP status code and response body from an additional
   # debug healthcheck request made after a deploy fails (this may include sensitive data),
   # which can help diagnose why the container is unhealthy.
+  healthcheck:
     interval: 3
     path: /health
     timeout: 3

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -114,10 +114,14 @@ proxy:
   # the deploy timeout, with a 5-second timeout for each request.
   #
   # Once the app is up, the proxy will stop hitting the healthcheck endpoint.
+  #
+  # Set `debug` to true to log the body of the last failed healthcheck response
+  # when a deploy fails, which can help diagnose why the container is unhealthy.
   healthcheck:
     interval: 3
     path: /health
     timeout: 3
+    debug: false
 
   # Buffering
   #

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -115,9 +115,9 @@ proxy:
   #
   # Once the app is up, the proxy will stop hitting the healthcheck endpoint.
   #
-  # Set `debug` to true to log the HTTP status code and response body of the last failed healthcheck
-  # when a deploy fails (this may include sensitive data), which can help diagnose why the container is unhealthy.
-  healthcheck:
+  # Set `debug` to true to log the HTTP status code and response body from an additional
+  # debug healthcheck request made after a deploy fails (this may include sensitive data),
+  # which can help diagnose why the container is unhealthy.
     interval: 3
     path: /health
     timeout: 3

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -115,8 +115,8 @@ proxy:
   #
   # Once the app is up, the proxy will stop hitting the healthcheck endpoint.
   #
-  # Set `debug` to true to log the body of the last failed healthcheck response
-  # when a deploy fails, which can help diagnose why the container is unhealthy.
+  # Set `debug` to true to log the HTTP status code and response body of the last failed healthcheck
+  # when a deploy fails (this may include sensitive data), which can help diagnose why the container is unhealthy.
   healthcheck:
     interval: 3
     path: /health

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -67,6 +67,10 @@ class Kamal::Configuration::Proxy
     proxy_config["path_prefixes"] || proxy_config["path_prefix"]&.split(",") || []
   end
 
+  def healthcheck_debug?
+    !!proxy_config.dig("healthcheck", "debug")
+  end
+
   def deploy_options
     {
       host: hosts,

--- a/test/commands/app_test.rb
+++ b/test/commands/app_test.rb
@@ -599,6 +599,18 @@ class CommandsAppTest < ActiveSupport::TestCase
       new_command.remove_proxy_app_directory.join(" ")
   end
 
+  test "health_check_response" do
+    assert_equal \
+      "docker inspect --format '{{.NetworkSettings.Networks.kamal.IPAddress}}' abc123 | xargs -I{} curl -s -o - -w '\\n%{http_code}' --max-time 5 http://{}:80/up",
+      new_command.health_check_response(target: "abc123").join(" ")
+  end
+
+  test "health_check_response with custom path" do
+    assert_equal \
+      "docker inspect --format '{{.NetworkSettings.Networks.kamal.IPAddress}}' abc123 | xargs -I{} curl -s -o - -w '\\n%{http_code}' --max-time 5 http://{}:80/healthz",
+      new_command(proxy: { "healthcheck" => { "path" => "/healthz" } }).health_check_response(target: "abc123").join(" ")
+  end
+
   private
     def new_command(role: "web", host: "1.1.1.1", **additional_config)
       config = Kamal::Configuration.new(@config.merge(additional_config), destination: @destination, version: "999")


### PR DESCRIPTION
Before kamal-proxy switches traffic to a new release, it performs a health check.

If the health check fails, Kamal automatically rolls back the newly deployed container.
Once the rollback has completed, it is no longer possible to manually run a curl command
against the failed container to inspect the health check response and understand what went wrong.

To improve debugging, we execute a curl health check while the failed container still
exists and log both the HTTP status code and the response body in the Kamal deployment logs.

This has been extremely helpful when diagnosing deployment issues caused by
misconfigurations, especially in GitHub Actions, where reproducing the failed state can be difficult.

This feature can be enabled via
```yml
proxy:
  healthcheck:
    debug: true
```

On failure you can notice an error like this
```sh
  INFO [6bcf829d] Running docker exec kamal-proxy kamal-proxy deploy app-web-production --target="f24e8f14647c:3000" --host="somedomain.de" --deploy-timeout="30s" --drain-timeout="30s" --health-check-path="/healthz" --buffer-requests --buffer-responses --log-request-header="Cache-Control" --log-request-header="Last-Modified" --log-request-header="User-Agent" on 10.0.0.8
  INFO [2f825aa3] Running docker inspect --format '{{.NetworkSettings.Networks.kamal.IPAddress}}' f24e8f14647c | xargs -I{} curl -s -o - -w '\n%{http_code}' --max-time 5 http://{}:3000/healthz on 10.0.0.8
  INFO [2f825aa3] Finished in 0.160 seconds with exit status 0 (successful).
 ERROR Health check response:
Check <DB healthy?> failed
500
 ERROR Failed to boot web on 10.0.0.8
```