### PR TITLE
Skip development gems when building the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,11 @@ COPY Gemfile Gemfile.lock kamal.gemspec ./
 # Required in kamal.gemspec
 COPY lib/kamal/version.rb /kamal/lib/kamal/version.rb
 
-# Install system dependencies
+# Install system dependencies. The image only ever runs the kamal binary, so
+# skip the development and rubocop groups.
 RUN apk add --no-cache build-base git docker-cli openssh-client-default yaml-dev \
     && gem install bundler --version=2.6.5 \
+    && bundle config set --local without "development rubocop" \
     && bundle install
 
 # Copy the rest of our application code into the container.


### PR DESCRIPTION
The image only ever runs the kamal binary, but `bundle install` pulls in the development and rubocop groups too, so it ships railties, actionpack, nokogiri, loofah, mocha, rubocop and the rest of their trees. None of it is reachable at runtime, and it all turns up in any vulnerability scan of the published image.

Building before and after:

| | before | after |
| --- | --- | --- |
| gems installed | 71 | 25 |
| image size | 823MB | 731MB |

The 25 that remain are exactly kamal's runtime closure, and `kamal version` still works.

Two things that look like leftovers but aren't: minitest is a runtime dependency of activesupport, and debug is a default gem in ruby:3.4-alpine.

One note on the mechanism — `bundle config set --local` doesn't write ./.bundle/config in this image, because the official Ruby images set BUNDLE_APP_CONFIG=/usr/local/bundle. The setting ends up in /usr/local/bundle/config, which is where bundle install reads it from, so it works, just not where you'd expect. `BUNDLE_WITHOUT` as an ENV would be more obvious if you'd prefer that.
