### PR TITLE
Prevent pruning across destinations

### DIFF
--- a/lib/kamal/commands/prune.rb
+++ b/lib/kamal/commands/prune.rb
@@ -15,7 +15,7 @@ class Kamal::Commands::Prune < Kamal::Commands::Base
 
   def app_containers(retain:)
     pipe \
-      docker(:ps, "-q", "-a", *service_filter, *stopped_containers_filters),
+      docker(:ps, "-q", "-a", *service_filter, *destination_filter, *stopped_containers_filters),
       "tail -n +#{retain + 1}",
       "while read container_id; do docker rm $container_id; done"
   end
@@ -27,12 +27,16 @@ class Kamal::Commands::Prune < Kamal::Commands::Base
 
     def active_image_list
       # Pull the images that are used by any containers
-      # Append repo:latest - to avoid deleting the latest tag
       # Append repo:<none> - to avoid deleting dangling images that are in use. Unused dangling images are deleted separately
-      "$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=#{config.service} | tr -d '\\n')#{config.latest_image}\\|#{config.repository}:<none>"
+      # Append a repo-agnostic latest pattern - to preserve destination tags that use another repository
+      "$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=#{config.service} | tr -d '\\n')#{config.repository}:<none>\\|[^ ]*:latest\\(-[^ ]*\\)\\?$"
     end
 
     def service_filter
       [ "--filter", "label=service=#{config.service}" ]
+    end
+
+    def destination_filter
+      [ "--filter", "label=destination=#{config.destination}" ]
     end
 end

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -202,7 +202,7 @@ class CliProxyTest < CliTestCase
       assert_match "docker container ls --all --filter 'name=^app-web-12345678$' --quiet | xargs docker stop", output
       assert_match "docker tag dhh/app:latest dhh/app:latest", output
       assert_match "/usr/bin/env mkdir -p .kamal", output
-      assert_match "docker ps -q -a --filter label=service=app --filter status=created --filter status=exited --filter status=dead | tail -n +6 | while read container_id; do docker rm $container_id; done", output
+      assert_match "docker ps -q -a --filter label=service=app --filter label=destination= --filter status=created --filter status=exited --filter status=dead | tail -n +6 | while read container_id; do docker rm $container_id; done", output
       assert_match "docker image prune --force --filter label=service=app", output
       assert_match "Upgraded proxy on 1.1.1.1,1.1.1.2,1.1.1.3,1.1.1.4", output
     end

--- a/test/cli/prune_test.rb
+++ b/test/cli/prune_test.rb
@@ -11,17 +11,17 @@ class CliPruneTest < CliTestCase
   test "images" do
     run_command("images").tap do |output|
       assert_match "docker image prune --force --filter label=service=app on 1.1.1.", output
-      assert_match "docker image ls --filter label=service=app --format '{{.ID}} {{.Repository}}:{{.Tag}}' | grep -v -w \"$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=app | tr -d '\\n')dhh/app:latest\\|dhh/app:<none>\" | while read image tag; do docker rmi $tag; done on 1.1.1.", output
+      assert_match "docker image ls --filter label=service=app --format '{{.ID}} {{.Repository}}:{{.Tag}}' | grep -v -w \"$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=app | tr -d '\\n')dhh/app:<none>\\|[^ ]*:latest\\(-[^ ]*\\)\\?$\" | while read image tag; do docker rmi $tag; done on 1.1.1.", output
     end
   end
 
   test "containers" do
     run_command("containers").tap do |output|
-      assert_match /docker ps -q -a --filter label=service=app --filter status=created --filter status=exited --filter status=dead | tail -n +6 | while read container_id; do docker rm $container_id; done on 1.1.1.\d/, output
+      assert_match /docker ps -q -a --filter label=service=app --filter label=destination= --filter status=created --filter status=exited --filter status=dead | tail -n +6 | while read container_id; do docker rm $container_id; done on 1.1.1.\d/, output
      end
 
     run_command("containers", "--retain", "10").tap do |output|
-      assert_match /docker ps -q -a --filter label=service=app --filter status=created --filter status=exited --filter status=dead | tail -n +11 | while read container_id; do docker rm $container_id; done on 1.1.1.\d/, output
+      assert_match /docker ps -q -a --filter label=service=app --filter label=destination= --filter status=created --filter status=exited --filter status=dead | tail -n +11 | while read container_id; do docker rm $container_id; done on 1.1.1.\d/, output
     end
 
     assert_raises(RuntimeError, "retain must be at least 1") do

--- a/test/commands/prune_test.rb
+++ b/test/commands/prune_test.rb
@@ -16,22 +16,38 @@ class CommandsPruneTest < ActiveSupport::TestCase
 
   test "tagged images" do
     assert_equal \
-      "docker image ls --filter label=service=app --format '{{.ID}} {{.Repository}}:{{.Tag}}' | grep -v -w \"$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=app | tr -d '\\n')dhh/app:latest\\|dhh/app:<none>\" | while read image tag; do docker rmi $tag; done",
+      "docker image ls --filter label=service=app --format '{{.ID}} {{.Repository}}:{{.Tag}}' | grep -v -w \"$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=app | tr -d '\\n')dhh/app:<none>\\|[^ ]*:latest\\(-[^ ]*\\)\\?$\" | while read image tag; do docker rmi $tag; done",
+      new_command.tagged_images.join(" ")
+  end
+
+  test "tagged images with destination" do
+    @destination = "staging"
+
+    assert_equal \
+      "docker image ls --filter label=service=app --format '{{.ID}} {{.Repository}}:{{.Tag}}' | grep -v -w \"$(docker container ls -a --format '{{.Image}}\\|' --filter label=service=app | tr -d '\\n')dhh/app:<none>\\|[^ ]*:latest\\(-[^ ]*\\)\\?$\" | while read image tag; do docker rmi $tag; done",
       new_command.tagged_images.join(" ")
   end
 
   test "app containers" do
     assert_equal \
-      "docker ps -q -a --filter label=service=app --filter status=created --filter status=exited --filter status=dead | tail -n +6 | while read container_id; do docker rm $container_id; done",
+      "docker ps -q -a --filter label=service=app --filter label=destination= --filter status=created --filter status=exited --filter status=dead | tail -n +6 | while read container_id; do docker rm $container_id; done",
       new_command.app_containers(retain: 5).join(" ")
 
     assert_equal \
-      "docker ps -q -a --filter label=service=app --filter status=created --filter status=exited --filter status=dead | tail -n +4 | while read container_id; do docker rm $container_id; done",
+      "docker ps -q -a --filter label=service=app --filter label=destination= --filter status=created --filter status=exited --filter status=dead | tail -n +4 | while read container_id; do docker rm $container_id; done",
       new_command.app_containers(retain: 3).join(" ")
+  end
+
+  test "app containers with destination" do
+    @destination = "staging"
+
+    assert_equal \
+      "docker ps -q -a --filter label=service=app --filter label=destination=staging --filter status=created --filter status=exited --filter status=dead | tail -n +6 | while read container_id; do docker rm $container_id; done",
+      new_command.app_containers(retain: 5).join(" ")
   end
 
   private
     def new_command
-      Kamal::Commands::Prune.new(Kamal::Configuration.new(@config, version: "123"))
+      Kamal::Commands::Prune.new(Kamal::Configuration.new(@config, destination: @destination, version: "123"))
     end
 end

--- a/test/integration/main_test.rb
+++ b/test/integration/main_test.rb
@@ -113,7 +113,7 @@ class MainTest < IntegrationTest
     assert_match "GNU/Linux", output
   end
 
-  test "deploy with destinations" do
+  test "deploy and prune with destinations" do
     @app = "app_with_destinations"
 
     kamal :staging_deploy
@@ -124,6 +124,32 @@ class MainTest < IntegrationTest
 
     config = YAML.load(kamal(:production_config, capture: true))
     assert_equal [ "vm2", "vm3" ], config[:hosts]
+
+    image = "registry:4443/app_with_destinations:#{latest_app_version}"
+    docker_compose "exec vm1 docker create --name production-old --label service=app_with_destinations --label destination=production #{image}"
+    docker_compose "exec vm1 docker create --name staging-old --label service=app_with_destinations --label destination=staging #{image}"
+    docker_compose "exec vm1 docker create --name staging-new --label service=app_with_destinations --label destination=staging #{image}"
+
+    kamal :prune, :containers, "-d", "staging", "--retain", "1"
+
+    containers = docker_compose("exec vm1 docker container ls -a --format '{{.Names}}'", capture: true).lines.map(&:strip)
+    assert_includes containers, "production-old"
+    assert_not_includes containers, "staging-old"
+    assert_includes containers, "staging-new"
+
+    docker_compose "exec vm1 docker tag #{image} other/app:latest"
+    docker_compose "exec vm1 docker tag #{image} other/app:latest-production"
+    docker_compose "exec vm1 docker tag #{image} other/app:latest.backup"
+    docker_compose "exec vm1 docker tag #{image} other/app:unused"
+
+    kamal :prune, :images, "-d", "staging"
+
+    images = docker_compose("exec vm1 docker image ls --filter label=service=app_with_destinations --format '{{.Repository}}:{{.Tag}}'", capture: true).lines.map(&:strip)
+    assert_includes images, "registry:4443/app_with_destinations:latest-staging"
+    assert_includes images, "other/app:latest"
+    assert_includes images, "other/app:latest-production"
+    assert_not_includes images, "other/app:latest.backup"
+    assert_not_includes images, "other/app:unused"
   end
 
   test "setup and remove" do


### PR DESCRIPTION
Fixes #1922.

## Summary

- Scope stopped-container retention by both service and destination, including the baseline `destination=` label.
- Keep image pruning service-wide while preserving `latest` and every `latest-<destination>` marker across repositories.
- Add a same-host Docker regression covering both container retention and image pruning.

## Why

Pruning stopped containers previously filtered only by service, so destinations sharing a host also shared one retention pool. A deployment in one destination could therefore remove rollback containers belonging to another.

Tagged image pruning is intentionally service-wide because images may be shared between destinations. However, it previously protected only the invoking configuration's latest tag. The repository-agnostic marker pattern is applied only to the service-labelled candidate set, allowing destination configurations to use different image repositories without deleting one another's current marker.

## Testing

- `bin/test test/commands/prune_test.rb test/cli/prune_test.rb test/cli/proxy_test.rb`
- `bin/test test/integration/main_test.rb:116`
- `bundle exec rubocop --parallel`
- `bin/test` — 856 runs and 3,130 assertions; all affected and Docker integration tests pass. Two existing host-architecture assertions in untouched builder tests fail locally on Apple Silicon.
