### PR TITLE
Allow SSL without hosts when a custom certificate is provided

### DIFF
--- a/lib/kamal/configuration/validator/proxy.rb
+++ b/lib/kamal/configuration/validator/proxy.rb
@@ -3,7 +3,9 @@ class Kamal::Configuration::Validator::Proxy < Kamal::Configuration::Validator
     unless config.nil?
       super
 
-      if config["host"].blank? && config["hosts"].blank? && config["ssl"]
+      custom_ssl_certificate = config["ssl"].is_a?(Hash) &&
+        config["ssl"]["certificate_pem"].present? && config["ssl"]["private_key_pem"].present?
+      if config["host"].blank? && config["hosts"].blank? && config["ssl"] && !custom_ssl_certificate
         error "Must set a host to enable automatic SSL"
       end
 


### PR DESCRIPTION
The host requirement on `proxy.ssl` exists because automatic (ACME) TLS cannot issue a certificate without knowing the hostname. When `certificate_pem` and `private_key_pem` are supplied no issuance happens — kamal-proxy serves the given certificate for any SNI and routes through its empty-host catch-all service.

Multi-tenant apps that receive arbitrary customer Host headers at the origin (for example behind Cloudflare for SaaS, where customer domains CNAME to a fallback origin) need exactly this shape: TLS termination with a custom certificate and no host list, so unknown hosts still reach the app.

kamal-proxy already supports it — `kamal-proxy deploy --tls --tls-certificate-path ... --tls-private-key-path ...` with no `--host` flag deploys a catch-all TLS service (verified in production use). Only the config validator refused the combination, with an error about automatic SSL that does not apply to custom certificates.

The change scopes the host requirement to the automatic-TLS case: `ssl: true` still requires a host; `ssl: { certificate_pem: ..., private_key_pem: ... }` no longer does.