### PR TITLE
Export pre-configure hook output to ENV for config ERB

### DIFF
--- a/lib/kamal/cli/base.rb
+++ b/lib/kamal/cli/base.rb
@@ -99,6 +99,9 @@ module Kamal::Cli
             say message
           end
 
+          # Export remaining keys so the ERB in the config file can read them
+          output.except("KAMAL_DESTINATION", "KAMAL_MESSAGE").each { |key, value| ENV[key] = value }
+
           output["KAMAL_DESTINATION"]
         rescue SSHKit::Command::Failed => e
           raise HookError.new("Hook `pre-configure` failed:\n#{e.message}")

--- a/lib/kamal/cli/templates/sample_hooks/pre-configure.sample
+++ b/lib/kamal/cli/templates/sample_hooks/pre-configure.sample
@@ -17,6 +17,8 @@
 #
 # KAMAL_DESTINATION — sets or overwrites the destination for this deploy
 # KAMAL_MESSAGE — printed to the user after the hook runs
-# Any other keys are accumulated and available to subsequent hooks
+# Any other keys are exported as environment variables before the config file
+# is rendered — so its ERB can read them, e.g. <%= ENV["MY_HOST"] %> — and are
+# also available to subsequent hooks
 
 echo "pre-configure hook called for destination: ${KAMAL_DESTINATION:-<none>}"

--- a/test/cli/pre_configure_test.rb
+++ b/test/cli/pre_configure_test.rb
@@ -35,6 +35,36 @@ class CliPreConfigureTest < CliTestCase
     end
   end
 
+  test "pre-configure hook output is exported to ENV for config ERB" do
+    config_yaml = <<~YAML
+      service: app
+      image: dhh/app
+      registry:
+        username: dhh
+        password: secret
+      servers:
+        - <%= ENV["PRE_CONFIGURE_HOST"] %>
+      builder:
+        arch: amd64
+    YAML
+
+    with_pre_configure_hook({ "PRE_CONFIGURE_HOST" => "1.2.3.4" }, config_yaml: config_yaml) do
+      run_command("exec", "date", "-c", "config/deploy.yml")
+
+      assert_includes KAMAL.config.all_hosts, "1.2.3.4"
+    end
+  ensure
+    ENV.delete("PRE_CONFIGURE_HOST")
+  end
+
+  test "pre-configure hook does not export reserved keys to ENV" do
+    with_pre_configure_hook({ "KAMAL_MESSAGE" => "Deploying to beta2" }) do
+      run_command("exec", "date", "-c", config_file_path("deploy_with_accessories"))
+
+      assert_nil ENV["KAMAL_MESSAGE"]
+    end
+  end
+
   test "pre-configure hook failure raises HookError" do
     with_pre_configure_hook_that_fails do
       assert_raises(Kamal::Cli::HookError) do
@@ -131,7 +161,7 @@ class CliPreConfigureTest < CliTestCase
       "test/fixtures/#{fixture_name}.yml"
     end
 
-    def with_pre_configure_hook(output, hooks_path: nil, destination: nil)
+    def with_pre_configure_hook(output, hooks_path: nil, destination: nil, config_yaml: nil)
       Dir.mktmpdir do |tmpdir|
         original_pwd = Dir.pwd
         old_dest = ENV["KAMAL_DESTINATION"]
@@ -149,6 +179,12 @@ class CliPreConfigureTest < CliTestCase
           hook_dir = File.join(tmpdir, resolved_hooks_path)
           FileUtils.mkdir_p(hook_dir)
           File.write(File.join(hook_dir, "pre-configure"), "#!/bin/bash\n")
+
+          if config_yaml
+            config_dir = File.join(tmpdir, "config")
+            FileUtils.mkdir_p(config_dir)
+            File.write(File.join(config_dir, "deploy.yml"), config_yaml)
+          end
 
           # If custom hooks_path, write a config that uses it (with raw ERB intact),
           # plus a destination overlay so config loads successfully after rewrite


### PR DESCRIPTION
## Summary

Builds on #1783. The `pre-configure` hook can already rewrite the destination and pass data to subsequent hooks via `$KAMAL_OUTPUT`, but its output is invisible to the ERB in the config file itself — the one consumer that runs immediately after it.

This exports every non-reserved key from the hook's output into `ENV` before `Configuration.create_from` runs, so a hook can compute dynamic values that `deploy.yml` reads with plain `<%= ENV["..."] %>`:

```sh
# .kamal/hooks/pre-configure
echo "MY_HOST=$(./bin/resolve_branch_host)" >> "$KAMAL_OUTPUT"
```

```yaml
servers:
  - <%= ENV["MY_HOST"] %>
```

`KAMAL_DESTINATION` and `KAMAL_MESSAGE` keep their existing special semantics and are not exported.

### Motivation

We deploy a monorepo (~20 apps) where every generated `deploy.*.yml` currently starts with an ERB line that loads an internal library and mutates `ENV` in-process — it even re-parses `-d` out of `ARGV` — so the rest of the YAML can read `<%= ENV[...] %>`. It works only because Kamal renders ERB in-process, and it's exactly the kind of thing `pre-configure` should replace. Since config-file ERB has access to nothing but `ENV`, this back-channel is the missing link for feeding hook-computed values into the config.

## Test plan

- [x] Hook output key becomes an env var visible to config ERB (`servers: - <%= ENV["PRE_CONFIGURE_HOST"] %>` resolves)
- [x] Reserved keys (`KAMAL_DESTINATION`, `KAMAL_MESSAGE`) are not exported
- [x] Existing pre-configure suite still green (14 runs, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)