### PR TITLE
Add tls_on_demand_url option for kamal-proxy

### DIFF
--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -47,6 +47,18 @@ proxy:
   # Defaults to `false`:
   ssl: true
 
+  # On-demand TLS
+  #
+  # For apps serving customer-supplied domains, which aren't known at deploy time.
+  # kamal-proxy asks the given endpoint whether a host may have a certificate issued,
+  # sending the hostname as a `host` query parameter and provisioning only on a 200
+  # response. The value is a path served by the app, or an absolute http(s) URL.
+  #
+  # Requires `ssl: true`, and cannot be combined with `host`/`hosts` or a custom SSL
+  # certificate. The app becomes the wildcard target, so it must approve its own
+  # domain too.
+  tls_on_demand_url: /up/tls_on_demand
+
   # Custom SSL certificate
   #
   # In some cases, using Let's Encrypt for automatic certificate management is not an

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -29,6 +29,10 @@ class Kamal::Configuration::Proxy
     proxy_config["hosts"] || proxy_config["host"]&.split(",") || []
   end
 
+  def tls_on_demand_url
+    proxy_config["tls_on_demand_url"]
+  end
+
   def custom_ssl_certificate?
     ssl = proxy_config["ssl"]
     return false unless ssl.is_a?(Hash)
@@ -73,6 +77,7 @@ class Kamal::Configuration::Proxy
       tls: ssl? ? true : nil,
       "tls-certificate-path": container_tls_cert,
       "tls-private-key-path": container_tls_key,
+      "tls-on-demand-url": tls_on_demand_url,
       "deploy-timeout": seconds_duration(config.deploy_timeout),
       "drain-timeout": seconds_duration(config.drain_timeout),
       "health-check-interval": seconds_duration(proxy_config.dig("healthcheck", "interval")),

--- a/lib/kamal/configuration/proxy/run.rb
+++ b/lib/kamal/configuration/proxy/run.rb
@@ -1,5 +1,5 @@
 class Kamal::Configuration::Proxy::Run
-  MINIMUM_VERSION = "v0.9.2"
+  MINIMUM_VERSION = "v0.10.0"
   DEFAULT_HTTP_PORT = 80
   DEFAULT_HTTPS_PORT = 443
   DEFAULT_LOG_MAX_SIZE = "10m"

--- a/lib/kamal/configuration/validator/proxy.rb
+++ b/lib/kamal/configuration/validator/proxy.rb
@@ -3,12 +3,28 @@ class Kamal::Configuration::Validator::Proxy < Kamal::Configuration::Validator
     unless config.nil?
       super
 
-      if config["host"].blank? && config["hosts"].blank? && config["ssl"]
+      if config["host"].blank? && config["hosts"].blank? && config["ssl"] && config["tls_on_demand_url"].blank?
         error "Must set a host to enable automatic SSL"
       end
 
       if (config.keys & [ "host", "hosts" ]).size > 1
         error "Specify one of 'host' or 'hosts', not both"
+      end
+
+      if config.key?("tls_on_demand_url")
+        unless config["ssl"]
+          error "Must enable ssl to use tls_on_demand_url"
+        end
+
+        if config["host"].present? || config["hosts"].present?
+          error "Cannot set a host when using tls_on_demand_url"
+        end
+
+        if config["ssl"].is_a?(Hash)
+          error "Cannot use a custom SSL certificate with tls_on_demand_url"
+        end
+
+        ensure_valid_tls_on_demand_url config["tls_on_demand_url"]
       end
 
       if config["ssl"].is_a?(Hash)
@@ -36,6 +52,20 @@ class Kamal::Configuration::Validator::Proxy < Kamal::Configuration::Validator
   end
 
   private
+    # Mirrors kamal-proxy's own parsing: a path, or an absolute http(s) URL with a host.
+    def ensure_valid_tls_on_demand_url(url)
+      if url.is_a?(String) && url.present?
+        return if url.start_with?("/") && !url.start_with?("//")
+
+        uri = URI.parse(url)
+        return if uri.scheme.in?([ "http", "https" ]) && uri.host.present?
+      end
+
+      error "tls_on_demand_url must be a path or an absolute http(s) URL"
+    rescue URI::InvalidURIError
+      error "tls_on_demand_url must be a path or an absolute http(s) URL"
+    end
+
     def ensure_valid_bind_ips(bind_ips)
       bind_ips.present? && bind_ips.each do |ip|
         next if ip =~ Resolv::IPv4::Regex || ip =~ Resolv::IPv6::Regex

--- a/test/cli/proxy_test.rb
+++ b/test/cli/proxy_test.rb
@@ -13,8 +13,8 @@ class CliProxyTest < CliTestCase
     run_command("boot", fixture: :with_proxy_run_config).tap do |output|
       assert_match "docker login", output
       assert_match "mkdir -p .kamal/proxy/apps-config", output
-      assert_match "docker container start kamal-proxy || docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m --expose=9090 --cpus \"1.5\" registry:4443/basecamp/kamal-proxy:v0.9.2 kamal-proxy run --debug --metrics-port \"9090\" on 1.1.1.1", output
-      assert_match "docker container start kamal-proxy || docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m --expose=9190 basecamp/kamal-proxy:v0.9.2 kamal-proxy run --metrics-port \"9190\" on 1.1.1.3", output
+      assert_match "docker container start kamal-proxy || docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m --expose=9090 --cpus \"1.5\" registry:4443/basecamp/kamal-proxy:v0.10.0 kamal-proxy run --debug --metrics-port \"9090\" on 1.1.1.1", output
+      assert_match "docker container start kamal-proxy || docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m --expose=9190 basecamp/kamal-proxy:v0.10.0 kamal-proxy run --metrics-port \"9190\" on 1.1.1.3", output
     end
   end
 

--- a/test/commands/proxy_test.rb
+++ b/test/commands/proxy_test.rb
@@ -168,14 +168,14 @@ class CommandsProxyTest < ActiveSupport::TestCase
   test "registry run config" do
     @config[:proxy] = { "run" => { "registry" => "registry:4443" } }
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m registry:4443/basecamp/kamal-proxy:v0.9.2 kamal-proxy run",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m registry:4443/basecamp/kamal-proxy:v0.10.0 kamal-proxy run",
       new_command.run.join(" ")
   end
 
   test "repository run config" do
     @config[:proxy] = { "run" => { "repository" => "custom/repo" } }
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m custom/repo:v0.9.2 kamal-proxy run",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m custom/repo:v0.10.0 kamal-proxy run",
       new_command.run.join(" ")
   end
 
@@ -189,35 +189,35 @@ class CommandsProxyTest < ActiveSupport::TestCase
   test "bind_ips run config" do
     @config[:proxy] = { "run" => { "bind_ips" => [ "0.0.0.0", "127.0.0.1" ] } }
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 0.0.0.0:80:80 --publish 0.0.0.0:443:443 --publish 127.0.0.1:80:80 --publish 127.0.0.1:443:443 --log-opt max-size=10m basecamp/kamal-proxy:v0.9.2 kamal-proxy run",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 0.0.0.0:80:80 --publish 0.0.0.0:443:443 --publish 127.0.0.1:80:80 --publish 127.0.0.1:443:443 --log-opt max-size=10m basecamp/kamal-proxy:v0.10.0 kamal-proxy run",
       new_command.run.join(" ")
   end
 
   test "log_max_size run config" do
     @config[:proxy] = { "run" => { "log_max_size" => "50m" } }
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=50m basecamp/kamal-proxy:v0.9.2 kamal-proxy run",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=50m basecamp/kamal-proxy:v0.10.0 kamal-proxy run",
       new_command.run.join(" ")
   end
 
   test "debug run config" do
     @config[:proxy] = { "run" => { "debug" => true } }
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m basecamp/kamal-proxy:v0.9.2 kamal-proxy run --debug",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m basecamp/kamal-proxy:v0.10.0 kamal-proxy run --debug",
       new_command.run.join(" ")
   end
 
   test "metrics_port run config" do
     @config[:proxy] = { "run" => { "metrics_port" => 9090 } }
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m --expose=9090 basecamp/kamal-proxy:v0.9.2 kamal-proxy run --metrics-port \"9090\"",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --publish 80:80 --publish 443:443 --log-opt max-size=10m --expose=9090 basecamp/kamal-proxy:v0.10.0 kamal-proxy run --metrics-port \"9090\"",
       new_command.run.join(" ")
   end
 
   test "don't publish run config" do
     @config[:proxy] = { "run" => { "publish" => false } }
     assert_equal \
-      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --log-opt max-size=10m basecamp/kamal-proxy:v0.9.2 kamal-proxy run",
+      "docker run --name kamal-proxy --network kamal --detach --restart unless-stopped --volume kamal-proxy-config:/home/kamal-proxy/.config/kamal-proxy --volume $PWD/.kamal/proxy/apps-config:/home/kamal-proxy/.apps-config --log-opt max-size=10m basecamp/kamal-proxy:v0.10.0 kamal-proxy run",
       new_command.run.join(" ")
   end
 

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -38,6 +38,60 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
     assert_not config.proxy.ssl?
   end
 
+  test "tls_on_demand_url with no host" do
+    @deploy[:proxy] = { "ssl" => true, "tls_on_demand_url" => "/up/tls_on_demand" }
+    assert_equal "/up/tls_on_demand", config.proxy.tls_on_demand_url
+    assert_includes config.proxy.deploy_command_args(target: "172.1.0.2"), "--tls-on-demand-url=\"/up/tls_on_demand\""
+  end
+
+  test "tls_on_demand_url with an absolute url" do
+    @deploy[:proxy] = { "ssl" => true, "tls_on_demand_url" => "https://example.com/allowed" }
+    assert_equal "https://example.com/allowed", config.proxy.tls_on_demand_url
+  end
+
+  test "tls_on_demand_url omitted when not set" do
+    @deploy[:proxy] = { "ssl" => true, "host" => "example.com" }
+    assert_nil config.proxy.tls_on_demand_url
+    assert_not config.proxy.deploy_command_args(target: "172.1.0.2").any? { |arg| arg.start_with?("--tls-on-demand-url") }
+  end
+
+  test "tls_on_demand_url requires ssl" do
+    @deploy[:proxy] = { "tls_on_demand_url" => "/up/tls_on_demand" }
+    assert_raises(Kamal::ConfigurationError) { config.proxy.ssl? }
+  end
+
+  test "tls_on_demand_url cannot be combined with a host" do
+    @deploy[:proxy] = { "ssl" => true, "host" => "example.com", "tls_on_demand_url" => "/up/tls_on_demand" }
+    assert_raises(Kamal::ConfigurationError) { config.proxy.ssl? }
+  end
+
+  test "tls_on_demand_url cannot be combined with a custom certificate" do
+    @deploy[:proxy] = {
+      "ssl" => { "certificate_pem" => "CERTIFICATE_PEM", "private_key_pem" => "PRIVATE_KEY_PEM" },
+      "tls_on_demand_url" => "/up/tls_on_demand"
+    }
+    assert_raises(Kamal::ConfigurationError) { config.proxy.ssl? }
+  end
+
+  test "tls_on_demand_url accepts paths and absolute http(s) urls" do
+    [ "/up/tls_on_demand", "/", "https://example.com/allowed", "HTTP://example.com", "http://example.com:8080/a" ].each do |url|
+      @deploy[:proxy] = { "ssl" => true, "tls_on_demand_url" => url }
+      assert_equal url, config.proxy.tls_on_demand_url, "#{url} should be allowed"
+    end
+  end
+
+  test "tls_on_demand_url rejects anything else" do
+    [ "//example.com/allowed", "https://", "ftp://example.com", "example.com", "", 123, true ].each do |url|
+      @deploy[:proxy] = { "ssl" => true, "tls_on_demand_url" => url }
+      assert_raises(Kamal::ConfigurationError, "#{url.inspect} should be rejected") { config.proxy.ssl? }
+    end
+  end
+
+  test "a blank tls_on_demand_url is rejected rather than passed to the proxy" do
+    @deploy[:proxy] = { "ssl" => true, "host" => "example.com", "tls_on_demand_url" => "" }
+    assert_raises(Kamal::ConfigurationError) { config.proxy.deploy_command_args(target: "172.1.0.2") }
+  end
+
   test "false not allowed" do
     @deploy[:proxy] = false
     assert_raises(Kamal::ConfigurationError, "proxy: should be a hash") do

--- a/test/integration/docker/deployer/setup.sh
+++ b/test/integration/docker/deployer/setup.sh
@@ -13,9 +13,9 @@ install_kamal
 # Seed the private registry with the proxy image (fetched once via the hub_cache
 # mirror) so the proxy.run.registry option stays exercised by the suite — see
 # app_with_roles, which pulls its proxy from registry:4443 rather than the Hub.
-docker pull basecamp/kamal-proxy:v0.9.2
-docker tag basecamp/kamal-proxy:v0.9.2 registry:4443/basecamp/kamal-proxy:v0.9.2
-docker push registry:4443/basecamp/kamal-proxy:v0.9.2
+docker pull basecamp/kamal-proxy:v0.10.0
+docker tag basecamp/kamal-proxy:v0.10.0 registry:4443/basecamp/kamal-proxy:v0.10.0
+docker push registry:4443/basecamp/kamal-proxy:v0.10.0
 
 # .ssh is on a shared volume that persists between runs. Clean it up as the
 # churn of temporary vm IPs can eventually create conflicts.


### PR DESCRIPTION
This landed in https://github.com/basecamp/kamal-proxy/pull/225 but is not yet exposed to the kamal deploy configuration file.

Also note that while it has been merged to kamal-proxy main branch, there hasn't been an official release since [0.9.2](https://github.com/basecamp/kamal-proxy/releases/tag/v0.9.2) in December, 2025