### PR TITLE
Add `builder.additional_contexts` configuration to natively pass additional build contexts

### DIFF
--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -6,7 +6,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   delegate :argumentize, to: Kamal::Utils
   delegate \
     :args, :secrets, :dockerfile, :target, :arches, :local_arches, :remote_arches, :remote,
-    :pack?, :pack_builder, :pack_buildpacks,
+    :pack?, :pack_builder, :pack_buildpacks, :additional_contexts,
     :cache_from, :cache_to, :ssh, :provenance, :sbom, :driver, :docker_driver?,
     to: :builder_config
 
@@ -41,7 +41,7 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   end
 
   def build_options
-    [ *build_cache, *build_labels, *build_args, *build_secrets, *build_dockerfile, *build_target, *build_ssh, *builder_provenance, *builder_sbom ]
+    [ *build_cache, *build_labels, *build_args, *build_secrets, *build_dockerfile, *build_target, *build_ssh, *builder_provenance, *builder_sbom, *build_additional_contexts ]
   end
 
   def build_context
@@ -93,6 +93,10 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
 
     def build_args
       argumentize "--build-arg", args, sensitive: true
+    end
+
+    def build_additional_contexts
+      argumentize "--build-context", additional_contexts
     end
 
     def build_secrets

--- a/lib/kamal/configuration/builder.rb
+++ b/lib/kamal/configuration/builder.rb
@@ -85,6 +85,10 @@ class Kamal::Configuration::Builder
     builder_config["context"] || "."
   end
 
+  def additional_contexts
+    builder_config["additional_contexts"] || {}
+  end
+
   def driver
     builder_config.fetch("driver", "docker-container")
   end

--- a/lib/kamal/configuration/docs/builder.yml
+++ b/lib/kamal/configuration/docs/builder.yml
@@ -67,6 +67,14 @@ builder:
   # The Dockerfile to use for building, defaults to `Dockerfile`:
   dockerfile: Dockerfile.production
 
+  # Additional build contexts
+  #
+  # Additional build contexts to use when building. They are referenced by
+  # name from the Dockerfile:
+  additional_contexts:
+    scripts: ../../scripts
+    assets: ../../assets
+
   # Build target
   #
   # If not set, then the default target is used:

--- a/lib/kamal/configuration/validator.rb
+++ b/lib/kamal/configuration/validator.rb
@@ -45,7 +45,7 @@ class Kamal::Configuration::Validator
               end
             elsif example_value.is_a?(Hash)
               case key.to_s
-              when "options", "args"
+              when "options", "args", "additional_contexts"
                 validate_type! value, Hash
               when "labels"
                 validate_hash_of! value, example_value.first[1].class

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -150,6 +150,20 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       builder.push.join(" ")
   end
 
+  test "build additional contexts" do
+    builder = new_builder_command(builder: { "additional_contexts" => { "scripts" => "../../scripts", "assets" => "../../assets" } })
+    assert_equal \
+      "--label service=\"app\" --file Dockerfile --build-context scripts=\"../../scripts\" --build-context assets=\"../../assets\"",
+      builder.target.build_options.join(" ")
+  end
+
+  test "push with additional contexts" do
+    builder = new_builder_command(builder: { "additional_contexts" => { "scripts" => "../../scripts", "assets" => "../../assets" } })
+    assert_equal \
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --build-context scripts=\"../../scripts\" --build-context assets=\"../../assets\" . 2>&1",
+      builder.push.join(" ")
+  end
+
   test "push with build args" do
     builder = new_builder_command(builder: { "args" => { "a" => 1, "b" => 2 } })
     assert_equal \

--- a/test/configuration/builder_test.rb
+++ b/test/configuration/builder_test.rb
@@ -141,6 +141,16 @@ class ConfigurationBuilderTest < ActiveSupport::TestCase
     assert_equal "..", config.builder.context
   end
 
+  test "additional_contexts" do
+    assert_equal({}, config.builder.additional_contexts)
+  end
+
+  test "setting additional_contexts" do
+    @deploy[:builder]["additional_contexts"] = { "scripts" => "../../scripts", "assets" => "../../assets" }
+
+    assert_equal({ "scripts" => "../../scripts", "assets" => "../../assets" }, config.builder.additional_contexts)
+  end
+
   test "ssh" do
     assert_nil config.builder.ssh
   end


### PR DESCRIPTION
### Problem

While migrating from Docker Compose to Kamal in production, one of our Dockerfiles copies scripts from a context inside the app context:

```dockerfile
COPY --from=scripts . .
```

Docker Compose has a native option to declare these extra build contexts via `additional_contexts`:

```yaml
additional_contexts:
  scripts: ../../scripts
```

Kamal had no equivalent, so the build broke during migration — there was no way to pass `--build-context` to Buildx from the deploy config.

### Fix

Kamal now supports declaring additional build contexts under `builder.additional_contexts` in `deploy.yml`:

```yaml
builder:
  context: "../../apps/dashboard"
  dockerfile: "../../infra/docker/dashboard.Dockerfile"
  additional_contexts:
    scripts: "../../scripts"
    assets: "../../assets"
```

Each entry is passed through to Buildx as `--build-context <name>=<value>` and can be referenced in the Dockerfile via `COPY --from=<name>`.

### Implementation

- **Config parsing** (`lib/kamal/configuration/builder.rb`): added an `additional_contexts` reader that returns the configured hash (or `{}`).
- **Validation** (`lib/kamal/configuration/validator.rb`): `additional_contexts` is treated as a free-form Hash (like `args`/`options`) since its keys are user-defined; the option is also documented in `docs/builder.yml`, which doubles as the schema example.
- **Command building** (`lib/kamal/commands/builder/base.rb`): added a `build_additional_contexts` method that formats each key/value pair using the existing `argumentize` helper and appends the result to `build_options`. All drivers (local, remote, hybrid, cloud) inherit from `Base`, so they all pick this up.
- **Tests**: added coverage for config parsing (default + configured) and for the generated `--build-context` flags in both `build_options` and the full `docker buildx build` command.
