### PR TITLE
Allow retaining deploy lock through post-deploy

### DIFF
--- a/lib/kamal/cli/main.rb
+++ b/lib/kamal/cli/main.rb
@@ -19,7 +19,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
   option :skip_push, aliases: "-P", type: :boolean, default: false, desc: "Skip image build and push"
   option :no_cache, type: :boolean, default: false, desc: "Build without using Docker's build cache"
   def deploy(boot_accessories: false)
-    modify do
+    modify(lock: KAMAL.config.post_deploy_lock?) do
       runtime = print_runtime do
         invoke_options = deploy_options
 
@@ -57,7 +57,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
   option :skip_push, aliases: "-P", type: :boolean, default: false, desc: "Skip image build and push"
   option :no_cache, type: :boolean, default: false, desc: "Build without using Docker's build cache"
   def redeploy
-    modify do
+    modify(lock: KAMAL.config.post_deploy_lock?) do
       runtime = print_runtime do
         invoke_options = deploy_options
 
@@ -87,7 +87,7 @@ class Kamal::Cli::Main < Kamal::Cli::Base
   def rollback(version)
     rolled_back = false
 
-    modify do
+    modify(lock: KAMAL.config.post_deploy_lock?) do
       runtime = print_runtime do
         modify(lock: true) do
           invoke_options = deploy_options

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -302,6 +302,10 @@ class Kamal::Configuration
     end
   end
 
+  def post_deploy_lock?
+    raw_config.post_deploy_lock || false
+  end
+
   def to_h
     {
       roles: role_names,

--- a/lib/kamal/configuration/docs/configuration.yml
+++ b/lib/kamal/configuration/docs/configuration.yml
@@ -104,6 +104,13 @@ hooks_output:
   pre-deploy: :verbose
   pre-build: :quiet
 
+# Post-deploy lock
+#
+# Keep the remote deploy lock held while the post-deploy hook runs, defaults to `false`.
+# This also acquires the lock before the build, serializing the entire deploy command.
+# Useful when post-deploy performs stateful work such as database migrations or cache warming:
+post_deploy_lock: true
+
 # Secrets path
 #
 # Path to secrets, defaults to `.kamal/secrets`.

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -324,6 +324,47 @@ class CliMainTest < CliTestCase
     assert_not KAMAL.holding_lock?
   end
 
+  test "redeploy can retain the lock through post-deploy" do
+    invoke_options = base_invoke_options(config_file: "deploy_with_post_deploy_lock.yml")
+
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:boot", [], invoke_options)
+
+    hook_lock_states = {}
+    Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).with do |hook|
+      hook_lock_states[hook] = KAMAL.holding_lock?
+      true
+    end.returns(true)
+
+    run_command("redeploy", config_file: "deploy_with_post_deploy_lock").tap do |output|
+      assert_operator output.index("Acquiring the deploy lock"), :<, output.index("Build and push app image")
+      assert_operator output.index("Build and push app image"), :<, output.index("post-deploy")
+      assert_operator output.index("post-deploy"), :<, output.index("Releasing the deploy lock")
+      assert hook_lock_states["post-deploy"]
+    end
+  end
+
+  test "rollback can retain the lock through post-deploy" do
+    invoke_options = base_invoke_options(config_file: "deploy_with_post_deploy_lock.yml")
+
+    Kamal::Cli::Main.any_instance.stubs(:container_available?).with("123").returns(true)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:boot", [], invoke_options.merge(version: "123"))
+
+    hook_lock_states = {}
+    Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).with do |hook|
+      hook_lock_states[hook] = KAMAL.holding_lock?
+      true
+    end.returns(true)
+
+    run_command("rollback", "123", config_file: "deploy_with_post_deploy_lock").tap do |output|
+      assert_operator output.index("Acquiring the deploy lock"), :<, output.index("pre-deploy")
+      assert_operator output.index("pre-deploy"), :<, output.index("post-deploy")
+      assert_operator output.index("post-deploy"), :<, output.index("Releasing the deploy lock")
+      assert hook_lock_states["post-deploy"]
+    end
+  end
+
   test "deploy when inheriting lock" do
     Thread.report_on_exception = false
 

--- a/test/cli/main_test.rb
+++ b/test/cli/main_test.rb
@@ -291,6 +291,39 @@ class CliMainTest < CliTestCase
     assert_match /held manually/, error.message
   end
 
+  test "deploy can retain the lock through post-deploy" do
+    invoke_options = base_invoke_options(config_file: "deploy_with_post_deploy_lock.yml")
+
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:build:deliver", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:proxy:boot", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:stale_containers", [], invoke_options.merge(stop: true))
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:app:boot", [], invoke_options)
+    Kamal::Cli::Main.any_instance.expects(:invoke).with("kamal:cli:prune:all", [], invoke_options)
+
+    hook_lock_states = {}
+    Kamal::Commands::Hook.any_instance.stubs(:hook_exists?).with do |hook|
+      hook_lock_states[hook] = KAMAL.holding_lock?
+      true
+    end.returns(true)
+
+    run_command("deploy", config_file: "deploy_with_post_deploy_lock").tap do |output|
+      assert_operator output.index("Acquiring the deploy lock"), :<, output.index("Build and push app image")
+      assert_operator output.index("Build and push app image"), :<, output.index("post-deploy")
+      assert_operator output.index("post-deploy"), :<, output.index("Releasing the deploy lock")
+      assert hook_lock_states["post-deploy"]
+    end
+  end
+
+  test "deploy releases the retained lock when post-deploy fails" do
+    Kamal::Cli::Main.any_instance.stubs(:invoke)
+    fail_hook "post-deploy"
+
+    assert_raises(Kamal::Cli::HookError) do
+      stderred { run_command("deploy", config_file: "deploy_with_post_deploy_lock") }
+    end
+    assert_not KAMAL.holding_lock?
+  end
+
   test "deploy when inheriting lock" do
     Thread.report_on_exception = false
 

--- a/test/configuration/validation_test.rb
+++ b/test/configuration/validation_test.rb
@@ -10,7 +10,7 @@ class ConfigurationValidationTest < ActiveSupport::TestCase
       assert_error "#{key}: should be a string", **{ key => [] }
     end
 
-    [ :require_destination, :allow_empty_roles ].each do |key|
+    [ :require_destination, :allow_empty_roles, :post_deploy_lock ].each do |key|
       assert_error "#{key}: should be a boolean", **{ key => "foo" }
     end
 

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -463,4 +463,14 @@ class ConfigurationTest < ActiveSupport::TestCase
     end
     assert_match /Invalid hooks_output 'invalid' for hook 'pre-deploy'/, error.message
   end
+
+  test "post_deploy_lock defaults to false" do
+    assert_not @config.post_deploy_lock?
+  end
+
+  test "post_deploy_lock can be enabled" do
+    config = Kamal::Configuration.new(@deploy.merge(post_deploy_lock: true))
+
+    assert config.post_deploy_lock?
+  end
 end

--- a/test/fixtures/deploy_with_post_deploy_lock.yml
+++ b/test/fixtures/deploy_with_post_deploy_lock.yml
@@ -1,0 +1,11 @@
+service: app
+image: dhh/app
+servers:
+  - "1.1.1.1"
+  - "1.1.1.2"
+registry:
+  username: user
+  password: pw
+builder:
+  arch: amd64
+post_deploy_lock: true


### PR DESCRIPTION
`deploy`, `redeploy`, and `rollback` currently release the automatic remote lock before running `post-deploy`. That lets a waiting deployment begin mutating the same service while a stateful post-deploy hook (for example, migrations or cache warming) is still running.

This adds an opt-in, backward-compatible configuration setting:

```yaml
post_deploy_lock: true
```

When enabled, the existing remote deploy lock covers the entire command, from before build/pull through completion of `post-deploy`. The existing nested lock remains re-entrant, hooks inherit `KAMAL_LOCK=true`, and failures still release the lock. The default remains `false`, so existing deployments are unchanged. (`setup` already holds its outer lock through the nested deploy and remains unchanged.)

Tests cover configuration/validation, acquisition and release order, lock visibility in `post-deploy`, and release after hook failure.

Validation:
- `./bin/test` excluding Docker integration: 841 runs, 2,745 assertions, 0 failures/errors
- `bundle exec rubocop`: 178 files, no offenses
- Docker integration bootstrap was attempted locally, but the fresh deployer container could not resolve RubyGems/Docker Hub and therefore never installed the `kamal` executable; all resulting integration errors occurred before test behavior.