### PR TITLE
Allow configuring sequential role boot order

### DIFF
--- a/lib/kamal/cli/app.rb
+++ b/lib/kamal/cli/app.rb
@@ -18,12 +18,13 @@ class Kamal::Cli::App < Kamal::Cli::Base
 
         # Primary hosts and roles are returned first, so they can open the barrier
         barrier = Kamal::Cli::Healthcheck::Barrier.new
+        boot_roles = KAMAL.config.boot.ordered_roles(KAMAL.roles, primary_role: KAMAL.primary_role)
 
         host_boot_groups.each do |hosts|
           host_list = Array(hosts).join(",")
           run_hook "pre-app-boot", hosts: host_list
 
-          on_roles(KAMAL.roles, hosts: hosts, parallel: KAMAL.config.boot.parallel_roles) do |host, role|
+          on_roles(boot_roles, hosts: hosts, parallel: KAMAL.config.boot.parallel_roles) do |host, role|
             Kamal::Cli::App::Boot.new(host, role, self, version, barrier).run
           end
 

--- a/lib/kamal/configuration.rb
+++ b/lib/kamal/configuration.rb
@@ -79,6 +79,7 @@ class Kamal::Configuration
 
     ensure_destination_if_required
     ensure_required_keys_present
+    ensure_valid_boot_role_order!
     ensure_valid_kamal_version
     ensure_retain_containers_valid
     ensure_valid_service_name
@@ -362,6 +363,20 @@ class Kamal::Configuration
 
     def ensure_valid_service_name
       raise Kamal::ConfigurationError, "Service name can only include alphanumeric characters, hyphens, and underscores" unless raw_config[:service] =~ /^[a-z0-9_-]+$/i
+
+      true
+    end
+
+    def ensure_valid_boot_role_order!
+      duplicates = boot.role_order.tally.select { |_, count| count > 1 }.keys
+      if duplicates.any?
+        raise Kamal::ConfigurationError, "Duplicate roles in boot.role_order: #{duplicates.join(", ")}"
+      end
+
+      unknown_roles = boot.role_order - roles.map(&:name)
+      if unknown_roles.any?
+        raise Kamal::ConfigurationError, "Unknown roles in boot.role_order: #{unknown_roles.join(", ")}"
+      end
 
       true
     end

--- a/lib/kamal/configuration/boot.rb
+++ b/lib/kamal/configuration/boot.rb
@@ -26,4 +26,18 @@ class Kamal::Configuration::Boot
   def parallel_roles
     boot_config["parallel_roles"]
   end
+
+  def role_order
+    boot_config["role_order"] || []
+  end
+
+  def ordered_roles(roles, primary_role:)
+    return roles if role_order.empty?
+
+    priorities = role_order.each_with_index.to_h
+
+    roles.each_with_index.sort_by do |role, index|
+      [ role == primary_role ? 0 : 1, priorities.fetch(role.name, priorities.length), index ]
+    end.map(&:first)
+  end
 end

--- a/lib/kamal/configuration/docs/boot.yml
+++ b/lib/kamal/configuration/docs/boot.yml
@@ -19,3 +19,10 @@ boot:
   #
   # Defaults to false.
   parallel_roles: true
+
+  # The order in which to boot roles when parallel_roles is false.
+  #
+  # The primary role always boots first so it can open the healthcheck barrier. Any roles not listed here boot afterwards in their existing order.
+  role_order:
+    - listener
+    - workers

--- a/test/cli/app_test.rb
+++ b/test/cli/app_test.rb
@@ -61,6 +61,22 @@ class CliAppTest < CliTestCase
     run_command("boot", config: :without_parallel_roles, host: nil)
   end
 
+  test "boot uses configured role order" do
+    stub_running
+    SSHKit::Backend::Abstract.any_instance.stubs(:capture_with_info)
+      .with { |*args| args.first == :docker && args.include?(:inspect) }
+      .returns("running")
+
+    run_command("boot", config: :with_role_order, host: nil).tap do |output|
+      web = output.index("docker run --detach --restart unless-stopped --name app-web-latest")
+      workers = output.index("docker run --detach --restart unless-stopped --name app-workers-latest")
+      cron = output.index("docker run --detach --restart unless-stopped --name app-cron-latest")
+
+      assert_operator web, :<, workers
+      assert_operator workers, :<, cron
+    end
+  end
+
   test "boot with parallel roles" do
     # With parallel_roles: each role gets its own on() call
     Kamal::Cli::App.any_instance.expects(:on).with("1.1.1.1").with_block_given.twice

--- a/test/configuration/boot_test.rb
+++ b/test/configuration/boot_test.rb
@@ -7,6 +7,7 @@ class ConfigurationBootTest < ActiveSupport::TestCase
     assert_nil config.boot.limit
     assert_nil config.boot.wait
     assert_nil config.boot.parallel_roles
+    assert_empty config.boot.role_order
   end
 
   test "specific limit group strategy" do
@@ -36,11 +37,34 @@ class ConfigurationBootTest < ActiveSupport::TestCase
     assert_equal true, config.boot.parallel_roles
   end
 
+  test "role_order" do
+    config = config_with_boot("role_order" => [ "workers", "web" ])
+
+    assert_equal [ "workers", "web" ], config.boot.role_order
+    assert_equal [ "web", "workers", "cron" ], config.boot.ordered_roles(config.roles, primary_role: config.primary_role).map(&:name)
+  end
+
+  test "role_order rejects duplicate roles" do
+    error = assert_raises(Kamal::ConfigurationError) do
+      config_with_boot("role_order" => [ "workers", "workers" ])
+    end
+
+    assert_equal "Duplicate roles in boot.role_order: workers", error.message
+  end
+
+  test "role_order rejects unknown roles" do
+    error = assert_raises(Kamal::ConfigurationError) do
+      config_with_boot("role_order" => [ "missing" ])
+    end
+
+    assert_equal "Unknown roles in boot.role_order: missing", error.message
+  end
+
   private
     def config_with_boot(boot)
       deploy = {
         service: "app", image: "dhh/app", registry: { "username" => "dhh", "password" => "secret" }, builder: { "arch" => "amd64" },
-        servers: { "web" => [ "1.1.1.1", "1.1.1.2" ], "workers" => [ "1.1.1.3", "1.1.1.4" ] },
+        servers: { "web" => [ "1.1.1.1", "1.1.1.2" ], "cron" => [ "1.1.1.1" ], "workers" => [ "1.1.1.3", "1.1.1.4" ] },
         boot: boot
       }.compact
 

--- a/test/fixtures/deploy_with_role_order.yml
+++ b/test/fixtures/deploy_with_role_order.yml
@@ -1,0 +1,24 @@
+service: app
+image: dhh/app
+servers:
+  web:
+    - "1.1.1.1"
+  cron:
+    hosts:
+      - "1.1.1.1"
+    cmd: sleep infinity
+  workers:
+    hosts:
+      - "1.1.1.1"
+    cmd: sleep infinity
+boot:
+  parallel_roles: false
+  role_order:
+    - workers
+    - cron
+builder:
+  arch: amd64
+
+registry:
+  username: user
+  password: pw


### PR DESCRIPTION
When several roles share a host and `boot.parallel_roles` is false, Kamal currently boots secondary roles in its internal alphabetical order. The CLI `--roles` option can override that for one invocation, but there is no way to persist a safe order for regular deploys.

A common example is an event listener that must be healthy before schedulers or workers begin mutating state. This adds an opt-in order:

```yaml
boot:
  parallel_roles: false
  role_order:
    - listener
    - workers
```

Semantics:

- The primary role always remains first so it can open the healthcheck barrier.
- Listed secondary roles follow in the configured order.
- Unlisted roles retain their existing relative order and boot afterward.
- Unknown and duplicate role names fail configuration validation.
- Existing configurations are unchanged.

Verification:

- `bin/test test/configuration/boot_test.rb test/cli/app_test.rb` — 63 runs, 283 assertions
- Full non-Docker suite — 841 runs, 2,740 assertions
- `bundle exec rubocop` — 178 files, no offenses

Docker integration tests were not run locally; the repository CI environment can exercise those.