### PR TITLE
Updating readiness delay status message in poller

### DIFF
--- a/lib/kamal/cli/healthcheck/poller.rb
+++ b/lib/kamal/cli/healthcheck/poller.rb
@@ -12,7 +12,7 @@ module Kamal::Cli::Healthcheck::Poller
       if status == "running"
         # Wait for the readiness delay and confirm it is still running
         if readiness_delay > 0
-          info "Container is running, waiting for readiness delay of #{readiness_delay} seconds"
+          info "Container is running, waiting for readiness with a delay of #{readiness_delay} seconds"
           sleep readiness_delay
           status = block.call
         end


### PR DESCRIPTION
This is a text-only update to improve the grammar in the readiness delay status message.

From:
`Container is running, waiting for readiness delay of #{readiness_delay} seconds`
To:
`Container is running, waiting for readiness with a delay of #{readiness_delay} seconds`