### PR TITLE
Fix accessory ERB files losing env on multi-host uploads

### DIFF
--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -148,21 +148,27 @@ class Kamal::Configuration::Accessory
 
     def expand_local_file(local_file)
       if local_file.end_with?("erb")
-        with_env_loaded { read_dynamic_file(local_file) }
+        read_dynamic_file(local_file)
       else
         Pathname.new(File.expand_path(local_file)).to_s
       end
     end
 
-    def with_env_loaded
-      env.to_h.each { |k, v| ENV[k] = v }
-      yield
-    ensure
-      env.to_h.each { |k, v| ENV.delete(k) }
+    def read_dynamic_file(local_file)
+      StringIO.new(render_dynamic_erb(File.read(local_file)))
     end
 
-    def read_dynamic_file(local_file)
-      StringIO.new(ERB.new(File.read(local_file)).result)
+    # Render with a per-call ENV constant so parallel host threads cannot
+    # clobber process-global ENV (SSHKit runs on(hosts) in :parallel).
+    def render_dynamic_erb(template)
+      renderer = Class.new
+      renderer.const_set(:ENV, ENV.to_h.merge(env.to_h))
+      renderer.class_eval <<~RUBY, __FILE__, __LINE__ + 1
+        def render(template)
+          ::ERB.new(template).result(binding)
+        end
+      RUBY
+      renderer.new.render(template)
     end
 
     def expand_remote_file(remote_file)

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -182,6 +182,50 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     end
   end
 
+  test "parallel erb file renders keep accessory env interpolations" do
+    @deploy[:accessories]["mysql"]["files"] = [
+      "test/fixtures/files/structure.sql.erb:/docker-entrypoint-initdb.d/structure.sql"
+    ]
+    @deploy[:accessories]["mysql"]["env"]["secret"] << "ENV_VAR:SECRET_VAR"
+
+    with_test_secrets("secrets" => "MYSQL_ROOT_PASSWORD=secret123\nSECRET_VAR=secret_env_value") do
+      accessory = Kamal::Configuration.new(@deploy).accessory(:mysql)
+      original_result = ERB.instance_method(:result)
+      entered, release, finished = Queue.new, Queue.new, Queue.new
+      renders = {}
+
+      begin
+        ERB.define_method(:result) do |*args, **kwargs|
+          entered.push(true)
+          release.pop
+          original_result.bind_call(self, *args, **kwargs)
+        end
+
+        threads = [ :host_a, :host_b ].map do |host|
+          Thread.new do
+            renders[host] = accessory.files.keys.first.read
+          ensure
+            finished.push(host)
+          end
+        end
+
+        2.times { entered.pop }
+        release.push(true)
+        finished.pop
+        release.push(true)
+        threads.each(&:value)
+
+        renders.each do |host, contents|
+          assert_match "secret123", contents, "#{host} lost MYSQL_ROOT_PASSWORD"
+          assert_match "secret_env_value", contents, "#{host} lost ENV_VAR"
+          assert_match "%", contents, "#{host} lost MYSQL_ROOT_HOST"
+        end
+      ensure
+        ERB.define_method(:result, original_result)
+      end
+    end
+  end
+
   test "directory with a relative path" do
     @deploy[:accessories]["mysql"]["directories"] = [ "data:/var/lib/mysql" ]
     assert_equal({ "$PWD/app-mysql/data" => { host_path: "app-mysql/data", container_path: "/var/lib/mysql", options: nil, mode: nil, owner: nil } }, @config.accessory(:mysql).directories)


### PR DESCRIPTION
Accessory ERB `files:` rendered from `on(hosts)` can lose interpolations when more than one host runs in parallel. `with_env_loaded` wrote into process-global `ENV` and deleted those keys in `ensure`, so one thread's cleanup could land inside another thread's render.

Render each accessory file with a per-call `ENV` hash (`ENV.to_h` merged with the accessory env) instead of mutating process-global `ENV`.

Fixes #1924