### PR TITLE
Adds support to fetch secrets from 1Password Environments (resolves #1907)

### DIFF
--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -47,24 +47,24 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
             results.merge!(fields_map(fields_json))
           end
         end
+      end
     end
-  end
 
-  def fetch_environment_secrets(secrets, environment:, account:, session:)
-    all_variables = op_environment_read(environment, account: account, session: session)
+    def fetch_environment_secrets(secrets, environment:, account:, session:)
+      all_variables = op_environment_read(environment, account: account, session: session)
 
-    if secrets.blank?
-      all_variables
-    else
-      all_variables.slice(*secrets).tap do |results|
-        missing = secrets - results.keys
+      if secrets.blank?
+        all_variables
+      else
+        all_variables.slice(*secrets).tap do |results|
+          missing = secrets - results.keys
 
-        if missing.any?
-          raise RuntimeError, "Could not read #{missing.join(", ")} from the #{environment} 1Password Environment"
+          if missing.any?
+            raise RuntimeError, "Could not read #{missing.join(", ")} from the #{environment} 1Password Environment"
+          end
         end
       end
     end
-  end
 
     def to_options(**options)
       optionize(options.compact).join(" ")

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -125,8 +125,9 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
       end
 
       output.each_line.with_object({}) do |line, results|
-        line = line.strip
-        next if line.empty?
+        line = line.chomp
+        next if line.blank?
+
         key, value = line.split("=", 2)
         results[key] = value if key.present?
       end

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -16,7 +16,9 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
     end
 
     def fetch_secrets(secrets, from:, account:, session:)
-      if secrets.blank?
+      if (environment = from_environment(from))
+        fetch_environment_secrets(secrets, environment: environment, account: account, session: session)
+      elsif secrets.blank?
         fetch_all_secrets(from: from, account: account, session: session)
       else
         fetch_specified_secrets(secrets, from: from, account: account, session: session)
@@ -45,11 +47,31 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
             results.merge!(fields_map(fields_json))
           end
         end
+    end
+  end
+
+  def fetch_environment_secrets(secrets, environment:, account:, session:)
+    all_variables = op_environment_read(environment, account: account, session: session)
+
+    if secrets.blank?
+      all_variables
+    else
+      all_variables.slice(*secrets).tap do |results|
+        missing = secrets - results.keys
+
+        if missing.any?
+          raise RuntimeError, "Could not read #{missing.join(", ")} from the #{environment} 1Password Environment"
+        end
       end
     end
+  end
 
     def to_options(**options)
       optionize(options.compact).join(" ")
+    end
+
+    def from_environment(from)
+      from.delete_prefix("environment-") if from&.start_with?("environment-")
     end
 
     def vaults_items_fields(secrets)
@@ -90,6 +112,23 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
 
       `op item get #{item.shellescape} #{to_options(**options)}`.tap do
         raise RuntimeError, "Could not read #{"#{fields.join(", ")} " if fields.present?}from #{item} in the #{vault} 1Password vault" unless $?.success?
+      end
+    end
+
+    def op_environment_read(environment, account:, session:)
+      raise ArgumentError, "environment must be present" if environment.blank?
+
+      options = { account: account, session: session.presence }
+
+      output = `op environment read #{environment.shellescape} #{to_options(**options)}`.tap do
+        raise RuntimeError, "Could not read the #{environment} 1Password Environment" unless $?.success?
+      end
+
+      output.each_line.with_object({}) do |line, results|
+        line = line.strip
+        next if line.empty?
+        key, value = line.split("=", 2)
+        results[key] = value if key.present?
       end
     end
 

--- a/test/secrets/one_password_adapter_test.rb
+++ b/test/secrets/one_password_adapter_test.rb
@@ -220,6 +220,103 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     assert_equal "1Password CLI is not installed", error.message
   end
 
+  test "fetch all variables from environment" do
+    stub_ticks.with("op --version 2> /dev/null")
+    stub_ticks.with("op account get --account myaccount 2> /dev/null")
+
+    stub_ticks
+      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .returns(<<~ENV)
+        SECRET1=VALUE1
+        SECRET2=VALUE2
+      ENV
+
+    json = JSON.parse(run_command("fetch", "--from", "environment-7mw7kfmwe2hpbcksbgco4ove7i"))
+
+    expected_json = {
+      "SECRET1"=>"VALUE1",
+      "SECRET2"=>"VALUE2"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch specified variables from environment" do
+    stub_ticks.with("op --version 2> /dev/null")
+    stub_ticks.with("op account get --account myaccount 2> /dev/null")
+
+    stub_ticks
+      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .returns(<<~ENV)
+        SECRET1=VALUE1
+        SECRET2=VALUE2
+        SECRET3=VALUE3
+      ENV
+
+    json = JSON.parse(run_command("fetch", "--from", "environment-7mw7kfmwe2hpbcksbgco4ove7i", "SECRET1", "SECRET3"))
+
+    expected_json = {
+      "SECRET1"=>"VALUE1",
+      "SECRET3"=>"VALUE3"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch missing variable from environment" do
+    stub_ticks.with("op --version 2> /dev/null")
+    stub_ticks.with("op account get --account myaccount 2> /dev/null")
+
+    stub_ticks
+      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .returns(<<~ENV)
+        SECRET1=VALUE1
+      ENV
+
+    error = assert_raises RuntimeError do
+      run_command("fetch", "--from", "environment-7mw7kfmwe2hpbcksbgco4ove7i", "SECRET1", "SECRET2")
+    end
+    assert_equal "Could not read SECRET2 from the 7mw7kfmwe2hpbcksbgco4ove7i 1Password Environment", error.message
+  end
+
+  test "fetch from environment with signin, no session" do
+    stub_ticks.with("op --version 2> /dev/null")
+
+    stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
+    stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("")
+
+    stub_ticks
+      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .returns(<<~ENV)
+        SECRET1=VALUE1
+      ENV
+
+    json = JSON.parse(run_command("fetch", "--from", "environment-7mw7kfmwe2hpbcksbgco4ove7i"))
+
+    expected_json = { "SECRET1"=>"VALUE1" }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch from environment with signin and session" do
+    stub_ticks.with("op --version 2> /dev/null")
+
+    stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
+    stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("1234567890")
+
+    stub_ticks
+      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\" --session \"1234567890\"")
+      .returns(<<~ENV)
+        SECRET1=VALUE1
+      ENV
+
+    json = JSON.parse(run_command("fetch", "--from", "environment-7mw7kfmwe2hpbcksbgco4ove7i"))
+
+    expected_json = { "SECRET1"=>"VALUE1" }
+
+    assert_equal expected_json, json
+  end
+
   private
     def run_command(*command)
       stdouted do


### PR DESCRIPTION
You can now fetch secrets by passing `environment-<id>` as the `--from` value. I'm open to any prefix but my goal was to be explicit in name and be able to leverage the existing CLI and adapter options. Both fetching individual secrets or the entire set are supported.

```bash
kamal secrets fetch --adapter 1password —account <account> --from "environment-<id>"
```

```bash
kamal secrets fetch --adapter 1password —account <account> --from "environment-<id>" SECRET_KEY_BASE
```

Resolves #1907 