### PR TITLE
Adds support for fetching secrets from 1Password Environments

### DIFF
--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -12,7 +12,7 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
       return puts "No value provided for required options '--account'"
     end
 
-    results = adapter.fetch(secrets, **options.slice(:account, :from, :environment).symbolize_keys)
+    results = adapter.fetch(secrets, **options.slice(:account, :from, :environment).compact.symbolize_keys)
     json = JSON.dump(results)
 
     return_or_puts options[:inline] ? json.shellescape : json, inline: options[:inline]

--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -8,7 +8,7 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
   def fetch(*secrets)
     adapter = initialize_adapter(options[:adapter])
 
-    if adapter.requires_account? && options[:account].blank?
+    if adapter_requires_account?(adapter) && options[:account].blank?
       return puts "No value provided for required options '--account'"
     end
 
@@ -40,6 +40,14 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
     def initialize_adapter(adapter)
       Kamal::Secrets::Adapters.lookup(adapter)
     end
+
+  def adapter_requires_account?(adapter)
+    if adapter.method(:requires_account?).arity.zero?
+      adapter.requires_account?
+    else
+      adapter.requires_account?(options[:environment])
+    end
+  end
 
     def return_or_puts(value, inline: nil)
       if inline

--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -12,6 +12,10 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
       return puts "No value provided for required options '--account'"
     end
 
+    if options[:environment] && !adapter.supports_environment?
+      return puts "Option '--environment' is not supported by this adapter"
+    end
+
     results = adapter.fetch(secrets, **options.slice(:account, :from, :environment).compact.symbolize_keys)
     json = JSON.dump(results)
 

--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -41,13 +41,13 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
       Kamal::Secrets::Adapters.lookup(adapter)
     end
 
-  def adapter_requires_account?(adapter)
-    if adapter.method(:requires_account?).arity.zero?
-      adapter.requires_account?
-    else
-      adapter.requires_account?(options[:environment])
+    def adapter_requires_account?(adapter)
+      if adapter.method(:requires_account?).arity.zero?
+        adapter.requires_account?
+      else
+        adapter.requires_account?(options[:environment])
+      end
     end
-  end
 
     def return_or_puts(value, inline: nil)
       if inline

--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -8,12 +8,12 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
   def fetch(*secrets)
     adapter = initialize_adapter(options[:adapter])
 
-    if adapter_requires_account?(adapter) && options[:account].blank?
-      return puts "No value provided for required options '--account'"
-    end
-
     if options[:environment] && !adapter.supports_environment?
       return puts "Option '--environment' is not supported by this adapter"
+    end
+
+    if adapter_requires_account?(adapter) && options[:account].blank?
+      return puts "No value provided for required options '--account'"
     end
 
     results = adapter.fetch(secrets, **options.slice(:account, :from, :environment).compact.symbolize_keys)

--- a/lib/kamal/cli/secrets.rb
+++ b/lib/kamal/cli/secrets.rb
@@ -3,6 +3,7 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
   option :adapter, type: :string, aliases: "-a", required: true, desc: "Which vault adapter to use"
   option :account, type: :string, required: false, desc: "The account identifier or username"
   option :from, type: :string, required: false, desc: "A vault or folder to fetch the secrets from"
+  option :environment, type: :string, required: false, desc: "A 1Password Environment ID to fetch secrets from (1Password adapter only)"
   option :inline, type: :boolean, required: false, hidden: true
   def fetch(*secrets)
     adapter = initialize_adapter(options[:adapter])
@@ -11,7 +12,7 @@ class Kamal::Cli::Secrets < Kamal::Cli::Base
       return puts "No value provided for required options '--account'"
     end
 
-    results = adapter.fetch(secrets, **options.slice(:account, :from).symbolize_keys)
+    results = adapter.fetch(secrets, **options.slice(:account, :from, :environment).symbolize_keys)
     json = JSON.dump(results)
 
     return_or_puts options[:inline] ? json.shellescape : json, inline: options[:inline]

--- a/lib/kamal/secrets/adapters/base.rb
+++ b/lib/kamal/secrets/adapters/base.rb
@@ -1,13 +1,13 @@
 class Kamal::Secrets::Adapters::Base
   delegate :optionize, to: Kamal::Utils
 
-  def fetch(secrets, account: nil, from: nil)
+  def fetch(secrets, account: nil, from: nil, environment: nil)
     raise RuntimeError, "Missing required option '--account'" if requires_account? && account.blank?
 
     check_dependencies!
 
     session = login(account)
-    fetch_secrets(secrets, from: from, account: account, session: session)
+    fetch_secrets(secrets, from: from, environment: environment, account: account, session: session)
   end
 
   def requires_account?

--- a/lib/kamal/secrets/adapters/base.rb
+++ b/lib/kamal/secrets/adapters/base.rb
@@ -14,6 +14,10 @@ class Kamal::Secrets::Adapters::Base
     true
   end
 
+  def supports_environment?
+    false
+  end
+
   private
     def login(...)
       raise NotImplementedError

--- a/lib/kamal/secrets/adapters/base.rb
+++ b/lib/kamal/secrets/adapters/base.rb
@@ -10,7 +10,7 @@ class Kamal::Secrets::Adapters::Base
     fetch_secrets(secrets, from: from, account: account, session: session)
   end
 
-  def requires_account?
+  def requires_account?(environment = nil)
     true
   end
 

--- a/lib/kamal/secrets/adapters/base.rb
+++ b/lib/kamal/secrets/adapters/base.rb
@@ -1,13 +1,13 @@
 class Kamal::Secrets::Adapters::Base
   delegate :optionize, to: Kamal::Utils
 
-  def fetch(secrets, account: nil, from: nil, environment: nil)
+  def fetch(secrets, account: nil, from: nil)
     raise RuntimeError, "Missing required option '--account'" if requires_account? && account.blank?
 
     check_dependencies!
 
     session = login(account)
-    fetch_secrets(secrets, from: from, environment: environment, account: account, session: session)
+    fetch_secrets(secrets, from: from, account: account, session: session)
   end
 
   def requires_account?

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -15,6 +15,10 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
     environment.blank?
   end
 
+  def supports_environment?
+    true
+  end
+
   private
     def login(account)
       return if account.blank?

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -15,6 +15,15 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
       $?.success?
     end
 
+  def fetch(secrets, account: nil, from: nil, environment: nil)
+    raise RuntimeError, "Missing required option '--account'" if requires_account? && account.blank?
+
+    check_dependencies!
+
+    session = login(account)
+    fetch_secrets(secrets, from: from, environment: environment, account: account, session: session)
+  end
+
     def fetch_secrets(secrets, from:, environment:, account:, session:)
       if secrets.blank?
         fetch_all_secrets(from: from, environment: environment, account: account, session: session)

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -1,6 +1,15 @@
 class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
   delegate :optionize, to: Kamal::Utils
 
+  def fetch(secrets, account: nil, from: nil, environment: nil)
+    raise RuntimeError, "Missing required option '--account'" if requires_account? && account.blank?
+
+    check_dependencies!
+
+    session = login(account)
+    fetch_secrets(secrets, from: from, environment: environment, account: account, session: session)
+  end
+
   private
     def login(account)
       unless loggedin?(account)
@@ -14,15 +23,6 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
       `op account get --account #{account.shellescape} 2> /dev/null`
       $?.success?
     end
-
-  def fetch(secrets, account: nil, from: nil, environment: nil)
-    raise RuntimeError, "Missing required option '--account'" if requires_account? && account.blank?
-
-    check_dependencies!
-
-    session = login(account)
-    fetch_secrets(secrets, from: from, environment: environment, account: account, session: session)
-  end
 
     def fetch_secrets(secrets, from:, environment:, account:, session:)
       if secrets.blank?

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -2,7 +2,7 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
   delegate :optionize, to: Kamal::Utils
 
   def fetch(secrets, account: nil, from: nil, environment: nil)
-    raise RuntimeError, "Missing required option '--account'" if requires_account? && account.blank?
+    raise RuntimeError, "Missing required option '--account'" if requires_account?(environment) && account.blank?
 
     check_dependencies!
 
@@ -10,8 +10,14 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
     fetch_secrets(secrets, from: from, environment: environment, account: account, session: session)
   end
 
+  def requires_account?(environment)
+    environment.blank?
+  end
+
   private
     def login(account)
+      return if account.blank?
+
       unless loggedin?(account)
         `op signin #{to_options(account: account, force: true, raw: true)}`.tap do
           raise RuntimeError, "Failed to login to 1Password" unless $?.success?
@@ -121,9 +127,10 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
     def op_environment_read(environment, account:, session:)
       raise ArgumentError, "environment must be present" if environment.blank?
 
-      options = { account: account, session: session.presence }
+      options = { account: account.presence, session: session.presence }
+      command = [ "op environment read #{environment.shellescape}", to_options(**options) ].reject(&:blank?).join(" ")
 
-      output = `op environment read #{environment.shellescape} #{to_options(**options)}`.tap do
+      output = `#{command}`.tap do
         raise RuntimeError, "Could not read the #{environment} 1Password Environment" unless $?.success?
       end
 

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -15,15 +15,17 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
       $?.success?
     end
 
-    def fetch_secrets(secrets, from:, account:, session:)
+    def fetch_secrets(secrets, from:, environment:, account:, session:)
       if secrets.blank?
-        fetch_all_secrets(from: from, account: account, session: session)
+        fetch_all_secrets(from: from, environment: environment, account: account, session: session)
       else
-        fetch_specified_secrets(secrets, from: from, account: account, session: session)
+        fetch_specified_secrets(secrets, from: from, environment: environment, account: account, session: session)
       end
     end
 
-    def fetch_specified_secrets(secrets, from:, account:, session:)
+    def fetch_specified_secrets(secrets, from:, environment:, account:, session:)
+      return fetch_specified_environment_secrets(secrets, environment: environment, account: account, session: session) if environment.present?
+
       {}.tap do |results|
         vaults_items_fields(prefixed_secrets(secrets, from: from)).map do |vault, items|
           items.each do |item, fields|
@@ -36,7 +38,9 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
       end
     end
 
-    def fetch_all_secrets(from:, account:, session:)
+    def fetch_all_secrets(from:, environment:, account:, session:)
+      return op_environment_read(environment, account: account, session: session) if environment.present?
+
       {}.tap do |results|
         vault_items(from).each do |vault, items|
           items.each do |item|
@@ -44,6 +48,18 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
 
             results.merge!(fields_map(fields_json))
           end
+        end
+      end
+    end
+
+    def fetch_specified_environment_secrets(secrets, environment:, account:, session:)
+      all_variables = op_environment_read(environment, account: account, session: session)
+
+      all_variables.slice(*secrets).tap do |results|
+        missing = secrets - results.keys
+
+        if missing.any?
+          raise RuntimeError, "Could not read #{missing.join(", ")} from the #{environment} 1Password Environment"
         end
       end
     end
@@ -90,6 +106,24 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
 
       `op item get #{item.shellescape} #{to_options(**options)}`.tap do
         raise RuntimeError, "Could not read #{"#{fields.join(", ")} " if fields.present?}from #{item} in the #{vault} 1Password vault" unless $?.success?
+      end
+    end
+
+    def op_environment_read(environment, account:, session:)
+      raise ArgumentError, "environment must be present" if environment.blank?
+
+      options = { account: account, session: session.presence }
+
+      output = `op environment read #{environment.shellescape} #{to_options(**options)}`.tap do
+        raise RuntimeError, "Could not read the #{environment} 1Password Environment" unless $?.success?
+      end
+
+      output.each_line.with_object({}) do |line, results|
+        line = line.chomp
+        next if line.blank?
+
+        key, value = line.split("=", 2)
+        results[key] = value if key.present?
       end
     end
 

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -2,6 +2,7 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
   delegate :optionize, to: Kamal::Utils
 
   def fetch(secrets, account: nil, from: nil, environment: nil)
+    raise RuntimeError, "Options '--from' and '--environment' cannot be used together" if from.present? && environment.present?
     raise RuntimeError, "Missing required option '--account'" if requires_account?(environment) && account.blank?
 
     check_dependencies!

--- a/lib/kamal/secrets/adapters/one_password.rb
+++ b/lib/kamal/secrets/adapters/one_password.rb
@@ -11,7 +11,7 @@ class Kamal::Secrets::Adapters::OnePassword < Kamal::Secrets::Adapters::Base
     fetch_secrets(secrets, from: from, environment: environment, account: account, session: session)
   end
 
-  def requires_account?(environment)
+  def requires_account?(environment = nil)
     environment.blank?
   end
 

--- a/test/secrets/last_pass_adapter_test.rb
+++ b/test/secrets/last_pass_adapter_test.rb
@@ -133,6 +133,13 @@ class LastPassAdapterTest < SecretAdapterTestCase
     assert_equal "LastPass CLI is not installed", error.message
   end
 
+  test "environment is provided as an option" do
+    stub_ticks_with("lpass --version 2> /dev/null", succeed: false)
+
+    message = run_command("fetch", "--environment", "asdf", "SECRET1", "FOLDER1/FSECRET1", "FOLDER1/FSECRET2")
+    assert_equal "Option '--environment' is not supported by this adapter", message
+  end
+
   private
     def run_command(*command)
       stdouted do

--- a/test/secrets/one_password_adapter_test.rb
+++ b/test/secrets/one_password_adapter_test.rb
@@ -220,6 +220,103 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     assert_equal "1Password CLI is not installed", error.message
   end
 
+  test "fetch all variables from environment" do
+    stub_ticks.with("op --version 2> /dev/null")
+    stub_ticks.with("op account get --account myaccount 2> /dev/null")
+
+    stub_ticks
+      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .returns(<<~ENV)
+        SECRET1=VALUE1
+        SECRET2=VALUE2
+      ENV
+
+    json = JSON.parse(run_command("fetch", "--environment", "7mw7kfmwe2hpbcksbgco4ove7i"))
+
+    expected_json = {
+      "SECRET1"=>"VALUE1",
+      "SECRET2"=>"VALUE2"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch specified variables from environment" do
+    stub_ticks.with("op --version 2> /dev/null")
+    stub_ticks.with("op account get --account myaccount 2> /dev/null")
+
+    stub_ticks
+      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .returns(<<~ENV)
+        SECRET1=VALUE1
+        SECRET2=VALUE2
+        SECRET3=VALUE3
+      ENV
+
+    json = JSON.parse(run_command("fetch", "--environment", "7mw7kfmwe2hpbcksbgco4ove7i", "SECRET1", "SECRET3"))
+
+    expected_json = {
+      "SECRET1"=>"VALUE1",
+      "SECRET3"=>"VALUE3"
+    }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch missing variable from environment" do
+    stub_ticks.with("op --version 2> /dev/null")
+    stub_ticks.with("op account get --account myaccount 2> /dev/null")
+
+    stub_ticks
+      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .returns(<<~ENV)
+        SECRET1=VALUE1
+      ENV
+
+    error = assert_raises RuntimeError do
+      run_command("fetch", "--environment", "7mw7kfmwe2hpbcksbgco4ove7i", "SECRET1", "SECRET2")
+    end
+    assert_equal "Could not read SECRET2 from the 7mw7kfmwe2hpbcksbgco4ove7i 1Password Environment", error.message
+  end
+
+  test "fetch from environment with signin, no session" do
+    stub_ticks.with("op --version 2> /dev/null")
+
+    stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
+    stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("")
+
+    stub_ticks
+      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .returns(<<~ENV)
+        SECRET1=VALUE1
+      ENV
+
+    json = JSON.parse(run_command("fetch", "--environment", "7mw7kfmwe2hpbcksbgco4ove7i"))
+
+    expected_json = { "SECRET1"=>"VALUE1" }
+
+    assert_equal expected_json, json
+  end
+
+  test "fetch from environment with signin and session" do
+    stub_ticks.with("op --version 2> /dev/null")
+
+    stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
+    stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("1234567890")
+
+    stub_ticks
+      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\" --session \"1234567890\"")
+      .returns(<<~ENV)
+        SECRET1=VALUE1
+      ENV
+
+    json = JSON.parse(run_command("fetch", "--environment", "7mw7kfmwe2hpbcksbgco4ove7i"))
+
+    expected_json = { "SECRET1"=>"VALUE1" }
+
+    assert_equal expected_json, json
+  end
+
   private
     def run_command(*command)
       stdouted do

--- a/test/secrets/one_password_adapter_test.rb
+++ b/test/secrets/one_password_adapter_test.rb
@@ -225,13 +225,13 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     stub_ticks.with("op account get --account myaccount 2> /dev/null")
 
     stub_ticks
-      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .with("op environment read asdf --account \"myaccount\"")
       .returns(<<~ENV)
         SECRET1=VALUE1
         SECRET2=VALUE2
       ENV
 
-    json = JSON.parse(run_command("fetch", "--environment", "7mw7kfmwe2hpbcksbgco4ove7i"))
+    json = JSON.parse(run_command("fetch", "--environment", "asdf"))
 
     expected_json = {
       "SECRET1"=>"VALUE1",
@@ -246,14 +246,14 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     stub_ticks.with("op account get --account myaccount 2> /dev/null")
 
     stub_ticks
-      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .with("op environment read asdf --account \"myaccount\"")
       .returns(<<~ENV)
         SECRET1=VALUE1
         SECRET2=VALUE2
         SECRET3=VALUE3
       ENV
 
-    json = JSON.parse(run_command("fetch", "--environment", "7mw7kfmwe2hpbcksbgco4ove7i", "SECRET1", "SECRET3"))
+    json = JSON.parse(run_command("fetch", "--environment", "asdf", "SECRET1", "SECRET3"))
 
     expected_json = {
       "SECRET1"=>"VALUE1",
@@ -268,15 +268,15 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     stub_ticks.with("op account get --account myaccount 2> /dev/null")
 
     stub_ticks
-      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .with("op environment read asdf --account \"myaccount\"")
       .returns(<<~ENV)
         SECRET1=VALUE1
       ENV
 
     error = assert_raises RuntimeError do
-      run_command("fetch", "--environment", "7mw7kfmwe2hpbcksbgco4ove7i", "SECRET1", "SECRET2")
+      run_command("fetch", "--environment", "asdf", "SECRET1", "SECRET2")
     end
-    assert_equal "Could not read SECRET2 from the 7mw7kfmwe2hpbcksbgco4ove7i 1Password Environment", error.message
+    assert_equal "Could not read SECRET2 from the asdf 1Password Environment", error.message
   end
 
   test "fetch from environment with signin, no session" do
@@ -286,12 +286,12 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("")
 
     stub_ticks
-      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\"")
+      .with("op environment read asdf --account \"myaccount\"")
       .returns(<<~ENV)
         SECRET1=VALUE1
       ENV
 
-    json = JSON.parse(run_command("fetch", "--environment", "7mw7kfmwe2hpbcksbgco4ove7i"))
+    json = JSON.parse(run_command("fetch", "--environment", "asdf"))
 
     expected_json = { "SECRET1"=>"VALUE1" }
 
@@ -305,12 +305,12 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("1234567890")
 
     stub_ticks
-      .with("op environment read 7mw7kfmwe2hpbcksbgco4ove7i --account \"myaccount\" --session \"1234567890\"")
+      .with("op environment read asdf --account \"myaccount\" --session \"1234567890\"")
       .returns(<<~ENV)
         SECRET1=VALUE1
       ENV
 
-    json = JSON.parse(run_command("fetch", "--environment", "7mw7kfmwe2hpbcksbgco4ove7i"))
+    json = JSON.parse(run_command("fetch", "--environment", "asdf"))
 
     expected_json = { "SECRET1"=>"VALUE1" }
 

--- a/test/secrets/one_password_adapter_test.rb
+++ b/test/secrets/one_password_adapter_test.rb
@@ -45,7 +45,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
         ]
       JSON
 
-    json = JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3"))
+    json = JSON.parse(run_command("fetch", "--account", "myaccount", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1",
@@ -105,7 +105,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(run_command("fetch", "--from", "op://myvault", "myitem/section/SECRET1", "myitem/section/SECRET2", "myitem2/section2/SECRET3"))
+    json = JSON.parse(run_command("fetch", "--account", "myaccount", "--from", "op://myvault", "myitem/section/SECRET1", "myitem/section/SECRET2", "myitem2/section2/SECRET3"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1",
@@ -163,7 +163,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
         }
       JSON
 
-    json = JSON.parse(run_command("fetch", "--from", "op://myvault/myitem"))
+    json = JSON.parse(run_command("fetch", "--account", "myaccount", "--from", "op://myvault/myitem"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1",
@@ -183,7 +183,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
       .with("op item get myitem --vault \"myvault\" --format \"json\" --account \"myaccount\" --fields \"label=section.SECRET1\"")
       .returns(single_item_json)
 
-    json = JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1"))
+    json = JSON.parse(run_command("fetch", "--account", "myaccount", "--from", "op://myvault/myitem", "section/SECRET1"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1"
@@ -202,7 +202,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
       .with("op item get myitem --vault \"myvault\" --format \"json\" --account \"myaccount\" --session \"1234567890\" --fields \"label=section.SECRET1\"")
       .returns(single_item_json)
 
-    json = JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1"))
+    json = JSON.parse(run_command("fetch", "--account", "myaccount", "--from", "op://myvault/myitem", "section/SECRET1"))
 
     expected_json = {
       "myvault/myitem/section/SECRET1"=>"VALUE1"
@@ -215,17 +215,16 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     stub_ticks_with("op --version 2> /dev/null", succeed: false)
 
     error = assert_raises RuntimeError do
-      JSON.parse(run_command("fetch", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3"))
+      JSON.parse(run_command("fetch", "--account", "myaccount", "--from", "op://myvault/myitem", "section/SECRET1", "section/SECRET2", "section2/SECRET3"))
     end
     assert_equal "1Password CLI is not installed", error.message
   end
 
   test "fetch all variables from environment" do
     stub_ticks.with("op --version 2> /dev/null")
-    stub_ticks.with("op account get --account myaccount 2> /dev/null")
 
     stub_ticks
-      .with("op environment read asdf --account \"myaccount\"")
+      .with("op environment read asdf")
       .returns(<<~ENV)
         SECRET1=VALUE1
         SECRET2=VALUE2
@@ -243,10 +242,9 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
 
   test "fetch specified variables from environment" do
     stub_ticks.with("op --version 2> /dev/null")
-    stub_ticks.with("op account get --account myaccount 2> /dev/null")
 
     stub_ticks
-      .with("op environment read asdf --account \"myaccount\"")
+      .with("op environment read asdf")
       .returns(<<~ENV)
         SECRET1=VALUE1
         SECRET2=VALUE2
@@ -265,10 +263,9 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
 
   test "fetch missing variable from environment" do
     stub_ticks.with("op --version 2> /dev/null")
-    stub_ticks.with("op account get --account myaccount 2> /dev/null")
 
     stub_ticks
-      .with("op environment read asdf --account \"myaccount\"")
+      .with("op environment read asdf")
       .returns(<<~ENV)
         SECRET1=VALUE1
       ENV
@@ -279,42 +276,13 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
     assert_equal "Could not read SECRET2 from the asdf 1Password Environment", error.message
   end
 
-  test "fetch from environment with signin, no session" do
-    stub_ticks.with("op --version 2> /dev/null")
+  test "fetch from environment without CLI installed" do
+    stub_ticks_with("op --version 2> /dev/null", succeed: false)
 
-    stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
-    stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("")
-
-    stub_ticks
-      .with("op environment read asdf --account \"myaccount\"")
-      .returns(<<~ENV)
-        SECRET1=VALUE1
-      ENV
-
-    json = JSON.parse(run_command("fetch", "--environment", "asdf"))
-
-    expected_json = { "SECRET1"=>"VALUE1" }
-
-    assert_equal expected_json, json
-  end
-
-  test "fetch from environment with signin and session" do
-    stub_ticks.with("op --version 2> /dev/null")
-
-    stub_ticks_with("op account get --account myaccount 2> /dev/null", succeed: false)
-    stub_ticks_with("op signin --account \"myaccount\" --force --raw", succeed: true).returns("1234567890")
-
-    stub_ticks
-      .with("op environment read asdf --account \"myaccount\" --session \"1234567890\"")
-      .returns(<<~ENV)
-        SECRET1=VALUE1
-      ENV
-
-    json = JSON.parse(run_command("fetch", "--environment", "asdf"))
-
-    expected_json = { "SECRET1"=>"VALUE1" }
-
-    assert_equal expected_json, json
+    error = assert_raises RuntimeError do
+      run_command("fetch", "--environment", "asdf")
+    end
+    assert_equal "1Password CLI is not installed", error.message
   end
 
   private
@@ -323,8 +291,7 @@ class SecretsOnePasswordAdapterTest < SecretAdapterTestCase
         Kamal::Cli::Secrets.start \
           [ *command,
             "-c", "test/fixtures/deploy_with_accessories.yml",
-            "--adapter", "1password",
-            "--account", "myaccount" ]
+            "--adapter", "1password" ]
       end
     end
 


### PR DESCRIPTION
Through a new `environment` option, define your 1Password Environment's ID to either fetch all secrets or specific secrets from an environment. Resolves #1907.

```bash
kamal secrets fetch --adapter 1password --environment <id>
```

```bash
kamal secrets fetch --adapter 1password --environment <id> SECRET_KEY_BASE
```