### PR TITLE
Additional proxy deploy options: `client-ip-header`, `exclude-metrics-paths`, `canonical-host`

### DIFF
--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -158,6 +158,18 @@ proxy:
       - X-Request-ID
       - X-Request-Start
 
+  # Excluding paths from metrics
+  #
+  # When metrics are enabled (see `metrics_port` under `run`), every request is recorded
+  # in the Prometheus output. Health checks from load balancers or uptime monitors can
+  # add noise to those metrics.
+  #
+  # List request paths to exclude from the metrics. Matches are exact. Excluded requests
+  # are still logged; only the Prometheus counters and in-flight gauge are skipped.
+  exclude_metrics_paths:
+    - /up
+    - /healthz
+
   # Run configuration
   #
   # These options are used when booting the proxy container.

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -80,6 +80,16 @@ proxy:
   # will forward them if it is set to `false`.
   forward_headers: true
 
+  # Client IP header
+  #
+  # If a proxy or CDN in front of kamal-proxy passes the original client IP in a header
+  # other than `X-Forwarded-For`, name that header here. For example, Cloudflare uses
+  # `True-Client-IP`.
+  #
+  # When set, kamal-proxy copies the value of this header into `X-Forwarded-For` before
+  # logging the request and forwarding it to your application.
+  client_ip_header: True-Client-IP
+
   # Response timeout
   #
   # How long to wait for requests to complete before timing out, defaults to 30 seconds:

--- a/lib/kamal/configuration/docs/proxy.yml
+++ b/lib/kamal/configuration/docs/proxy.yml
@@ -26,6 +26,16 @@ proxy:
     - foo.example.com
     - bar.example.com
 
+  # Canonical host
+  #
+  # Redirect all requests to this host. Can be used to enfore a consistent host
+  # while accepting requests on many hosts. For example, to enforce the use
+  # of the `www` subdomain when your app is served both with and without it.
+  #
+  # The canonical host must be one of the hosts listed in `hosts`, or the deploy
+  # will fail.
+  canonical_host: foo.example.com
+
   # App port
   #
   # The port the application container is exposed on.

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -91,6 +91,7 @@ class Kamal::Configuration::Proxy
       "tls-redirect": proxy_config.dig("ssl_redirect"),
       "log-request-header": proxy_config.dig("logging", "request_headers") || DEFAULT_LOG_REQUEST_HEADERS,
       "log-response-header": proxy_config.dig("logging", "response_headers"),
+      "exclude-metrics-path": proxy_config.dig("exclude_metrics_paths"),
       "error-pages": error_pages
     }.compact
   end

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -70,6 +70,7 @@ class Kamal::Configuration::Proxy
   def deploy_options
     {
       host: hosts,
+      "canonical-host": proxy_config.dig("canonical_host"),
       tls: ssl? ? true : nil,
       "tls-certificate-path": container_tls_cert,
       "tls-private-key-path": container_tls_key,

--- a/lib/kamal/configuration/proxy.rb
+++ b/lib/kamal/configuration/proxy.rb
@@ -87,6 +87,7 @@ class Kamal::Configuration::Proxy
       "path-prefix": path_prefixes,
       "strip-path-prefix": proxy_config.dig("strip_path_prefix"),
       "forward-headers": proxy_config.dig("forward_headers"),
+      "client-ip-header": proxy_config.dig("client_ip_header"),
       "tls-redirect": proxy_config.dig("ssl_redirect"),
       "log-request-header": proxy_config.dig("logging", "request_headers") || DEFAULT_LOG_REQUEST_HEADERS,
       "log-response-header": proxy_config.dig("logging", "response_headers"),

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -105,6 +105,16 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
     end
   end
 
+  test "client ip header" do
+    @deploy[:proxy] = { "client_ip_header" => "True-Client-IP" }
+    assert_equal "True-Client-IP", config.proxy.deploy_options[:"client-ip-header"]
+  end
+
+  test "client ip header not set" do
+    @deploy[:proxy] = {}
+    assert_not config.proxy.deploy_options.key?(:"client-ip-header")
+  end
+
   private
     def config
       Kamal::Configuration.new(@deploy)

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -128,6 +128,16 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
     assert_not config.proxy.deploy_options.key?(:"exclude-metrics-path")
   end
 
+  test "canonical host" do
+    @deploy[:proxy] = { "hosts" => [ "example.com", "www.example.com" ], "canonical_host" => "example.com" }
+    assert_equal "example.com", config.proxy.deploy_options[:"canonical-host"]
+  end
+
+  test "canonical host not set" do
+    @deploy[:proxy] = {}
+    assert_not config.proxy.deploy_options.key?(:"canonical-host")
+  end
+
   private
     def config
       Kamal::Configuration.new(@deploy)

--- a/test/configuration/proxy_test.rb
+++ b/test/configuration/proxy_test.rb
@@ -115,6 +115,19 @@ class ConfigurationProxyTest < ActiveSupport::TestCase
     assert_not config.proxy.deploy_options.key?(:"client-ip-header")
   end
 
+  test "exclude metrics paths" do
+    @deploy[:proxy] = { "exclude_metrics_paths" => [ "/up", "/healthz" ] }
+    proxy = config.proxy
+    assert_equal [ "/up", "/healthz" ], proxy.deploy_options[:"exclude-metrics-path"]
+    assert_includes proxy.deploy_command_args(target: "172.1.0.2"), "--exclude-metrics-path=\"/up\""
+    assert_includes proxy.deploy_command_args(target: "172.1.0.2"), "--exclude-metrics-path=\"/healthz\""
+  end
+
+  test "exclude metrics paths not set" do
+    @deploy[:proxy] = {}
+    assert_not config.proxy.deploy_options.key?(:"exclude-metrics-path")
+  end
+
   private
     def config
       Kamal::Configuration.new(@deploy)


### PR DESCRIPTION
Adds support for 3 new deploy options in Kamal Proxy.

@djmb fyi two of these will be new in 0.10.0. `--canonical-host` exists already in 0.9.2 but hadn't been wired up yet.

(Also cc @lewispb)