### PR TITLE
Keep .claude out of the Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+# Agent session state — worktrees under .claude/ are whole extra checkouts of this repo
+.claude


### PR DESCRIPTION
Local agent session state (`.claude`) can grow large — worktrees under `.claude/worktrees` are whole extra checkouts of the repo — and ships with the Docker build context, bloating images. Ignore it.