### PR TITLE
Move the nested test daemons' networks off Docker's default pool

### DIFF
--- a/test/integration/docker/deployer/boot.sh
+++ b/test/integration/docker/deployer/boot.sh
@@ -6,11 +6,19 @@
 mkdir -p /etc/docker
 # Point this inner daemon at the hub-cache pull-through cache so Docker Hub base
 # images are fetched at most once per run instead of on every test.
+# Keep this daemon's own networks off 172.16.0.0/12, Docker's default address
+# pool. The outer daemon allocates its bridge from that pool too, and hands
+# containers its bridge gateway as their DNS upstream (resolv.conf ExtServers).
+# An inner network landing on the same subnet shadows that address: the route
+# stays inside this container, DNS to the outer host silently dies, and only
+# name resolution breaks while raw IP traffic keeps working.
 cat > /etc/docker/daemon.json <<'EOF'
 {
   "storage-driver": "fuse-overlayfs",
   "registry-mirrors": [ "http://hub-cache:5000" ],
-  "insecure-registries": [ "hub-cache:5000" ]
+  "insecure-registries": [ "hub-cache:5000" ],
+  "bip": "10.222.0.1/24",
+  "default-address-pools": [ { "base": "10.223.0.0/16", "size": 24 } ]
 }
 EOF
 

--- a/test/integration/docker/deployer/setup.sh
+++ b/test/integration/docker/deployer/setup.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
+# Fail loudly: a failed gem install here otherwise surfaces much later as a
+# confusing "kamal: executable file not found in $PATH".
+set -euo pipefail
+
 install_kamal() {
   cd /kamal && gem build kamal.gemspec -o /tmp/kamal.gem && gem install /tmp/kamal.gem
 }

--- a/test/integration/docker/vm/boot.sh
+++ b/test/integration/docker/vm/boot.sh
@@ -10,11 +10,19 @@ service ssh restart
 mkdir -p /etc/docker
 # Point this inner daemon at the hub-cache pull-through cache so Docker Hub base
 # images are fetched at most once per run instead of on every test.
+# Keep this daemon's own networks off 172.16.0.0/12, Docker's default address
+# pool. The outer daemon allocates its bridge from that pool too, and hands
+# containers its bridge gateway as their DNS upstream (resolv.conf ExtServers).
+# An inner network landing on the same subnet shadows that address: the route
+# stays inside this container, DNS to the outer host silently dies, and only
+# name resolution breaks while raw IP traffic keeps working.
 cat > /etc/docker/daemon.json <<'EOF'
 {
   "storage-driver": "fuse-overlayfs",
   "registry-mirrors": [ "http://hub-cache:5000" ],
-  "insecure-registries": [ "hub-cache:5000" ]
+  "insecure-registries": [ "hub-cache:5000" ],
+  "bip": "10.222.0.1/24",
+  "default-address-pools": [ { "base": "10.223.0.0/16", "size": 24 } ]
 }
 EOF
 


### PR DESCRIPTION
The deployer and vm containers each run their own dockerd, which creates
its docker0 on Docker's default 172.17.0.0/16. On hosts that hand
containers the docker0 gateway as their DNS server -- the usual
arrangement under systemd-resolved -- 172.17.0.1 then means two things
inside the container, and the inner bridge wins. DNS queries never leave
the container and arrive where nothing is listening. Raw IP traffic is
unaffected, so only name resolution breaks.

Set bip to move the inner docker0, and default-address-pools so the
networks that daemon creates later -- including Kamal's own kamal network
-- also stay off 172.16.0.0/12. bip alone leaves the collision to
reappear on the next network created.

---

**Fail the integration deployer setup loudly**

setup.sh had no set -e, so a failed `gem install` left it exiting 0 from
its last line. The suite ran on without Kamal installed and reported the
problem several steps later as `exec: "kamal": executable file not found
in $PATH`.