### PR TITLE
Name builders after the registry they push to

### DIFF
--- a/lib/kamal/commands/builder/base.rb
+++ b/lib/kamal/commands/builder/base.rb
@@ -1,3 +1,5 @@
+require "digest"
+
 class Kamal::Commands::Builder::Base < Kamal::Commands::Base
   class BuilderError < StandardError; end
 
@@ -139,5 +141,13 @@ class Kamal::Commands::Builder::Base < Kamal::Commands::Base
 
     def platform_options(arches)
       argumentize "--platform", arches.map { |arch| "linux/#{arch}" }.join(",") if arches.any?
+    end
+
+    # Buildx caches registry credentials on the builder, so a builder must not
+    # be shared between registry accounts. The digest is an identifier, not a
+    # secret: the name reveals which account an app pushes to.
+    def registry_digest
+      identity = [ registry_config.server || "docker.io", registry_config.username ]
+      Digest::SHA256.hexdigest(identity.join("\x00"))[0, 12]
     end
 end

--- a/lib/kamal/commands/builder/hybrid.rb
+++ b/lib/kamal/commands/builder/hybrid.rb
@@ -8,7 +8,7 @@ class Kamal::Commands::Builder::Hybrid < Kamal::Commands::Builder::Remote
 
   private
     def builder_name
-      "kamal-hybrid-#{driver}-#{remote_builder_name_suffix}"
+      "kamal-hybrid-#{driver}-#{remote_builder_name_suffix}-#{registry_digest}"
     end
 
     def create_local_buildx

--- a/lib/kamal/commands/builder/local.rb
+++ b/lib/kamal/commands/builder/local.rb
@@ -12,9 +12,9 @@ class Kamal::Commands::Builder::Local < Kamal::Commands::Builder::Base
   private
     def builder_name
       if registry_config.local?
-        "kamal-local-registry-#{driver}"
+        "kamal-local-registry-#{driver}-#{registry_digest}"
       else
-        "kamal-local-#{driver}"
+        "kamal-local-#{driver}-#{registry_digest}"
       end
     end
 end

--- a/lib/kamal/commands/builder/remote.rb
+++ b/lib/kamal/commands/builder/remote.rb
@@ -34,7 +34,7 @@ class Kamal::Commands::Builder::Remote < Kamal::Commands::Builder::Base
 
   private
     def builder_name
-      "kamal-remote-#{remote_builder_name_suffix}"
+      "kamal-remote-#{remote_builder_name_suffix}-#{registry_digest}"
     end
 
     def remote_context_name

--- a/test/cli/build_test.rb
+++ b/test/cli/build_test.rb
@@ -26,7 +26,7 @@ class CliBuildTest < CliTestCase
         assert_match /Cloning repo into build directory/, output
         assert_match /git -C #{Dir.tmpdir}\/kamal-clones\/app-#{pwd_sha} clone #{Dir.pwd}/, output
         assert_match /docker --version && docker buildx version/, output
-        assert_match /docker buildx build --output=type=registry --platform linux\/amd64 --builder kamal-local-docker-container -t dhh\/app:999 -t dhh\/app:latest --label service="app" --file Dockerfile \. 2>&1 as .*@localhost/, output
+        assert_match /docker buildx build --output=type=registry --platform linux\/amd64 --builder kamal-local-docker-container-6e208c509c5d -t dhh\/app:999 -t dhh\/app:latest --label service="app" --file Dockerfile \. 2>&1 as .*@localhost/, output
       end
     end
   end
@@ -45,8 +45,8 @@ class CliBuildTest < CliTestCase
 
       run_command("push", "--verbose", fixture: :with_remote_builder).tap do |output|
         assert_no_match "Running docker login -u [REDACTED] -p [REDACTED] as ", output
-        assert_match "docker buildx inspect kamal-remote-ssh---app-1-1-1-5 | grep -q Endpoint:.*kamal-remote-ssh---app-1-1-1-5-context && docker context inspect kamal-remote-ssh---app-1-1-1-5-context --format '{{.Endpoints.docker.Host}}' | grep -xq ssh://app@1.1.1.5 || (echo no compatible builder && exit 1)", output
-        assert_match "Command: ( export BUILDKIT_NO_CLIENT_TOKEN=\"1\" ; docker buildx build --output=type=registry --platform linux/#{remote_arch} --builder kamal-remote-ssh---app-1-1-1-5 -t dhh/app:999 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1 )", output
+        assert_match "docker buildx inspect kamal-remote-ssh---app-1-1-1-5-6e208c509c5d | grep -q Endpoint:.*kamal-remote-ssh---app-1-1-1-5-6e208c509c5d-context && docker context inspect kamal-remote-ssh---app-1-1-1-5-6e208c509c5d-context --format '{{.Endpoints.docker.Host}}' | grep -xq ssh://app@1.1.1.5 || (echo no compatible builder && exit 1)", output
+        assert_match "Command: ( export BUILDKIT_NO_CLIENT_TOKEN=\"1\" ; docker buildx build --output=type=registry --platform linux/#{remote_arch} --builder kamal-remote-ssh---app-1-1-1-5-6e208c509c5d -t dhh/app:999 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1 )", output
       end
     end
   end
@@ -90,7 +90,7 @@ class CliBuildTest < CliTestCase
         assert_match /Cloning repo into build directory/, output
         assert_match /git -C #{Dir.tmpdir}\/kamal-clones\/app-#{pwd_sha} clone #{Dir.pwd}/, output
         assert_match /docker --version && docker buildx version/, output
-        assert_match /docker buildx build --output=type=docker --platform linux\/amd64 --builder kamal-local-docker-container -t dhh\/app:999 -t dhh\/app:latest --label service="app" --file Dockerfile \. 2>&1 as .*@localhost/, output
+        assert_match /docker buildx build --output=type=docker --platform linux\/amd64 --builder kamal-local-docker-container-6e208c509c5d -t dhh\/app:999 -t dhh\/app:latest --label service="app" --file Dockerfile \. 2>&1 as .*@localhost/, output
       end
     end
   end
@@ -115,7 +115,7 @@ class CliBuildTest < CliTestCase
       SSHKit::Backend::Abstract.any_instance.expects(:execute).with(:git, "-C", build_directory, :gc, "--auto", "--quiet")
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
-        .with(:docker, :buildx, :build, "--output=type=registry", "--platform", "linux/amd64", "--builder", "kamal-local-docker-container", "-t", "dhh/app:999", "-t", "dhh/app:latest", "--label", "service=\"app\"", "--file", "Dockerfile", ".", "2>&1", env: {})
+        .with(:docker, :buildx, :build, "--output=type=registry", "--platform", "linux/amd64", "--builder", "kamal-local-docker-container-6e208c509c5d", "-t", "dhh/app:999", "-t", "dhh/app:latest", "--label", "service=\"app\"", "--file", "Dockerfile", ".", "2>&1", env: {})
 
       SSHKit::Backend::Abstract.any_instance.expects(:capture_with_info)
         .with(:git, "-C", anything, :"rev-parse", :HEAD)
@@ -139,7 +139,7 @@ class CliBuildTest < CliTestCase
       assert_no_match /Cloning repo into build directory/, output
       assert_hook_ran "pre-build", output
       assert_match /docker --version && docker buildx version/, output
-      assert_match /docker buildx build --output=type=registry --platform linux\/amd64 --builder kamal-local-docker-container -t dhh\/app:999 -t dhh\/app:latest --label service="app" --file Dockerfile . 2>&1 as .*@localhost/, output
+      assert_match /docker buildx build --output=type=registry --platform linux\/amd64 --builder kamal-local-docker-container-6e208c509c5d -t dhh\/app:999 -t dhh\/app:latest --label service="app" --file Dockerfile . 2>&1 as .*@localhost/, output
     end
   end
 
@@ -149,7 +149,7 @@ class CliBuildTest < CliTestCase
     run_command("push", "--no-cache", "--verbose", fixture: :without_clone).tap do |output|
       assert_hook_ran "pre-build", output
       assert_match /docker --version && docker buildx version/, output
-      assert_match /docker buildx build --output=type=registry --platform linux\/amd64 --builder kamal-local-docker-container -t dhh\/app:999 -t dhh\/app:latest --label service="app" --file Dockerfile --no-cache . 2>&1 as .*@localhost/, output
+      assert_match /docker buildx build --output=type=registry --platform linux\/amd64 --builder kamal-local-docker-container-6e208c509c5d -t dhh\/app:999 -t dhh\/app:latest --label service="app" --file Dockerfile --no-cache . 2>&1 as .*@localhost/, output
     end
   end
 
@@ -202,13 +202,13 @@ class CliBuildTest < CliTestCase
       .with(:docker, :start, "kamal-docker-registry", "||", :docker, :run, "--detach", "-p", "127.0.0.1:5000:5000", "--name", "kamal-docker-registry", "registry:3")
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
-        .with(:docker, :buildx, :rm, "kamal-local-registry-docker-container")
+        .with(:docker, :buildx, :rm, "kamal-local-registry-docker-container-3e4092d0c8b9")
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
-        .with(:docker, :buildx, :create, "--name", "kamal-local-registry-docker-container", "--driver=docker-container", "--driver-opt", "network=host")
+        .with(:docker, :buildx, :create, "--name", "kamal-local-registry-docker-container-3e4092d0c8b9", "--driver=docker-container", "--driver-opt", "network=host")
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
-        .with(:docker, :buildx, :inspect, "kamal-local-registry-docker-container")
+        .with(:docker, :buildx, :inspect, "kamal-local-registry-docker-container-3e4092d0c8b9")
         .raises(SSHKit::Command::Failed.new("no builder"))
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute).with { |*args| args.first.to_s.start_with?("git") }
@@ -222,7 +222,7 @@ class CliBuildTest < CliTestCase
         .returns("")
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
-        .with(:docker, :buildx, :build, "--output=type=registry", "--platform", "linux/amd64", "--builder", "kamal-local-registry-docker-container", "-t", "localhost:5000/dhh/app:999", "-t", "localhost:5000/dhh/app:latest", "--label", "service=\"app\"", "--file", "Dockerfile", ".", "2>&1", env: {})
+        .with(:docker, :buildx, :build, "--output=type=registry", "--platform", "linux/amd64", "--builder", "kamal-local-registry-docker-container-3e4092d0c8b9", "-t", "localhost:5000/dhh/app:999", "-t", "localhost:5000/dhh/app:latest", "--label", "service=\"app\"", "--file", "Dockerfile", ".", "2>&1", env: {})
 
       run_command("push", fixture: :with_local_registry_and_accessories).tap do |output|
         assert_match /WARN Missing compatible builder, so creating a new one first/, output
@@ -241,13 +241,13 @@ class CliBuildTest < CliTestCase
         .with { |*args| args[0..1] == [ :docker, :login ] }
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
-        .with(:docker, :buildx, :rm, "kamal-local-docker-container")
+        .with(:docker, :buildx, :rm, "kamal-local-docker-container-6e208c509c5d")
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
-        .with(:docker, :buildx, :create, "--name", "kamal-local-docker-container", "--driver=docker-container")
+        .with(:docker, :buildx, :create, "--name", "kamal-local-docker-container-6e208c509c5d", "--driver=docker-container")
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
-        .with(:docker, :buildx, :inspect, "kamal-local-docker-container")
+        .with(:docker, :buildx, :inspect, "kamal-local-docker-container-6e208c509c5d")
         .raises(SSHKit::Command::Failed.new("no builder"))
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute).with { |*args| args.first.start_with?("git") }
@@ -261,7 +261,7 @@ class CliBuildTest < CliTestCase
         .returns("")
 
       SSHKit::Backend::Abstract.any_instance.expects(:execute)
-        .with(:docker, :buildx, :build, "--output=type=registry", "--platform", "linux/amd64", "--builder", "kamal-local-docker-container", "-t", "dhh/app:999", "-t", "dhh/app:latest", "--label", "service=\"app\"", "--file", "Dockerfile", ".", "2>&1", env: {})
+        .with(:docker, :buildx, :build, "--output=type=registry", "--platform", "linux/amd64", "--builder", "kamal-local-docker-container-6e208c509c5d", "-t", "dhh/app:999", "-t", "dhh/app:latest", "--label", "service=\"app\"", "--file", "Dockerfile", ".", "2>&1", env: {})
 
       run_command("push").tap do |output|
         assert_match /WARN Missing compatible builder, so creating a new one first/, output
@@ -327,32 +327,32 @@ class CliBuildTest < CliTestCase
 
   test "create" do
     run_command("create").tap do |output|
-      assert_match /docker buildx create --name kamal-local-docker-container --driver=docker-container/, output
+      assert_match /docker buildx create --name kamal-local-docker-container-6e208c509c5d --driver=docker-container/, output
     end
   end
 
   test "create remote" do
     run_command("create", fixture: :with_remote_builder).tap do |output|
       assert_match "Running /usr/bin/env true on 1.1.1.5", output
-      assert_match "docker context create kamal-remote-ssh---app-1-1-1-5-context --description 'kamal-remote-ssh---app-1-1-1-5 host' --docker 'host=ssh://app@1.1.1.5'", output
-      assert_match "docker buildx create --name kamal-remote-ssh---app-1-1-1-5 kamal-remote-ssh---app-1-1-1-5-context", output
+      assert_match "docker context create kamal-remote-ssh---app-1-1-1-5-6e208c509c5d-context --description 'kamal-remote-ssh---app-1-1-1-5-6e208c509c5d host' --docker 'host=ssh://app@1.1.1.5'", output
+      assert_match "docker buildx create --name kamal-remote-ssh---app-1-1-1-5-6e208c509c5d kamal-remote-ssh---app-1-1-1-5-6e208c509c5d-context", output
     end
   end
 
   test "create remote with custom ports" do
     run_command("create", fixture: :with_remote_builder_and_custom_ports).tap do |output|
       assert_match "Running /usr/bin/env true on 1.1.1.5", output
-      assert_match "docker context create kamal-remote-ssh---app-1-1-1-5-2122-context --description 'kamal-remote-ssh---app-1-1-1-5-2122 host' --docker 'host=ssh://app@1.1.1.5:2122'", output
-      assert_match "docker buildx create --name kamal-remote-ssh---app-1-1-1-5-2122 kamal-remote-ssh---app-1-1-1-5-2122-context", output
+      assert_match "docker context create kamal-remote-ssh---app-1-1-1-5-2122-6e208c509c5d-context --description 'kamal-remote-ssh---app-1-1-1-5-2122-6e208c509c5d host' --docker 'host=ssh://app@1.1.1.5:2122'", output
+      assert_match "docker buildx create --name kamal-remote-ssh---app-1-1-1-5-2122-6e208c509c5d kamal-remote-ssh---app-1-1-1-5-2122-6e208c509c5d-context", output
     end
   end
 
   test "create hybrid" do
     run_command("create", fixture: :with_hybrid_builder).tap do |output|
       assert_match "Running /usr/bin/env true on 1.1.1.5", output
-      assert_match "docker buildx create --platform linux/#{local_arch} --name kamal-hybrid-docker-container-ssh---app-1-1-1-5 --driver=docker-container", output
-      assert_match "docker context create kamal-hybrid-docker-container-ssh---app-1-1-1-5-context --description 'kamal-hybrid-docker-container-ssh---app-1-1-1-5 host' --docker 'host=ssh://app@1.1.1.5'", output
-      assert_match "docker buildx create --platform linux/#{remote_arch} --append --name kamal-hybrid-docker-container-ssh---app-1-1-1-5 kamal-hybrid-docker-container-ssh---app-1-1-1-5-context", output
+      assert_match "docker buildx create --platform linux/#{local_arch} --name kamal-hybrid-docker-container-ssh---app-1-1-1-5-6e208c509c5d --driver=docker-container", output
+      assert_match "docker context create kamal-hybrid-docker-container-ssh---app-1-1-1-5-6e208c509c5d-context --description 'kamal-hybrid-docker-container-ssh---app-1-1-1-5-6e208c509c5d host' --docker 'host=ssh://app@1.1.1.5'", output
+      assert_match "docker buildx create --platform linux/#{remote_arch} --append --name kamal-hybrid-docker-container-ssh---app-1-1-1-5-6e208c509c5d kamal-hybrid-docker-container-ssh---app-1-1-1-5-6e208c509c5d-context", output
     end
   end
 
@@ -403,7 +403,7 @@ class CliBuildTest < CliTestCase
       run_command("dev", "--verbose").tap do |output|
         assert_no_match(/Cloning repo into build directory/, output)
         assert_match(/docker --version && docker buildx version/, output)
-        assert_match(/docker buildx build --output=type=docker --platform linux\/amd64 --builder kamal-local-docker-container -t dhh\/app:999-dirty -t dhh\/app:latest-dirty --label service="app" --file Dockerfile \. 2>&1 as .*@localhost/, output)
+        assert_match(/docker buildx build --output=type=docker --platform linux\/amd64 --builder kamal-local-docker-container-6e208c509c5d -t dhh\/app:999-dirty -t dhh\/app:latest-dirty --label service="app" --file Dockerfile \. 2>&1 as .*@localhost/, output)
       end
     end
   end
@@ -415,7 +415,7 @@ class CliBuildTest < CliTestCase
       run_command("dev", "--output=local", "--verbose").tap do |output|
         assert_no_match(/Cloning repo into build directory/, output)
         assert_match(/docker --version && docker buildx version/, output)
-        assert_match(/docker buildx build --output=type=local --platform linux\/amd64 --builder kamal-local-docker-container -t dhh\/app:999-dirty -t dhh\/app:latest-dirty --label service="app" --file Dockerfile \. 2>&1 as .*@localhost/, output)
+        assert_match(/docker buildx build --output=type=local --platform linux\/amd64 --builder kamal-local-docker-container-6e208c509c5d -t dhh\/app:999-dirty -t dhh\/app:latest-dirty --label service="app" --file Dockerfile \. 2>&1 as .*@localhost/, output)
       end
     end
   end
@@ -427,21 +427,21 @@ class CliBuildTest < CliTestCase
       run_command("dev", "--no-cache", "--verbose").tap do |output|
         assert_no_match(/Cloning repo into build directory/, output)
         assert_match(/docker --version && docker buildx version/, output)
-        assert_match(/docker buildx build --output=type=docker --platform linux\/amd64 --builder kamal-local-docker-container -t dhh\/app:999-dirty -t dhh\/app:latest-dirty --label service="app" --file Dockerfile --no-cache \. 2>&1 as .*@localhost/, output)
+        assert_match(/docker buildx build --output=type=docker --platform linux\/amd64 --builder kamal-local-docker-container-6e208c509c5d -t dhh\/app:999-dirty -t dhh\/app:latest-dirty --label service="app" --file Dockerfile --no-cache \. 2>&1 as .*@localhost/, output)
       end
     end
   end
 
   test "create with local registry" do
     run_command("create", fixture: :with_local_registry).tap do |output|
-      assert_match /docker buildx create --name kamal-local-registry-docker-container --driver=docker-container --driver-opt network=host/, output
+      assert_match /docker buildx create --name kamal-local-registry-docker-container-3e4092d0c8b9 --driver=docker-container --driver-opt network=host/, output
     end
   end
 
   test "create with local registry and remote builder" do
     run_command("create", fixture: :with_local_registry_and_remote_builder).tap do |output|
       # Verify remote builder with local-registry in name
-      assert_match /docker buildx create --name kamal-remote-ssh---app-1-1-1-5-local-registry/, output
+      assert_match /docker buildx create --name kamal-remote-ssh---app-1-1-1-5-local-registry-3e4092d0c8b9/, output
       assert_match /--driver-opt network=host/, output
     end
   end
@@ -468,7 +468,7 @@ class CliBuildTest < CliTestCase
   test "create with local registry and remote builder with custom port" do
     run_command("create", fixture: :with_local_registry_and_remote_builder_with_port).tap do |output|
       # Verify remote builder with local-registry in name includes custom port in context name
-      assert_match /docker buildx create --name kamal-remote-ssh---app-1-1-1-5-2222-local-registry/, output
+      assert_match /docker buildx create --name kamal-remote-ssh---app-1-1-1-5-2222-local-registry-3e4092d0c8b9/, output
       assert_match /--driver-opt network=host/, output
     end
   end

--- a/test/cli/cli_test_case.rb
+++ b/test/cli/cli_test_case.rb
@@ -37,7 +37,7 @@ class CliTestCase < ActiveSupport::TestCase
       SSHKit::Backend::Abstract.any_instance.stubs(:execute)
         .with { |arg1, arg2| arg1 == :rm && arg2 == ".kamal/lock-app/details" }
       SSHKit::Backend::Abstract.any_instance.stubs(:execute)
-        .with(:docker, :buildx, :inspect, "kamal-local-docker-container")
+        .with(:docker, :buildx, :inspect, "kamal-local-docker-container-6e208c509c5d")
     end
 
     def assert_hook_ran(hook, output, count: 1)

--- a/test/commands/builder_test.rb
+++ b/test/commands/builder_test.rb
@@ -9,7 +9,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "cache" => { "type" => "gha" } })
     assert_equal "local", builder.name
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
       builder.push.join(" ")
   end
 
@@ -17,7 +17,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "arch" => [ "amd64" ] })
     assert_equal "local", builder.name
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile . 2>&1",
       builder.push.join(" ")
   end
 
@@ -25,7 +25,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "cache" => { "type" => "gha" } })
     assert_equal "local", builder.name
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
       builder.push.join(" ")
   end
 
@@ -33,7 +33,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "arch" => [ "amd64", "arm64" ], "remote" => "ssh://app@127.0.0.1", "cache" => { "type" => "gha" } })
     assert_equal "hybrid", builder.name
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64,linux/arm64 --builder kamal-hybrid-docker-container-ssh---app-127-0-0-1 -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64,linux/arm64 --builder kamal-hybrid-docker-container-ssh---app-127-0-0-1-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
       builder.push.join(" ")
   end
 
@@ -41,7 +41,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "arch" => [ "amd64", "arm64" ], "remote" => "ssh://app@127.0.0.1", "cache" => { "type" => "gha" }, "local" => false })
     assert_equal "remote", builder.name
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64,linux/arm64 --builder kamal-remote-ssh---app-127-0-0-1 -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64,linux/arm64 --builder kamal-remote-ssh---app-127-0-0-1-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
       builder.push.join(" ")
   end
 
@@ -49,7 +49,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "arch" => [ "#{remote_arch}" ], "remote" => "ssh://app@host", "cache" => { "type" => "gha" } })
     assert_equal "remote", builder.name
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/#{remote_arch} --builder kamal-remote-ssh---app-host -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/#{remote_arch} --builder kamal-remote-ssh---app-host-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
       builder.push.join(" ")
   end
 
@@ -57,7 +57,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(builder: { "arch" => [ "#{local_arch}" ], "remote" => "ssh://app@host", "cache" => { "type" => "gha" } })
     assert_equal "local", builder.name
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/#{local_arch} --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/#{local_arch} --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --cache-to type=gha --cache-from type=gha --label service=\"app\" --file Dockerfile . 2>&1",
       builder.push.join(" ")
   end
 
@@ -146,14 +146,14 @@ class CommandsBuilderTest < ActiveSupport::TestCase
   test "build context" do
     builder = new_builder_command(builder: { "context" => ".." })
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile .. 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile .. 2>&1",
       builder.push.join(" ")
   end
 
   test "push with build args" do
     builder = new_builder_command(builder: { "args" => { "a" => 1, "b" => 2 } })
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" --file Dockerfile . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --build-arg a=\"1\" --build-arg b=\"2\" --file Dockerfile . 2>&1",
       builder.push.join(" ")
   end
 
@@ -162,7 +162,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
       FileUtils.touch("Dockerfile")
       builder = new_builder_command(builder: { "secrets" => [ "a", "b" ] })
       assert_equal \
-        "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"a\" --secret id=\"b\" --file Dockerfile . 2>&1",
+        "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --secret id=\"a\" --secret id=\"b\" --file Dockerfile . 2>&1",
         builder.push.join(" ")
     end
   end
@@ -182,35 +182,35 @@ class CommandsBuilderTest < ActiveSupport::TestCase
   test "context build" do
     builder = new_builder_command(builder: { "context" => "./foo" })
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile ./foo 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile ./foo 2>&1",
       builder.push.join(" ")
   end
 
   test "push with provenance" do
     builder = new_builder_command(builder: { "provenance" => "mode=max" })
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --provenance mode=max . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --provenance mode=max . 2>&1",
       builder.push.join(" ")
   end
 
   test "push with provenance false" do
     builder = new_builder_command(builder: { "provenance" => false })
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --provenance false . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --provenance false . 2>&1",
       builder.push.join(" ")
   end
 
   test "push with sbom" do
     builder = new_builder_command(builder: { "sbom" => true })
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --sbom true . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --sbom true . 2>&1",
       builder.push.join(" ")
   end
 
   test "push with sbom false" do
     builder = new_builder_command(builder: { "sbom" => false })
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --sbom false . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --sbom false . 2>&1",
       builder.push.join(" ")
   end
 
@@ -222,7 +222,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
   test "push with no cache" do
     builder = new_builder_command
     assert_equal \
-      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --no-cache . 2>&1",
+      "docker buildx build --output=type=registry --platform linux/amd64 --builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:123 -t dhh/app:latest --label service=\"app\" --file Dockerfile --no-cache . 2>&1",
       builder.push("registry", no_cache: true).join(" ")
   end
 
@@ -253,7 +253,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     builder = new_builder_command(registry: { "server" => "localhost:5000" })
     assert_equal "local", builder.name
     assert_equal \
-      "docker buildx create --name kamal-local-registry-docker-container --driver=docker-container --driver-opt network=host",
+      "docker buildx create --name kamal-local-registry-docker-container-73efb98bf89f --driver=docker-container --driver-opt network=host",
       builder.create.join(" ")
   end
 
@@ -264,7 +264,7 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     )
     assert_equal "remote", builder.name
     assert_equal \
-      "docker context create kamal-remote-ssh---app-1-1-1-5-local-registry-context --description 'kamal-remote-ssh---app-1-1-1-5-local-registry host' --docker 'host=ssh://app@1.1.1.5' ; docker buildx create --name kamal-remote-ssh---app-1-1-1-5-local-registry --driver-opt network=host kamal-remote-ssh---app-1-1-1-5-local-registry-context",
+      "docker context create kamal-remote-ssh---app-1-1-1-5-local-registry-73efb98bf89f-context --description 'kamal-remote-ssh---app-1-1-1-5-local-registry-73efb98bf89f host' --docker 'host=ssh://app@1.1.1.5' ; docker buildx create --name kamal-remote-ssh---app-1-1-1-5-local-registry-73efb98bf89f --driver-opt network=host kamal-remote-ssh---app-1-1-1-5-local-registry-73efb98bf89f-context",
       builder.create.join(" ")
   end
 
@@ -275,8 +275,32 @@ class CommandsBuilderTest < ActiveSupport::TestCase
     )
     assert_equal "hybrid", builder.name
     assert_equal \
-      "docker buildx create --platform linux/#{local_arch} --name kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry --driver=docker-container --driver-opt network=host && docker context create kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry-context --description 'kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry host' --docker 'host=ssh://app@1.1.1.5' && docker buildx create --platform linux/#{remote_arch} --append --name kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry --driver-opt network=host kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry-context",
+      "docker buildx create --platform linux/#{local_arch} --name kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry-73efb98bf89f --driver=docker-container --driver-opt network=host && docker context create kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry-73efb98bf89f-context --description 'kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry-73efb98bf89f host' --docker 'host=ssh://app@1.1.1.5' && docker buildx create --platform linux/#{remote_arch} --append --name kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry-73efb98bf89f --driver-opt network=host kamal-hybrid-docker-container-ssh---app-1-1-1-5-local-registry-73efb98bf89f-context",
       builder.create.join(" ")
+  end
+
+  test "a new registry username gets its own builder" do
+    assert_not_equal \
+      new_builder_command(registry: { "username" => "alice" }).target.send(:builder_name),
+      new_builder_command(registry: { "username" => "bob" }).target.send(:builder_name)
+  end
+
+  test "a new registry server gets its own builder" do
+    assert_not_equal \
+      new_builder_command(registry: { "server" => "ghcr.io" }).target.send(:builder_name),
+      new_builder_command(registry: { "server" => "registry.example.com" }).target.send(:builder_name)
+  end
+
+  test "implicit and explicit Docker Hub share a builder" do
+    assert_equal \
+      new_builder_command.target.send(:builder_name),
+      new_builder_command(registry: { "server" => "docker.io" }).target.send(:builder_name)
+  end
+
+  test "two services on the same registry account share a builder" do
+    assert_equal \
+      new_builder_command(service: "app").target.send(:builder_name),
+      new_builder_command(service: "other", image: "dhh/other").target.send(:builder_name)
   end
 
   private


### PR DESCRIPTION
Buildx caches registry credentials on the builder, so one builder shared
across registry accounts pushes with the wrong credentials. Changing the
Docker Hub account in deploy.yml failed with `insufficient_scope:
authorization failed` until `kamal build remove` was run by hand.

Builder names now carry a 12-character digest of the registry server and
username, so a new account gets its own builder. Apps sharing an account
keep sharing a builder, and its cache.

A missing server is canonicalised to docker.io so implicit and explicit
Docker Hub do not split.

Builders created before this change have no digest and are left behind on
upgrade; remove them with `docker buildx rm`.

Fixes #1383

### Why a digest rather than the values

Not for secrecy. The digest is a compact key for a two-part value: `server`
can contain a `:` (`localhost:5000`), which buildx rejects, and inlining two
user-supplied fields gives variable-length names.

The builder name reveals which account an app pushes to, and in most setups
the username is already adjacent in the same command:

```
--builder kamal-local-docker-container-f005c512b8b0 -t dhh/app:999
```

ECR (`AWS`) and GCP (`_json_key_base64`) use constants. Only where the login
principal differs from the image namespace — a GHCR org, say — is the
username absent from the output, and there it is a handle, not a credential.

The remote host stays in the name in clear for the same reason: it is in
`servers:` and on every SSHKit log line, and it is the only thing that
identifies which host a remote builder belongs to.

### Not addressed

- Cloud builders keep the collision. `Cloud#create` passes no `--name`, so
  Docker derives it from the driver. Whether `--name` can be combined with the
  cloud driver is untested here.
- Rotating a password without changing the username. Hashing credentials would
  rotate the builder on every ECR token refresh, twice a day.