### PR TITLE
Honor --since and --lines when following accessory logs

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -202,17 +202,19 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
       grep = options[:grep]
       grep_options = options[:grep_options]
       timestamps = !options[:skip_timestamps]
+      since = options[:since]
 
       if options[:follow]
         if hosts.any?
+          lines = options[:lines].presence || ((since || grep) ? nil : 10) # Default to 10 lines if since or grep isn't set
+
           run_locally do
             info "Following logs on #{hosts.first}..."
-            info accessory.follow_logs(host: hosts.first, timestamps: timestamps, grep: grep, grep_options: grep_options)
-            exec accessory.follow_logs(host: hosts.first, timestamps: timestamps, grep: grep, grep_options: grep_options)
+            info accessory.follow_logs(host: hosts.first, timestamps: timestamps, since: since, lines: lines, grep: grep, grep_options: grep_options)
+            exec accessory.follow_logs(host: hosts.first, timestamps: timestamps, since: since, lines: lines, grep: grep, grep_options: grep_options)
           end
         end
       else
-        since = options[:since]
         lines = options[:lines].presence || ((since || grep) ? nil : 100) # Default to 100 lines if since or grep isn't set
 
         on(hosts) do

--- a/lib/kamal/commands/accessory.rb
+++ b/lib/kamal/commands/accessory.rb
@@ -47,10 +47,10 @@ class Kamal::Commands::Accessory < Kamal::Commands::Base
       ("grep '#{grep}'#{" #{grep_options}" if grep_options}" if grep)
   end
 
-  def follow_logs(host:, timestamps: true, grep: nil, grep_options: nil)
+  def follow_logs(host:, timestamps: true, since: nil, lines: nil, grep: nil, grep_options: nil)
     run_over_ssh \
       pipe(
-        docker(:logs, service_name, ("--timestamps" if timestamps), "--tail", "10", "--follow", "2>&1"),
+        docker(:logs, service_name, ("--timestamps" if timestamps), ("--since #{since}" if since), ("--tail #{lines}" if lines), "--follow", "2>&1"),
         (%(grep "#{grep}"#{" #{grep_options}" if grep_options}) if grep)
       ),
       host: host

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -160,18 +160,32 @@ class CliAccessoryTest < CliTestCase
     assert_match "docker logs app-mysql --timestamps --tail 10 --follow 2>&1", run_command("logs", "mysql", "--follow")
   end
 
+  test "logs with follow and since" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:exec)
+      .with("ssh -t root@1.1.1.3 -p 22 'docker logs app-mysql --timestamps --since 5m --follow 2>&1'")
+
+    assert_match "docker logs app-mysql --timestamps --since 5m --follow 2>&1", run_command("logs", "mysql", "--follow", "--since", "5m")
+  end
+
+  test "logs with follow and lines" do
+    SSHKit::Backend::Abstract.any_instance.stubs(:exec)
+      .with("ssh -t root@1.1.1.3 -p 22 'docker logs app-mysql --timestamps --tail 123 --follow 2>&1'")
+
+    assert_match "docker logs app-mysql --timestamps --tail 123 --follow 2>&1", run_command("logs", "mysql", "--follow", "--lines", "123")
+  end
+
   test "logs with follow and grep" do
     SSHKit::Backend::Abstract.any_instance.stubs(:exec)
-      .with("ssh -t root@1.1.1.3 -p 22 'docker logs app-mysql --timestamps --tail 10 --follow 2>&1 | grep \"hey\"'")
+      .with("ssh -t root@1.1.1.3 -p 22 'docker logs app-mysql --timestamps --follow 2>&1 | grep \"hey\"'")
 
-    assert_match "docker logs app-mysql --timestamps --tail 10 --follow 2>&1 | grep \"hey\"", run_command("logs", "mysql", "--follow", "--grep", "hey")
+    assert_match "docker logs app-mysql --timestamps --follow 2>&1 | grep \"hey\"", run_command("logs", "mysql", "--follow", "--grep", "hey")
   end
 
   test "logs with follow, grep, and grep options" do
     SSHKit::Backend::Abstract.any_instance.stubs(:exec)
-      .with("ssh -t root@1.1.1.3 -p 22 'docker logs app-mysql --timestamps --tail 10 --follow 2>&1 | grep \"hey\" -C 2'")
+      .with("ssh -t root@1.1.1.3 -p 22 'docker logs app-mysql --timestamps --follow 2>&1 | grep \"hey\" -C 2'")
 
-    assert_match "docker logs app-mysql --timestamps --tail 10 --follow 2>&1 | grep \"hey\" -C 2", run_command("logs", "mysql", "--follow", "--grep", "hey", "--grep-options", "-C 2")
+    assert_match "docker logs app-mysql --timestamps --follow 2>&1 | grep \"hey\" -C 2", run_command("logs", "mysql", "--follow", "--grep", "hey", "--grep-options", "-C 2")
   end
 
   test "logs with follow defaults to first host" do

--- a/test/commands/accessory_test.rb
+++ b/test/commands/accessory_test.rb
@@ -179,12 +179,18 @@ class CommandsAccessoryTest < ActiveSupport::TestCase
 
   test "follow logs" do
     assert_equal \
-      "ssh -t root@1.1.1.5 -p 22 'docker logs app-mysql --timestamps --tail 10 --follow 2>&1'",
+      "ssh -t root@1.1.1.5 -p 22 'docker logs app-mysql --timestamps --follow 2>&1'",
       new_command(:mysql).follow_logs(host: "1.1.1.5")
 
     assert_equal \
-      "ssh -t root@1.1.1.5 -p 22 'docker logs app-mysql --tail 10 --follow 2>&1'",
+      "ssh -t root@1.1.1.5 -p 22 'docker logs app-mysql --follow 2>&1'",
       new_command(:mysql).follow_logs(host: "1.1.1.5", timestamps: false)
+  end
+
+  test "follow logs with since and lines" do
+    assert_equal \
+      "ssh -t root@1.1.1.5 -p 22 'docker logs app-mysql --timestamps --since 5m --tail 123 --follow 2>&1'",
+      new_command(:mysql).follow_logs(host: "1.1.1.5", since: "5m", lines: 123)
   end
 
   test "remove container" do


### PR DESCRIPTION
`kamal accessory logs -f` dropped both options. `follow_logs` took neither and
hardcoded `--tail 10`:

```ruby
def follow_logs(timestamps: true, grep: nil, grep_options: nil)
  docker(:logs, service_name, ..., "--tail", "10", "--follow", "2>&1")
```

Follow-up to #1937, which fixed the same thing for `kamal app logs`.

The default moves to the CLI, as it is for app, so `--since` is not capped by
it. One behaviour change that comes with matching app: `--grep` now drops the
default `--tail` too, so a grepped follow searches the whole log rather than
the last 10 lines.