### PR TITLE
Upload custom SSL certificates for proxied accessories

### DIFF
--- a/lib/kamal/cli/accessory.rb
+++ b/lib/kamal/cli/accessory.rb
@@ -28,6 +28,16 @@ class Kamal::Cli::Accessory < Kamal::Cli::Base
             execute *KAMAL.auditor.record("Booted #{name} accessory"), verbosity: :debug
             execute *accessory.ensure_env_directory
             upload! accessory.secrets_io, accessory.secrets_path, mode: "0600"
+
+            if accessory.running_proxy? && accessory.proxy.custom_ssl_certificate?
+              cert_content = accessory.proxy.certificate_pem_content
+              key_content = accessory.proxy.private_key_pem_content
+
+              execute *accessory.create_ssl_directory
+              upload! StringIO.new(cert_content), accessory.proxy.host_tls_cert, mode: "0644"
+              upload! StringIO.new(key_content), accessory.proxy.host_tls_key, mode: "0644"
+            end
+
             execute *accessory.run(host: host)
 
             if accessory.running_proxy?

--- a/lib/kamal/commands/accessory/proxy.rb
+++ b/lib/kamal/commands/accessory/proxy.rb
@@ -9,6 +9,10 @@ module Kamal::Commands::Accessory::Proxy
     proxy_exec :remove, service_name
   end
 
+  def create_ssl_directory
+    make_directory(File.join(config.proxy_boot.tls_directory, proxy.role_name))
+  end
+
   private
     def proxy_exec(*command)
       docker :exec, proxy_container_name, "kamal-proxy", *command

--- a/lib/kamal/configuration/accessory.rb
+++ b/lib/kamal/configuration/accessory.rb
@@ -132,6 +132,7 @@ class Kamal::Configuration::Accessory
       Kamal::Configuration::Proxy.new \
         config: config,
         proxy_config: accessory_config["proxy"],
+        role_name: "accessories/#{name}",
         context: "accessories/#{name}/proxy",
         secrets: config.secrets
     end

--- a/test/cli/accessory_test.rb
+++ b/test/cli/accessory_test.rb
@@ -42,6 +42,21 @@ class CliAccessoryTest < CliTestCase
     end
   end
 
+  test "boot with custom ssl certificate" do
+    Kamal::Cli::Accessory.any_instance.expects(:directories).with("busybox")
+    Kamal::Cli::Accessory.any_instance.expects(:upload).with("busybox")
+    Kamal::Configuration::Proxy.any_instance.stubs(:custom_ssl_certificate?).returns(true)
+    Kamal::Configuration::Proxy.any_instance.stubs(:certificate_pem_content).returns("CERTIFICATE CONTENT")
+    Kamal::Configuration::Proxy.any_instance.stubs(:private_key_pem_content).returns("PRIVATE KEY CONTENT")
+
+    run_command("boot", "busybox").tap do |output|
+      assert_match "mkdir -p .kamal/proxy/apps-config/app/tls/accessories/busybox", output
+      assert_match "Uploading \"CERTIFICATE CONTENT\" to .kamal/proxy/apps-config/app/tls/accessories/busybox/cert.pem", output
+      assert_match "Uploading \"PRIVATE KEY CONTENT\" to .kamal/proxy/apps-config/app/tls/accessories/busybox/key.pem", output
+      assert_match "--tls-certificate-path=\"/home/kamal-proxy/.apps-config/app/tls/accessories/busybox/cert.pem\" --tls-private-key-path=\"/home/kamal-proxy/.apps-config/app/tls/accessories/busybox/key.pem\"", output
+    end
+  end
+
   test "upload" do
     run_command("upload", "mysql").tap do |output|
       assert_match "mkdir -p app-mysql/etc/mysql", output

--- a/test/configuration/accessory_test.rb
+++ b/test/configuration/accessory_test.rb
@@ -446,6 +446,16 @@ class ConfigurationAccessoryTest < ActiveSupport::TestCase
     assert_equal [ "monitoring.example.com" ], @config.accessory(:monitoring).proxy.hosts
   end
 
+  test "proxy with custom ssl certificate" do
+    @deploy[:accessories]["monitoring"]["proxy"]["ssl"] = { "certificate_pem" => "CERT_PEM", "private_key_pem" => "KEY_PEM" }
+    proxy = Kamal::Configuration.new(@deploy).accessory(:monitoring).proxy
+
+    assert_equal ".kamal/proxy/apps-config/app/tls/accessories/monitoring/cert.pem", proxy.host_tls_cert
+    assert_equal ".kamal/proxy/apps-config/app/tls/accessories/monitoring/key.pem", proxy.host_tls_key
+    assert_equal "/home/kamal-proxy/.apps-config/app/tls/accessories/monitoring/cert.pem", proxy.container_tls_cert
+    assert_equal "/home/kamal-proxy/.apps-config/app/tls/accessories/monitoring/key.pem", proxy.container_tls_key
+  end
+
   test "invalid boolean restart policy" do
     @deploy[:accessories]["mysql"]["options"] = { "restart" => false }
 

--- a/test/fixtures/deploy_with_accessories_with_different_registries.yml
+++ b/test/fixtures/deploy_with_accessories_with_different_registries.yml
@@ -43,5 +43,7 @@ accessories:
       server: other.registry
       username: other_user
       password: other_pw
+    proxy:
+      host: busybox.example.com
 
 readiness_delay: 0


### PR DESCRIPTION
An accessory can run behind kamal-proxy on its own hostname with a certificate you provide, for example imgproxy on a subdomain fronted by Cloudflare, with a Cloudflare Origin Certificate:

```yaml
accessories:
  imgproxy:
    proxy:
      host: img.example.com
      ssl:
        certificate_pem: IMGPROXY_CERT
        private_key_pem: IMGPROXY_KEY
```

The config is accepted, but `kamal accessory boot` fails with `Error: unable to load certificate` from `kamal-proxy deploy`. The deploy command points at the certificate inside the proxy's apps-config directory, but nothing writes it there: only the app boot path (`Kamal::Cli::App::SslCertificates`) uploads certificates.

This does for accessories what the app boot already does:

- upload the certificate and key right after the secrets, before registering the accessory with kamal-proxy, using the same `Proxy` accessors and `upload!` calls as the app
- store them under `tls/accessories/<name>/`, since app roles use `tls/<role>/` and an accessory named like a role would otherwise overwrite that role's certificate. This mirrors how the env directory already keeps `env/roles/<name>.env` and `env/accessories/<name>.env` apart

No extra validation: the proxy validator already requires both keys, and `Kamal::Secrets` raises when a secret is missing.

Unit tests cover the config paths and the boot output. I also verified it end to end in the integration environment: a proxied accessory with a custom certificate boots, the files land in `.kamal/proxy/apps-config/<service>/tls/accessories/<name>/`, and kamal-proxy serves it over HTTPS with that certificate.

CI (RuboCop, unit and integration tests on Ruby 3.2 to 4.0) is green on my fork: https://github.com/pigoz/kamal/actions/runs/33794121433

Fixes #1769

### Notes for review

- **Missing secrets.** Both secrets are resolved before the directory is created or anything is uploaded, and `Kamal::Secrets#[]` raises a `ConfigurationError` naming the missing one, so a bad config fails without touching the host. That is also why the uploads have no nil guards.
- **File mode `0644`.** kamal-proxy runs as its own user inside the container and reads the files through the bind-mounted apps-config directory, so they must be readable by that user. The app path uploads with the same mode, into the same directory tree under the deploy user's `.kamal`.
- **Accessory name in a path.** Same situation as `tls/<role>/` for roles and `env/accessories/<name>.env` for accessories today. Neither role nor accessory names are validated anywhere, and an accessory name containing `/` already fails at the env upload and at `docker run` before this code runs. Validating names would be a separate change that could break existing configs.
- **Fixture change.** `deploy_with_accessories_with_different_registries.yml` is only used by `test/cli/accessory_test.rb`. Giving `busybox` a proxy, as `test/commands/accessory_test.rb` already does, only adds a `kamal-proxy deploy` line to the `boot all` output, and lets the new test reuse the fixture with the same stubs as the app's `boot with custom ssl certificate` test.
- **`kamal accessory start`** does not re-upload the files, same as `kamal app start`. `reboot` goes through `boot`, and the files persist on the host across proxy reboots.
